### PR TITLE
Several obscure FC fixes.

### DIFF
--- a/src/com/ferg/awful/ForumDisplayFragment.java
+++ b/src/com/ferg/awful/ForumDisplayFragment.java
@@ -31,6 +31,7 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.text.Html;
@@ -147,9 +148,10 @@ public class ForumDisplayFragment extends ListFragment implements AwfulUpdateCal
         }
         registerForContextMenu(getListView());
     }
-
+    
     private boolean isHoneycomb() {
-        return ((AwfulActivity) getActivity()).isHoneycomb();
+    	//We can't refer to getActivity() here, it might return null if we are detached (during rotate, ect).
+    	return Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
     }
 
     @Override

--- a/src/com/ferg/awful/PostReplyFragment.java
+++ b/src/com/ferg/awful/PostReplyFragment.java
@@ -150,7 +150,7 @@ public class PostReplyFragment extends DialogFragment {
             mFetchCookieTask = new FetchFormCookieTask();
             mFetchCookieTask.execute(mThreadId);
         }
-       if(mSelection>0){
+       if(mSelection>0 && mMessage != null && mMessage.length() >= mSelection){
         mMessage.setSelection(mSelection);}
         // We'll enable it once we have a formkey and cookie
         mSubmit.setEnabled(false);

--- a/src/com/ferg/awful/service/AwfulServiceConnection.java
+++ b/src/com/ferg/awful/service/AwfulServiceConnection.java
@@ -530,7 +530,7 @@ public class AwfulServiceConnection extends BroadcastReceiver implements
 
 		@Override
 		public boolean isEnabled(int ix) {
-			if(state == null || isPageCount(ix)){
+			if(state == null || isPageCount(ix) || ix >= state.getChildrenCount(currentPage)){
 				return false;
 			}
 			return state.getChild(currentPage,ix).isEnabled();

--- a/src/com/ferg/awful/thread/AwfulThread.java
+++ b/src/com/ferg/awful/thread/AwfulThread.java
@@ -479,7 +479,9 @@ public class AwfulThread extends AwfulPagedItem implements AwfulDisplayItem {
 			unread.setVisibility(View.GONE);
 		}
 		TextView title = (TextView) tmp.findViewById(R.id.title);
-		title.setText(Html.fromHtml(mTitle));
+		if(mTitle != null){
+			title.setText(Html.fromHtml(mTitle));
+		}
 		if(prefs != null){
 			title.setTextColor(prefs.postFontColor);
 			author.setTextColor(prefs.postFontColor2);


### PR DESCRIPTION
-Index bound errors in AwfulForum (index miscount) and ReplyFragment (setSpan called while reply is empty).
-Null pointer in AwfulThread.
-Crash if isHoneycomb() is called while fragment is detached (during rotation).

Just clearing some easy stuff from bugsense.
