### PR TITLE
Endless Thread Loading

### DIFF
--- a/src/com/ferg/awful/ForumDisplayActivity.java
+++ b/src/com/ferg/awful/ForumDisplayActivity.java
@@ -248,7 +248,9 @@ public class ForumDisplayActivity extends Activity {
     		if (!loading && (totalItemCount - visibleItemCount) <= (firstVisibleItem + visibleThreshold)) {
     			//load new items in background and add them
     			loading = true;
-    			new FetchThreadsTask(mForum.getCurrentPage() + 1).execute(mForum.getForumId());
+				if (mForum.getCurrentPage() != mForum.getLastPage()) {
+					new FetchThreadsTask(mForum.getCurrentPage() + 1).execute(mForum.getForumId());
+				}
     		}
     	}
 


### PR DESCRIPTION
Instead of needing to hit menu, next page, instead the next page is loaded when nearing the bottom of the current page while viewing threads in a given forum.
