### PR TITLE
Switch nav drawer to support Design lib version

### DIFF
--- a/Awful.apk/build.gradle
+++ b/Awful.apk/build.gradle
@@ -43,22 +43,23 @@ android {
 }
 
 dependencies {
-        compile 'com.android.support:appcompat-v7:21.+'
-        compile project(':libraries:tree-view-list-android')
-        compile 'com.mcxiaoke.volley:library:1.+'
-        compile 'com.github.androidquery:androidquery:0.26.8'
-        compile 'com.google.code.gson:gson:2.3.1'
-        compile 'org.jsoup:jsoup:1.8.2'
-        compile 'joda-time:joda-time:2.7'
-        compile 'com.samskivert:jmustache:1.10'
-        compile 'org.apache.httpcomponents:httpmime:4.4.1'
-        compile 'org.apache.httpcomponents:httpcore:4.4.1'
-        compile 'org.apache.commons:commons-lang3:3.4'
-        compile 'com.ToxicBakery.viewpager.transforms:view-pager-transforms:1.2.32'
-        //    compile 'com.github.orangegangsters:swipy:1.2.0@aar'
-        compile 'com.github.OrangeGangsters:SwipyRefreshLayout:15eeb9444d'
-        compile 'com.getbase:floatingactionbutton:1.9.0'
-        compile('com.crashlytics.sdk.android:crashlytics:2.2.2@aar') {
-            transitive = true;
-        }
+    compile 'com.android.support:appcompat-v7:21.+'
+    compile 'com.android.support:design:22.2.0'
+    compile project(':libraries:tree-view-list-android')
+    compile 'com.mcxiaoke.volley:library:1.+'
+    compile 'com.github.androidquery:androidquery:0.26.8'
+    compile 'com.google.code.gson:gson:2.3.1'
+    compile 'org.jsoup:jsoup:1.8.2'
+    compile 'joda-time:joda-time:2.7'
+    compile 'com.samskivert:jmustache:1.10'
+    compile 'org.apache.httpcomponents:httpmime:4.4.1'
+    compile 'org.apache.httpcomponents:httpcore:4.4.1'
+    compile 'org.apache.commons:commons-lang3:3.4'
+    compile 'com.ToxicBakery.viewpager.transforms:view-pager-transforms:1.2.32'
+    //    compile 'com.github.orangegangsters:swipy:1.2.0@aar'
+    compile 'com.github.OrangeGangsters:SwipyRefreshLayout:15eeb9444d'
+    compile 'com.getbase:floatingactionbutton:1.9.0'
+    compile('com.crashlytics.sdk.android:crashlytics:2.2.2@aar') {
+        transitive = true;
+    }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -597,6 +597,7 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
         }
     	closeLoaders();
     	setForumId(id);//if the fragment isn't attached yet, just set the values and let the lifecycle handle it
+        ((ForumsIndexActivity) getActivity()).setNavIds(id, null);
     	updateColors();
     	mPage = page;
     	mLastPage = 0;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
@@ -30,17 +30,20 @@
 package com.ferg.awfulapp;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
-import android.content.res.TypedArray;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.support.annotation.Nullable;
+import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
@@ -59,8 +62,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.widget.ImageView;
-import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.androidquery.AQuery;
@@ -103,12 +104,15 @@ public class ForumsIndexActivity extends AwfulActivity {
     private DrawerLayout mDrawerLayout;
     private ActionBarDrawerToggle mDrawerToggle;
 
-    private int mNavForumId = Constants.USERCP_ID;
-    private int mNavThreadId = 0;
-    private int mForumId = Constants.USERCP_ID;
-    private int mForumPage = 1;
-    private int mThreadId = 0;
-    private int mThreadPage = 1;
+    private static final int NULL_THREAD_ID = 0;
+    private static final int NULL_PAGE_ID = -1;
+
+    private volatile int mNavForumId    = Constants.USERCP_ID;
+    private volatile int mNavThreadId   = NULL_THREAD_ID;
+    private volatile int mForumId       = Constants.USERCP_ID;
+    private volatile int mForumPage     = 1;
+    private volatile int mThreadId      = NULL_THREAD_ID;
+    private volatile int mThreadPage    = 1;
 
     private boolean mPrimeRecreate = false;
 
@@ -121,11 +125,15 @@ public class ForumsIndexActivity extends AwfulActivity {
         isTablet = AwfulUtils.isTablet(this);
         int initialPage;
         if (savedInstanceState != null) {
-            mForumId = savedInstanceState.getInt(Constants.FORUM_ID, mForumId);
-            mForumPage = savedInstanceState.getInt(Constants.FORUM_PAGE, mForumPage);
-            setThreadPage(savedInstanceState.getInt(Constants.THREAD_PAGE, 1));
-            setThreadId(savedInstanceState.getInt(Constants.THREAD_ID, 0));
-            initialPage = savedInstanceState.getInt("viewPage", -1);
+            int forumId = savedInstanceState.getInt(Constants.FORUM_ID, mForumId);
+            int forumPage = savedInstanceState.getInt(Constants.FORUM_PAGE, mForumPage);
+            setForum(forumId, forumPage);
+
+            int threadPage = savedInstanceState.getInt(Constants.THREAD_PAGE, 1);
+            int threadId = savedInstanceState.getInt(Constants.THREAD_ID, NULL_THREAD_ID);
+            setThread(threadId, threadPage);
+
+            initialPage = savedInstanceState.getInt("viewPage", NULL_PAGE_ID);
         } else {
             initialPage = parseNewIntent(getIntent());
         }
@@ -153,12 +161,8 @@ public class ForumsIndexActivity extends AwfulActivity {
         mToolbar = (Toolbar) findViewById(R.id.awful_toolbar);
         setSupportActionBar(mToolbar);
         setNavigationDrawer();
-
-
         setActionBar();
-
         checkIntentExtras();
-
         setupImmersion();
     }
 
@@ -169,6 +173,7 @@ public class ForumsIndexActivity extends AwfulActivity {
         // Sync the toggle state after onRestoreInstanceState has occurred.
         mDrawerToggle.syncState();
     }
+
 
     @SuppressLint("NewApi")
     private void setupImmersion() {
@@ -209,59 +214,57 @@ public class ForumsIndexActivity extends AwfulActivity {
     }
 
 
-    public void setNavigationDrawer() {
-        final Activity self = this;
+    /** Listener for all the navigation drawer menu items */
+    private final NavigationView.OnNavigationItemSelectedListener navDrawerSelectionListener;
+    {
+        final Context context = this;
+        navDrawerSelectionListener = new NavigationView.OnNavigationItemSelectedListener() {
 
-        RelativeLayout navIndexLayout = (RelativeLayout) findViewById(R.id.sidebar_index);
-        if (null != navIndexLayout) {
-            TextView navIndex = (TextView) navIndexLayout.findViewById(R.id.drawer_text);
-            navIndexLayout.setVisibility(View.VISIBLE);
-            navIndex.setOnClickListener(new View.OnClickListener() {
-                public void onClick(View view) {
-                    displayForumIndex();
-                    mDrawerLayout.closeDrawers();
-                }
-            });
-            navIndex.setText("The SA Forums");
-        }
-
-        RelativeLayout navForumLayout = (RelativeLayout) findViewById(R.id.sidebar_forum);
-        if (null != navForumLayout) {
-            TextView navForum = (TextView) navForumLayout.findViewById(R.id.drawer_text);
-            if (mNavForumId != 0) {
-                navForumLayout.setVisibility(View.VISIBLE);
-                navForum.setOnClickListener(new View.OnClickListener() {
-                    public void onClick(View view) {
+            @Override
+            public boolean onNavigationItemSelected (MenuItem menuItem){
+                switch (menuItem.getItemId()) {
+                    case R.id.sidebar_index:
+                        displayForumIndex();
+                        break;
+                    case R.id.sidebar_forum:
                         displayForum(mNavForumId, 1);
-                        mDrawerLayout.closeDrawers();
-                    }
-                });
-                navForum.setText(StringProvider.getForumName(this, mNavForumId));
-            } else {
-                navForumLayout.setVisibility(View.GONE);
-            }
-        }
-
-        RelativeLayout navThreadLayout = (RelativeLayout) findViewById(R.id.sidebar_thread);
-        if (null != navThreadLayout) {
-            if (mNavThreadId != 0) {
-                TextView navThread = (TextView) navThreadLayout.findViewById(R.id.drawer_text);
-                Log.d(TAG, "NavThread, Navforum: " + mNavThreadId + " " + mNavForumId);
-                navThreadLayout.setVisibility(View.VISIBLE);
-                navThread.setOnClickListener(new View.OnClickListener() {
-                    public void onClick(View view) {
+                        break;
+                    case R.id.sidebar_thread:
                         displayThread(mNavThreadId, mThreadPage, mNavForumId, mForumPage, false);
-
-                        mDrawerLayout.closeDrawers();
-                    }
-                });
-                navThread.setText(StringProvider.getThreadName(this, mNavThreadId));
-            } else {
-                navThreadLayout.setVisibility(View.GONE);
+                        break;
+                    case R.id.sidebar_bookmarks:
+                        startActivity(new Intent().setClass(context, ForumsIndexActivity.class)
+                                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                                .putExtra(Constants.FORUM_ID, Constants.USERCP_ID)
+                                .putExtra(Constants.FORUM_PAGE, 1));
+                        break;
+                    case R.id.sidebar_settings:
+                        startActivity(new Intent().setClass(context, SettingsActivity.class));
+                        break;
+                    case R.id.sidebar_pm:
+                        startActivity(new Intent().setClass(context, PrivateMessageActivity.class));
+                        break;
+                    case R.id.sidebar_logout:
+                        new LogOutDialog(context).show();
+                        break;
+                    default:
+                        return false;
+                }
+                mDrawerLayout.closeDrawer(Gravity.LEFT);
+                return true;
             }
-        }
+        };
+    }
 
+
+    /**
+     * Initialise the navigation drawer
+     */
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void setNavigationDrawer() {
         mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+        NavigationView navigation = (NavigationView) findViewById(R.id.navigation);
+        navigation.setNavigationItemSelectedListener(navDrawerSelectionListener);
 
         mDrawerToggle = new ActionBarDrawerToggle(
                 this,                  /* host Activity */
@@ -272,10 +275,12 @@ public class ForumsIndexActivity extends AwfulActivity {
         );
         mDrawerLayout.setDrawerListener(mDrawerToggle);
 
+        // update the navigation drawer header
         TextView username = (TextView) findViewById(R.id.sidebar_username);
         if (null != username) {
             username.setText(mPrefs.username);
         }
+
         ImageView avatar = (ImageView) findViewById(R.id.sidebar_avatar);
         if (null != avatar) {
             AQuery aq = new AQuery(this);
@@ -286,87 +291,58 @@ public class ForumsIndexActivity extends AwfulActivity {
                     aq.id(R.id.sidebar_avatar).image(R.drawable.icon);
                 }
             }
-        }
-        RelativeLayout logoutLayout = (RelativeLayout) findViewById(R.id.sidebar_logout);
-        if (null != logoutLayout) {
-            TextView logout = (TextView) logoutLayout.findViewById(R.id.drawer_text);
-            logout.setOnClickListener(new View.OnClickListener() {
-                public void onClick(View view) {
-                    mDrawerLayout.closeDrawers();
-                    new LogOutDialog(self).show();
-                }
-            });
-            logout.setText(getResources().getText(R.string.logout));
-            logoutLayout.setVisibility(View.VISIBLE);
-
-            ImageView logoutImage = (ImageView) logoutLayout.findViewById(R.id.drawer_icon);
-            int[] attrs = { R.attr.iconMenuLogoutDark };
-            TypedArray ta = logoutImage.getContext().getTheme().obtainStyledAttributes(attrs);
-            logoutImage.setImageDrawable(ta.getDrawable(0));
-            logoutImage.setVisibility(View.VISIBLE);
-        }
-        RelativeLayout messagesLayout = (RelativeLayout) findViewById(R.id.sidebar_pm);
-        if (null != messagesLayout) {
-            TextView messages = (TextView) messagesLayout.findViewById(R.id.drawer_text);
-            messages.setEnabled(mPrefs.hasPlatinum);
-            messagesLayout.setVisibility(mPrefs.hasPlatinum ? View.VISIBLE : View.GONE);
-            messages.setOnClickListener(new View.OnClickListener() {
-                public void onClick(View view) {
-                    mDrawerLayout.closeDrawers();
-                    startActivity(new Intent().setClass(self, PrivateMessageActivity.class));
-                }
-            });
-            messages.setText(getResources().getText(R.string.private_message));
-
-            ImageView messagesImage = (ImageView) messagesLayout.findViewById(R.id.drawer_icon);
-            int[] attrs = { R.attr.iconMenuMailDark };
-            TypedArray ta = messagesImage.getContext().getTheme().obtainStyledAttributes(attrs);
-            messagesImage.setImageDrawable(ta.getDrawable(0));
-            messagesImage.setVisibility(View.VISIBLE);
-        }
-        RelativeLayout bookmarksLayout = (RelativeLayout) findViewById(R.id.sidebar_bookmarks);
-        if (null != bookmarksLayout) {
-            TextView bookmarks = (TextView) bookmarksLayout.findViewById(R.id.drawer_text);
-            bookmarks.setOnClickListener(new View.OnClickListener() {
-                public void onClick(View view) {
-                    mDrawerLayout.closeDrawers();
-                    startActivity(new Intent().setClass(self, ForumsIndexActivity.class)
-                            .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                            .putExtra(Constants.FORUM_ID, Constants.USERCP_ID)
-                            .putExtra(Constants.FORUM_PAGE, 1));
-                }
-            });
-            bookmarks.setText(getResources().getText(R.string.user_cp));
-            bookmarksLayout.setVisibility((Constants.USERCP_ID == mNavForumId ? View.GONE : View.VISIBLE));
-
-            ImageView bookmarksImage = (ImageView) bookmarksLayout.findViewById(R.id.drawer_icon);
-            int[] attrs = { R.attr.iconMenuBookmarkDark };
-            TypedArray ta = bookmarksImage.getContext().getTheme().obtainStyledAttributes(attrs);
-            bookmarksImage.setImageDrawable(ta.getDrawable(0));
-            bookmarksImage.setVisibility(View.VISIBLE);
-        }
-        RelativeLayout settingsLayout = (RelativeLayout) findViewById(R.id.sidebar_settings);
-        if (null != settingsLayout) {
-            TextView settings = (TextView) settingsLayout.findViewById(R.id.drawer_text);
-            settings.setOnClickListener(new View.OnClickListener() {
-                public void onClick(View view) {
-                    mDrawerLayout.closeDrawers();
-                    startActivity(new Intent().setClass(self, SettingsActivity.class));
-                }
-            });
-            settings.setText(getResources().getText(R.string.settings));
-            settingsLayout.setVisibility(View.VISIBLE);
-
-            ImageView settingsImage = (ImageView) settingsLayout.findViewById(R.id.drawer_icon);
-            int[] attrs = { R.attr.iconMenuSettingsDark };
-            TypedArray ta = settingsImage.getContext().getTheme().obtainStyledAttributes(attrs);
-            settingsImage.setImageDrawable(ta.getDrawable(0));
-            settingsImage.setVisibility(View.VISIBLE);
+            if (AwfulUtils.isLollipop()) {
+                avatar.setClipToOutline(true);
+            }
         }
 
-
+        updateNavigationMenu();
         mDrawerToggle.syncState();
     }
+
+
+    /**
+     * Update any changeable menu items, e.g. current thread title
+     * Synchronized because it gets called by other threads through
+     * {@link #setNavIds(int, Integer)}
+     */
+    private synchronized void updateNavigationMenu() {
+        // avoid premature update calls (e.g. through onCreate)
+        NavigationView navView = (NavigationView) findViewById(R.id.navigation);
+        if (navView == null) {
+            return;
+        }
+        Menu navMenu = navView.getMenu();
+
+        // display the current forum title (or not)
+        MenuItem forumItem = navMenu.findItem(R.id.sidebar_forum);
+        if (forumItem != null) {
+            if (mNavForumId != 0 && mNavForumId != Constants.USERCP_ID) {
+                forumItem.setVisible(true);
+                forumItem.setTitle(StringProvider.getForumName(this, mNavForumId));
+            } else {
+                forumItem.setVisible(false);
+            }
+        }
+
+        MenuItem threadItem = navMenu.findItem(R.id.sidebar_thread);
+        if (threadItem != null) {
+            if (mNavThreadId != NULL_THREAD_ID) {
+                threadItem.setVisible(true);
+                threadItem.setTitle(StringProvider.getThreadName(this, mNavThreadId));
+            } else {
+                threadItem.setVisible(false);
+            }
+        }
+
+        // private messages - show 'em if you got 'em
+        MenuItem pmItem = navMenu.findItem(R.id.sidebar_pm);
+        if (pmItem != null) {
+            pmItem.setEnabled(mPrefs.hasPlatinum);
+            pmItem.setVisible(mPrefs.hasPlatinum);
+        }
+    }
+
 
     @Override
     @SuppressLint("NewApi")
@@ -448,48 +424,58 @@ public class ForumsIndexActivity extends AwfulActivity {
         if (mThreadFragment != null) {
             if (url.isThread() || url.isPost()) {
                 mThreadFragment.openThread(url);
-            } else if (intent.getIntExtra(Constants.THREAD_ID, 0) > 0) {
+            } else if (intent.getIntExtra(Constants.THREAD_ID, NULL_THREAD_ID) > 0) {
                 mThreadFragment.openThread(mThreadId, mThreadPage);
             }
         }
     }
 
     private int parseNewIntent(Intent intent) {
-        int initialPage = -1;
-        mForumId = getIntent().getIntExtra(Constants.FORUM_ID, mForumId);
-        mForumPage = getIntent().getIntExtra(Constants.FORUM_PAGE, mForumPage);
-        setThreadPage(getIntent().getIntExtra(Constants.THREAD_PAGE, mThreadPage));
-        setThreadId(getIntent().getIntExtra(Constants.THREAD_ID, mThreadId));
-        if (mForumId == 2) {//workaround for old userCP ID, ugh. the old id still appears if someone created a bookmark launch shortcut prior to b23
-            mForumId = Constants.USERCP_ID;//should never have used 2 as a hard-coded forum-id, what a horror.
+        int initialPage = NULL_PAGE_ID;
+        int forumId     = getIntent().getIntExtra(Constants.FORUM_ID, mForumId);
+        int forumPage   = getIntent().getIntExtra(Constants.FORUM_PAGE, mForumPage);
+        int threadId    = getIntent().getIntExtra(Constants.THREAD_ID, mThreadId);
+        int threadPage  = getIntent().getIntExtra(Constants.THREAD_PAGE, mThreadPage);
+
+        if (forumId == 2) {//workaround for old userCP ID, ugh. the old id still appears if someone created a bookmark launch shortcut prior to b23
+            forumId = Constants.USERCP_ID;//should never have used 2 as a hard-coded forum-id, what a horror.
         }
+
+        boolean displayIndex = false;
         if (getIntent().getData() != null && getIntent().getData().getScheme().equals("http")) {
             url = AwfulURL.parse(getIntent().getDataString());
             switch (url.getType()) {
                 case FORUM:
-                    mForumId = (int) url.getId();
-                    mForumPage = (int) url.getPage();
+                    forumId = (int) url.getId();
+                    forumPage = (int) url.getPage();
                     break;
                 case THREAD:
                     if (!url.isRedirect()) {
-                        setThreadPage((int) url.getPage());
-                        setThreadId((int) url.getId());
+                        threadPage = (int) url.getPage();
+                        threadId = (int) url.getId();
                     }
                     break;
                 case POST:
                     break;
                 case INDEX:
-                    displayForumIndex();
+                    displayIndex = true;
                     break;
                 default:
             }
+        }
+
+        setForum(forumId, forumPage);
+        setThread(threadId, threadPage);
+
+        if (displayIndex) {
+            displayForumIndex();
         }
         if (intent.getIntExtra(Constants.FORUM_ID, 0) > 1 || url.isForum()) {
             initialPage = isTablet ? 0 : 1;
         } else {
             skipLoad = !isTablet;
         }
-        if (intent.getIntExtra(Constants.THREAD_ID, 0) > 0 || url.isRedirect() || url.isThread()) {
+        if (intent.getIntExtra(Constants.THREAD_ID, NULL_THREAD_ID) > 0 || url.isRedirect() || url.isThread()) {
             initialPage = 2;
         }
         return initialPage;
@@ -533,8 +519,7 @@ public class ForumsIndexActivity extends AwfulActivity {
     protected void onPause() {
         super.onPause();
         if (mForumFragment != null) {
-            mForumId = mForumFragment.getForumId();
-            mForumPage = mForumFragment.getPage();
+            setForum(mForumFragment.getForumId(), mForumFragment.getPage());
         }
     }
 
@@ -568,18 +553,27 @@ public class ForumsIndexActivity extends AwfulActivity {
     }
 
 
-    public void setThreadId(int threadId) {
-        int oldThreadId = mThreadId;
-        mThreadId = threadId;
-        mNavThreadId = threadId;
-        if ((oldThreadId < 1 || threadId < 1) && threadId != oldThreadId && pagerAdapter != null) {
-            pagerAdapter.notifyDataSetChanged();//notify pager adapter so it'll show/hide the thread view
-        }
+    public synchronized void setForum(int forumId, int page) {
+        mForumId = forumId;
+        mForumPage = page;
+        setNavIds(mForumId, null);
     }
 
-    public void setThreadPage(int page) {
-        mThreadPage = page;
+
+    public synchronized void setThread(@Nullable Integer threadId, @Nullable Integer page) {
+        if (page != null) {
+            mThreadPage = page;
+        }
+        if (threadId != null) {
+            int oldThreadId = mThreadId;
+            mThreadId = threadId;
+            if ((oldThreadId < 1 || threadId < 1) && threadId != oldThreadId && pagerAdapter != null) {
+                pagerAdapter.notifyDataSetChanged();//notify pager adapter so it'll show/hide the thread view
+            }
+        }
+        setNavIds(mNavForumId, mThreadId);
     }
+
 
     public class ForumPagerAdapter extends FragmentStatePagerAdapter implements ViewPager.OnPageChangeListener {
         public ForumPagerAdapter(FragmentManager fm) {
@@ -723,9 +717,8 @@ public class ForumsIndexActivity extends AwfulActivity {
     @Override
     public void displayForum(int id, int page) {
         Log.d(TAG, "displayForum " + id);
-        mForumId = id;
-        mForumPage = page;
-        setNavigationDrawer();
+        setForum(id, page);
+        setNavIds(id, null);
         if (mForumFragment != null) {
             mForumFragment.openForum(id, page);
             if (mViewPager != null) {
@@ -800,17 +793,13 @@ public class ForumsIndexActivity extends AwfulActivity {
         if (mViewPager != null) {
             if (mThreadFragment != null) {
                 if (!forceReload && getThreadId() == id && getThreadPage() == page) {
-                    setThreadId(mNavThreadId);
-
-                    setNavForumId(mThreadFragment.getParentForumId());
-                    setNavigationDrawer();
+                    setNavIds(mThreadFragment.getParentForumId(), mNavThreadId);
                 } else {
                     mThreadFragment.openThread(id, page);
                     mViewPager.getAdapter().notifyDataSetChanged();
                 }
             } else {
-                setThreadPage(page);
-                setThreadId(id);
+                setThread(id, page);
             }
             mViewPager.setCurrentItem(pagerAdapter.getItemPosition(mThreadFragment));
         } else {
@@ -900,15 +889,20 @@ public class ForumsIndexActivity extends AwfulActivity {
             mViewPager.setAdapter(pagerAdapter);
         }
         mDrawerToggle.onConfigurationChanged(newConfig);
-
     }
 
-    public void setNavForumId(int forumId) {
-        this.mNavForumId = forumId;
-    }
 
-    public void setNavThreadId(int threadId) {
-        this.mNavThreadId = threadId;
+    /**
+     * Set the IDs that the navigation view knows about?
+     * Updates the navigation menu to reflect these
+     * @param forumId   The current forum
+     * @param threadId
+     */
+    public synchronized void setNavIds(int forumId, @Nullable Integer threadId) {
+        // if we only get a forumId, clear the thread one so it's not displayed
+        mNavForumId = forumId;
+        mNavThreadId = threadId != null ? threadId : NULL_THREAD_ID;
+        updateNavigationMenu();
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -513,9 +513,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 //        	mP2RAttacher.setPullFromBottom(true);
 //        }
         if(parent != null && mParentForumId != 0){
-            parent.setNavForumId(mParentForumId);
-            parent.setNavThreadId(getThreadId());
-            parent.setNavigationDrawer();
+			parent.setNavIds(mParentForumId, getThreadId());
         }
 	}
 
@@ -1472,10 +1470,10 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
         return parent.getThreadPage();
 	}
 	public void setPage(int aPage){
-		parent.setThreadPage(aPage);
+		parent.setThread(null, aPage);
 	}
 	public void setThreadId(int aThreadId){
-        parent.setThreadId(aThreadId);
+        parent.setThread(aThreadId, null);
 	}
 	
 	public void selectUser(int id, String name){
@@ -1569,10 +1567,12 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
         		threadBookmarked = aData.getInt(aData.getColumnIndex(AwfulThread.BOOKMARKED))>0;
                 threadArchived = aData.getInt(aData.getColumnIndex(AwfulThread.ARCHIVED))>0;
         		mParentForumId = aData.getInt(aData.getColumnIndex(AwfulThread.FORUM_ID));
-                //Same thread, already done this, don't override the forum name
-                if(null == getTitle() || !getTitle().equals(aData.getString(aData.getColumnIndex(AwfulThread.TITLE)))) {
-                    parent.setNavForumId(mParentForumId);
-                }
+//                //Same thread, already done this, don't override the forum name
+//                if(null == getTitle() || !getTitle().equals(aData.getString(aData.getColumnIndex(AwfulThread.TITLE)))) {
+//                    parent.setNavForumId(mParentForumId);
+//
+//                }
+				parent.setNavIds(mParentForumId, getThreadId());
                 setTitle(aData.getString(aData.getColumnIndex(AwfulThread.TITLE)));
         		updatePageBar();
         		updateProbationBar();
@@ -1585,7 +1585,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
         			shareProvider.setShareIntent(createShareIntent());
         		}
                 invalidateOptionsMenu();
-                parent.setNavigationDrawer();
 				if(!mPrefs.noFAB) {
 					mFAB.setVisibility(View.VISIBLE);
 					if (threadClosed || threadArchived) {

--- a/Awful.apk/src/main/res/drawable/avatar_clipping_circle.xml
+++ b/Awful.apk/src/main/res/drawable/avatar_clipping_circle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#00000000" />
+    <corners android:radius="20dp" />
+</shape>

--- a/Awful.apk/src/main/res/layout/forum_index_activity.xml
+++ b/Awful.apk/src/main/res/layout/forum_index_activity.xml
@@ -16,22 +16,7 @@
         app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
         app:popupTheme="?attr/awfulPopUpTheme"
         />
-    <android.support.v4.widget.DrawerLayout
-        android:id="@+id/drawer_layout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
 
-        <com.ferg.awfulapp.widget.ToggleViewPager
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:id="@+id/forum_index_pager"
-            />
-        <include
-            layout="@layout/sidebar"
-            android:layout_height="match_parent"
-            android:layout_gravity="left"
-            android:id="@+id/sidebar"
-            android:layout_width="280dp"/>
-    </android.support.v4.widget.DrawerLayout>
+    <include layout="@layout/nav_drawer" />
 
 </LinearLayout>

--- a/Awful.apk/src/main/res/layout/nav_drawer.xml
+++ b/Awful.apk/src/main/res/layout/nav_drawer.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.ferg.awfulapp.widget.ToggleViewPager
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        android:id="@+id/forum_index_pager"
+        />
+
+    <android.support.design.widget.NavigationView
+        android:id="@+id/navigation"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        app:headerLayout="@layout/nav_drawer_header"
+        app:menu="@menu/nav_drawer" />
+</android.support.v4.widget.DrawerLayout>

--- a/Awful.apk/src/main/res/layout/nav_drawer_header.xml
+++ b/Awful.apk/src/main/res/layout/nav_drawer_header.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="172dp"
+    android:background="@color/forums_blue_darkest"
+    android:orientation="vertical"
+    android:theme="@style/ThemeOverlay.AppCompat.Dark">
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:src="@drawable/icon"
+        android:scaleType="centerCrop"
+        android:tint="#8800314b" />
+
+
+    <ImageView
+        android:id="@+id/sidebar_avatar"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:elevation="4dp"
+        android:src="@drawable/icon"
+        android:background="@drawable/avatar_clipping_circle"
+        android:layout_above="@+id/sidebar_username"
+        android:layout_marginBottom="@dimen/abc_action_bar_content_inset_material"
+        android:layout_alignLeft="@+id/sidebar_username"
+        android:layout_alignStart="@+id/sidebar_username" />
+
+    <TextView
+        android:id="@+id/sidebar_username"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginLeft="@dimen/abc_action_bar_content_inset_material"
+        android:layout_marginStart="@dimen/abc_action_bar_content_inset_material"
+        android:layout_marginBottom="@dimen/abc_action_bar_content_inset_material"
+        android:text="Username"
+        android:textAppearance="@style/TextAppearance.AppCompat.Subhead"/>
+
+</RelativeLayout>

--- a/Awful.apk/src/main/res/menu/nav_drawer.xml
+++ b/Awful.apk/src/main/res/menu/nav_drawer.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/sidebar_index"
+        android:title="@string/drawer_title"/>
+    <item
+        android:id="@+id/sidebar_forum"
+        android:title=""/>
+    <item
+        android:id="@+id/sidebar_thread"
+        android:title=""/>
+
+    <group
+        android:id="@+id/main_nav_options">
+        <item
+            android:id="@+id/sidebar_bookmarks"
+            android:icon="?attr/iconMenuBookmarkDark"
+            android:title="@string/user_cp" />
+        <item
+            android:id="@+id/sidebar_pm"
+            android:icon="?attr/iconMenuMailDark"
+            android:title="@string/private_message" />
+        <item
+            android:id="@+id/sidebar_settings"
+            android:icon="?attr/iconMenuSettingsDark"
+            android:title="@string/settings" />
+        <item
+            android:id="@+id/sidebar_logout"
+            android:icon="?attr/iconMenuLogoutDark"
+            android:title="@string/logout" />
+    </group>
+
+</menu>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="drawer_open">Open</string>
     <string name="drawer_close">Close</string>
 
+    <string name="drawer_title">The SA Forums</string>
     <!-- sort THIS out -->
     <string name="usercp">Bookmarks</string>
     <string name="user_cp">Bookmarks</string>


### PR DESCRIPTION
(I know you already fixed this, but I'd already started playing with it :frog: )

I've reworked the navigation stuff to use the new Design library, it's a bit easier
to work with too (mostly defined in XML with a callback for item selection).
I added a material-ish header without an actual graphic (just a horrible blown-up
app icon with a tint because why not), and a mini avatar icon. Pre-lollipop will
need some library or custom code to make it round.

Forum/thread names update immediately now (well, as soon as the loader is done)
I had to make a choice about exactly what happens with this stuff, since you
can have a thread open (with an associated forum) and then visit a different
forum in its fragment without opening a thread. So you end up with a forum
and a thread that are unconnected, so which do you show in the menu?

I went with the last fragment to update getting to set the details - it's all handled
in that setNavIds method, so it could be tweaked with a call to that whenever a
fragment is in view, or something. The loaders are kind of all over the place so it's
still inconsistent, things triggering in the background and re-updating 'what you're
looking at', but that's always been an issue!