### PR TITLE
Fix a memory leak for precious kilobytes

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ActivityConfigurator.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ActivityConfigurator.java
@@ -32,7 +32,9 @@ public class ActivityConfigurator implements AwfulPreferences.AwfulPreferenceUpd
 	
 	public void onStop() {}
 	
-	public void onDestroy() {}
+	public void onDestroy() {
+		mPrefs.unregisterCallback(this);
+	}
 	
 	private void setOrientation() {
 		String orientationStr = mPrefs.orientation;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
@@ -124,6 +124,7 @@ public class AwfulActivity extends ActionBarActivity implements AwfulPreferences
     protected void onDestroy() {
         super.onDestroy(); if(DEBUG) Log.e(TAG, "onDestroy");
         mConf.onDestroy();
+        mPrefs.unregisterCallback(this);
     }
 
 


### PR DESCRIPTION
Some objects were registering for callbacks and never deregistering, and that meant plenty of activities hanging around after a GC, so I put a stop to that. I made the callback collection use weak references too, if that's cool