### PR TITLE
Jump to last unread post w/o coloring

### DIFF
--- a/src/com/ferg/awful/network/NetworkUtils.java
+++ b/src/com/ferg/awful/network/NetworkUtils.java
@@ -176,19 +176,10 @@ public class NetworkUtils {
     }
     
     public static TagNode get(String aUrl) throws Exception {
-        return get(aUrl, null, null);
+        return get(aUrl, null);
     }
 
 	public static TagNode get(String aUrl, HashMap<String, String> aParams) throws Exception {
-        return get(aUrl, aParams, null);
-	}
-	
-	public static TagNode get(String aUrl, List<URI> redirects) throws Exception {
-	    return get(aUrl, null, redirects);
-	}
-
-	public synchronized static TagNode get(String aUrl, HashMap<String, String> aParams,
-			List<URI> redirects) throws Exception {
         TagNode response = null;
         String parameters = getQueryStringParameters(aParams);
         URI location = new URI(aUrl + parameters);
@@ -198,24 +189,8 @@ public class NetworkUtils {
         HttpGet httpGet;
         HttpResponse httpResponse;
 
-        if (redirects == null) {
-            httpGet = new HttpGet(location);
-            httpResponse = sHttpClient.execute(httpGet);
-        } else {
-            do {
-                httpGet = new HttpGet(location);
-                redirects.add(location);
-                HttpClientParams.setRedirecting(httpGet.getParams(), false);
-
-                httpResponse = sHttpClient.execute(httpGet);
-
-                if (httpResponse.containsHeader("location")) {
-                    location = location.resolve(httpResponse.getFirstHeader(
-                            "location").getValue());
-                    Log.i(TAG, "Redirecting to " + location);
-                }
-            } while (httpResponse.containsHeader("location"));
-        }
+        httpGet = new HttpGet(location);
+        httpResponse = sHttpClient.execute(httpGet);
 
         HttpEntity entity = httpResponse.getEntity();
 
@@ -226,48 +201,6 @@ public class NetworkUtils {
         Log.i(TAG, "Fetched " + location);
         return response;
     }
-
-	public static TagNode getWithRedirects(String aUrl, List<URI> redirects)
-			throws Exception {
-		return getWithRedirects(aUrl, null, redirects);
-	}
-
-	public static TagNode getWithRedirects(String aUrl, HashMap<String, String> aParams,
-			List<URI> redirects) throws Exception {
-        TagNode response = null;
-        String parameters = getQueryStringParameters(aParams);
-
-        Log.i(TAG, "Fetching " + aUrl + parameters);
-
-        URI location = new URI(aUrl + parameters);
-
-        HttpGet httpGet;
-        HttpResponse httpResponse;
-
-        do {
-            httpGet = new HttpGet(location);
-            redirects.add(location);
-            HttpClientParams.setRedirecting(httpGet.getParams(), false);
-
-            httpResponse = sHttpClient.execute(httpGet);
-
-            if (httpResponse.containsHeader("location")) {
-                location = location.resolve(httpResponse.getFirstHeader(
-                        "location").getValue());
-                Log.i(TAG, "Redirecting to " + location.toString());
-            }
-        } while (httpResponse.containsHeader("location"));
-
-        HttpEntity entity = httpResponse.getEntity();
-
-        if (entity != null) {
-            response = sCleaner
-                    .clean(new InputStreamReader(entity.getContent(), CHARSET));
-        }
-
-        Log.i(TAG, "Fetched " + location.toString());
-        return response;
-	}
 
 	public static TagNode post(String aUrl, HashMap<String, String> aParams) throws Exception {
         TagNode response = null;

--- a/src/com/ferg/awful/thread/AwfulPost.java
+++ b/src/com/ferg/awful/thread/AwfulPost.java
@@ -245,17 +245,19 @@ public class AwfulPost implements AwfulDisplayItem {
 
     public void markLastRead() {
         try {
-            List<URI> redirects = new LinkedList<URI>();
             if(mLastReadUrl != null){
-            	NetworkUtils.get(Constants.BASE_URL+ mLastReadUrl, redirects);
+            	NetworkUtils.get(Constants.BASE_URL+ mLastReadUrl);
             }
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
-    public static ArrayList<AwfulPost> parsePosts(TagNode aThread, int pti, AwfulThread aThreadObject){
+    public static ArrayList<AwfulPost> parsePosts(TagNode aThread, int aPage, int postPerPage, AwfulThread aThreadObject){
         ArrayList<AwfulPost> result = new ArrayList<AwfulPost>();
+        
+        int lastReadPage = aThreadObject.getLastReadPage(postPerPage);
+        int lastReadPost = aThreadObject.getLastReadPost(postPerPage);
 
 		boolean lastReadFound = false;
 		boolean even = false;
@@ -322,7 +324,7 @@ public class AwfulPost implements AwfulDisplayItem {
 			                }
 						}
 					}
-					if((pti != -1 && index < pti) ||
+					if(aPage < lastReadPage || (aPage == lastReadPage && index <= lastReadPost) ||
 					   (pc.getAttributeByName("class").contains("seen") && !lastReadFound)){
 						post.setPreviouslyRead(true);
 					}
@@ -356,13 +358,6 @@ public class AwfulPost implements AwfulDisplayItem {
                 index++;
             }
 
-            // if there are zero unread posts the pti points to what the next post
-            // would be. a thread with 6 posts would have a pti of 7 
-            if (index == pti) {
-                result.get(result.size() - 1).setLastRead(true);
-                lastReadFound = true;
-            }
-            
             Log.i(TAG, Integer.toString(postNodes.length));
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/com/ferg/awful/thread/AwfulThread.java
+++ b/src/com/ferg/awful/thread/AwfulThread.java
@@ -61,7 +61,6 @@ public class AwfulThread extends AwfulPagedItem implements AwfulDisplayItem {
     private String mIcon;
     private int mUnreadCount;
 	private int mTotalPosts;
-    private int mPTI;
     private boolean mClosed;
 	private boolean mBookmarked;
     private HashMap<Integer, ArrayList<AwfulPost>> mPosts;
@@ -204,33 +203,14 @@ public class AwfulThread extends AwfulPagedItem implements AwfulDisplayItem {
         return result;
     }
 
-    public void getThreadPosts(int postPerPage) throws Exception {
-        getThreadPosts(-1, postPerPage);
-    }
-
     public void getThreadPosts(int aPage, int postPerPage) throws Exception {
         HashMap<String, String> params = new HashMap<String, String>();
         params.put(Constants.PARAM_THREAD_ID, mThreadId);
         params.put(Constants.PARAM_PER_PAGE, Integer.toString(postPerPage));
+        params.put(Constants.PARAM_PAGE, Integer.toString(aPage));
 
-        if (aPage == -1) {
-            params.put(Constants.PARAM_GOTO, "newpost");
-        } else {
-            params.put(Constants.PARAM_PAGE, Integer.toString(aPage));
-        }
+        TagNode response = NetworkUtils.get(Constants.FUNCTION_THREAD, params);
 
-        List<URI> redirects = new LinkedList<URI>();
-        TagNode response = NetworkUtils.get(
-                Constants.FUNCTION_THREAD, params, redirects);
-
-        mPTI = -1;
-        if (redirects.size() > 1) {
-            String fragment = redirects.get(redirects.size() - 1).getFragment();
-            if (fragment.startsWith(Constants.FRAGMENT_PTI)) {
-                mPTI = Integer.parseInt(
-                        fragment.substring(Constants.FRAGMENT_PTI.length()));
-            }
-        }
         if (mTitle == null) {
         	TagNode[] tarTitle = response.getElementsByAttValue("class", "bclast", true, true);
 
@@ -247,7 +227,7 @@ public class AwfulThread extends AwfulPagedItem implements AwfulDisplayItem {
         	String bkSrc = bkButtons[0].getAttributeByName("src");
         	setBookmarked(bkSrc != null && bkSrc.contains("unbookmark"));
         }
-        setPosts(AwfulPost.parsePosts(response, mPTI, this), aPage);
+        setPosts(AwfulPost.parsePosts(response, aPage, postPerPage, this), aPage);
         parsePageNumbers(response);
     }
 


### PR DESCRIPTION
This fixes the jumping to last unread post functionality for people who don't have that option set in the control panel.

Last time I added all this pti related code but since there is getLastReadPost and getLastReadPage that's useless. This removes all of that and just figures out posts based on those two methods. I've tested jumping into the middle of a page I've read, jumping to the next completely unread page, opening a completely read thread (should show the top of the last page, right?), and opening an unread thread.

I'm a bit paranoid there's an off by one hiding here but I haven't found any.
