### PR TITLE
New 'Disabled' option in Settings -> Thread info

### DIFF
--- a/res/values/setting_constants.xml
+++ b/res/values/setting_constants.xml
@@ -16,6 +16,7 @@
 		<item>author</item>
 		<item>killedby</item>
 		<item>threadpages</item>
+		<item>disabled</item>
 	</string-array>
 	<string-array name="imgur_thumbnails_values">
 		<item>d</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -69,6 +69,7 @@
 		<item>Author</item>
 		<item>Killed By</item>
 		<item>Number of Pages</item>
+		<item>Disabled</item>
 	</string-array>
 	<string-array name="imgur_thumbnails">
 		<item>Don\'t replace pictures</item>

--- a/src/com/ferg/awful/thread/AwfulThread.java
+++ b/src/com/ferg/awful/thread/AwfulThread.java
@@ -503,7 +503,10 @@ public class AwfulThread extends AwfulPagedItem implements AwfulDisplayItem {
 			}
 			
 		}
-		if(prefs.threadInfo.equals("threadpages")){
+		info.setVisibility(View.VISIBLE);
+		if(prefs.threadInfo.equals("disabled")){
+			info.setVisibility(View.GONE);
+		}else if(prefs.threadInfo.equals("threadpages")){
 			info.setText((int)(Math.ceil(mTotalPosts/prefs.postPerPage)+1)+" pages");	
 		}else if(prefs.threadInfo.equals("killedby")){
 			info.setText("Killed By: "+mKilledBy);


### PR DESCRIPTION
Adds an option to display no thread info, slightly compressing the thread list since I don't refer to any of the info that can currently be displayed there.
