### PR TITLE
Jumping based on the pti fragment

### DIFF
--- a/src/com/ferg/awful/constants/Constants.java
+++ b/src/com/ferg/awful/constants/Constants.java
@@ -58,6 +58,8 @@ public class Constants {
     public static final String PARAM_PER_PAGE  = "perpage";
     public static final String PARAM_INDEX     = "index";
     public static final String PARAM_BOOKMARK  = "bookmark";
+    
+    public static final String FRAGMENT_PTI    = "pti";
 
     // Intent parameters
     public static final String FORUM     = "forum";

--- a/src/com/ferg/awful/thread/AwfulPost.java
+++ b/src/com/ferg/awful/thread/AwfulPost.java
@@ -27,9 +27,12 @@
 
 package com.ferg.awful.thread;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.regex.Matcher;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 import org.htmlcleaner.CleanerProperties;
@@ -241,9 +244,21 @@ public class AwfulPost {
         ArrayList<AwfulPost> result = new ArrayList<AwfulPost>();
 
         try {
-            TagNode response = NetworkUtils.get(Constants.BASE_URL + mLastReadUrl);
-            
-            result = parsePosts(response);
+            List<URI> redirects = new LinkedList<URI>();
+            TagNode response = NetworkUtils.getWithRedirects(Constants.BASE_URL
+                    + mLastReadUrl, redirects);
+
+            int pti = -1;
+            if (redirects.size() > 1) {
+                String fragment = redirects.get(redirects.size() - 1)
+                        .getFragment();
+                if (fragment.startsWith(Constants.FRAGMENT_PTI)) {
+                    pti = Integer.parseInt(
+                            fragment.substring(Constants.FRAGMENT_PTI.length()));
+                }
+            }
+
+            result = parsePosts(response, pti);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -251,7 +266,7 @@ public class AwfulPost {
         return result;
     }
 
-    public static ArrayList<AwfulPost> parsePosts(TagNode aThread) {
+    public static ArrayList<AwfulPost> parsePosts(TagNode aThread, int pti) {
         ArrayList<AwfulPost> result = new ArrayList<AwfulPost>();
         //HtmlCleaner cleaner = new HtmlCleaner();
         //CleanerProperties properties = cleaner.getProperties();
@@ -263,6 +278,7 @@ public class AwfulPost {
 		boolean even = false;
         try {
         	TagNode[] postNodes = aThread.getElementsByAttValue("class", "post", true, true);
+            int index = 1;
             for (TagNode node : postNodes) {
 				
                 AwfulPost post = new AwfulPost();
@@ -312,7 +328,8 @@ public class AwfulPost {
 			                }
 						}
 					}
-					if(pc.getAttributeByName("class").contains("seen") && !lastReadFound){
+					if((pti != -1 && index < pti) ||
+					   (pc.getAttributeByName("class").contains("seen") && !lastReadFound)){
 						post.setPreviouslyRead(true);
 					}
 
@@ -342,8 +359,16 @@ public class AwfulPost {
                 //it's always there though, so we can set it true without an explicit check
                 post.setHasRapSheetLink(true);
                 result.add(post);
+                index++;
             }
 
+            // if there are zero unread posts the pti points to what the next post
+            // would be. a thread with 6 posts would have a pti of 7 
+            if (index == pti) {
+                result.get(result.size() - 1).setLastRead(true);
+                lastReadFound = true;
+            }
+            
             Log.i(TAG, Integer.toString(postNodes.length));
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/com/ferg/awful/thread/AwfulThread.java
+++ b/src/com/ferg/awful/thread/AwfulThread.java
@@ -27,15 +27,17 @@
 
 package com.ferg.awful.thread;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.htmlcleaner.TagNode;
+
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-
-import org.htmlcleaner.TagNode;
-import org.htmlcleaner.XPatherException;
 
 import com.ferg.awful.constants.Constants;
 import com.ferg.awful.network.NetworkUtils;
@@ -61,6 +63,7 @@ public class AwfulThread extends AwfulPagedItem implements Parcelable {
     private boolean mSticky;
     private String mIcon;
     private int mUnreadCount;
+    private int mPTI;
     private ArrayList<AwfulPost> mPosts;
 
     public AwfulThread() {}
@@ -76,6 +79,7 @@ public class AwfulThread extends AwfulPagedItem implements Parcelable {
         mSticky      = aAwfulThread.readInt() == 1 ? true : false;
         mIcon        = aAwfulThread.readString();
         mUnreadCount = aAwfulThread.readInt();
+        mPTI         = aAwfulThread.readInt();
     }
 
     public static final Parcelable.Creator CREATOR = new Parcelable.Creator() {
@@ -101,6 +105,7 @@ public class AwfulThread extends AwfulPagedItem implements Parcelable {
         aDestination.writeInt(mSticky ? 1 : 0);
         aDestination.writeString(mIcon);
         aDestination.writeInt(mUnreadCount);
+        aDestination.writeInt(mPTI);
     }
     
     public static TagNode getForumThreads(String aForumId) throws Exception {
@@ -192,9 +197,20 @@ public class AwfulThread extends AwfulPagedItem implements Parcelable {
             params.put(Constants.PARAM_GOTO, "newpost");
         } else {
             params.put(Constants.PARAM_PAGE, Integer.toString(aPage));
-        } 
+        }
 
-		TagNode response = NetworkUtils.get(Constants.FUNCTION_THREAD, params);
+        List<URI> redirects = new LinkedList<URI>();
+        TagNode response = NetworkUtils.getWithRedirects(
+                Constants.FUNCTION_THREAD, params, redirects);
+
+        mPTI = -1;
+        if (redirects.size() > 1) {
+            String fragment = redirects.get(redirects.size() - 1).getFragment();
+            if (fragment.startsWith(Constants.FRAGMENT_PTI)) {
+                mPTI = Integer.parseInt(
+                        fragment.substring(Constants.FRAGMENT_PTI.length()));
+            }
+        }
 
         // If we got here from ChromeToPhone the title hasn't been parsed yet,
         // so grab that now
@@ -207,8 +223,8 @@ public class AwfulThread extends AwfulPagedItem implements Parcelable {
             }
         }
 
-        setPosts(AwfulPost.parsePosts(response));
-		parsePageNumbers(response);
+        setPosts(AwfulPost.parsePosts(response, mPTI));
+        parsePageNumbers(response);
     }
 
     public String getThreadId() {


### PR DESCRIPTION
This allows jumping to the first unread post for people who don't have coloring seen posts.

It just records where the &goto=newpost redirects to and then extracts the #pti7 fragment. It seems a bit hacky to me but I don't see any alternative. I also left the old post coloring code since I wanted to make sure not to break anything, not sure if it's needed anymore.
