### PR TITLE
Fix for Login bug

### DIFF
--- a/src/com/ferg/awful/AwfulLoginActivity.java
+++ b/src/com/ferg/awful/AwfulLoginActivity.java
@@ -78,6 +78,15 @@ public class AwfulLoginActivity extends AwfulActivity {
 			}
 		});
     }
+
+    //Not sure if this needs a @Override since it worked without one
+    public void onResume(){
+    	super.onResume();
+    	boolean loggedIn = NetworkUtils.restoreLoginCookies(this);
+		if (loggedIn) {
+			this.finish();
+		}
+    }
     
     @Override
     public void onPause() {


### PR DESCRIPTION
Added onResume() to AwfulLoginActivity that kills the Login if already logged in. Fixes the Login bug.
