### PR TITLE
Check logged-in status in onResume instead of onCreate (fixes #286)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
@@ -74,7 +74,6 @@ public class AwfulActivity extends ActionBarActivity implements AwfulPreferences
         aq = new AQuery(this);
         mConf = new ActivityConfigurator(this);
         mConf.onCreate();
-        loggedIn = NetworkUtils.restoreLoginCookies(this.getAwfulApplication());
     }
 
     @Override
@@ -87,7 +86,8 @@ public class AwfulActivity extends ActionBarActivity implements AwfulPreferences
     protected void onResume() {
         super.onResume(); if(DEBUG) Log.e(TAG, "onResume");
         mConf.onResume();
-        
+        // check login state when coming back into use, instead of in onCreate
+        loggedIn = NetworkUtils.restoreLoginCookies(this.getAwfulApplication());
         if (isLoggedIn()) {
         	if(mPrefs.ignoreFormkey == null || mPrefs.userTitle == null){
         		 getAwfulApplication().queueRequest(new ProfileRequest(this, null).build(null, null));


### PR DESCRIPTION
Logging out leaves the 'cookie' field in NetworkUtils empty, but logging back in
doesn't recreate it - that only happens when restoreLoginCookies is called. That
was only happening when the activity was created, so it wasn't updating its
'loggedIn' flag or rebuilding the cookie in the middle of a session, which is why
all the requests were failing until you restarted

I think onResume is probably the best place for it, it's the first thing you'll hit after
the login activity closes and it doesn't get called too often