### PR TITLE
Some Volley/cookie handling tweaks (#336)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
@@ -90,10 +90,10 @@ public class AwfulActivity extends ActionBarActivity implements AwfulPreferences
         loggedIn = NetworkUtils.restoreLoginCookies(this.getAwfulApplication());
         if (isLoggedIn()) {
         	if(mPrefs.ignoreFormkey == null || mPrefs.userTitle == null){
-        		 getAwfulApplication().queueRequest(new ProfileRequest(this, null).build(null, null));
+        		 NetworkUtils.queueRequest(new ProfileRequest(this, null).build(null, null));
         	}
             if(mPrefs.ignoreFormkey == null){
-                getAwfulApplication().queueRequest(new FeatureRequest(this).build(null, null));
+                NetworkUtils.queueRequest(new FeatureRequest(this).build(null, null));
             }
             Log.v(TAG, "Cookie Loaded!");
         } else {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulDialogFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulDialogFragment.java
@@ -50,6 +50,7 @@ import com.android.volley.Request;
 import com.android.volley.VolleyError;
 import com.androidquery.AQuery;
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.task.AwfulRequest;
@@ -216,31 +217,21 @@ public abstract class AwfulDialogFragment extends DialogFragment implements Acti
 	@Override
 	public void onDestroyActionMode(ActionMode mode) {	}
 
-    protected AwfulApplication getAwfulApplication(){
-        AwfulActivity act = getAwfulActivity();
-        if(act != null){
-            return (AwfulApplication) act.getApplication();
-        }
-        return null;
-    }
     public void queueRequest(Request request){
         queueRequest(request, false);
     }
+
     public void queueRequest(Request request, boolean cancelOnDestroy){
-        AwfulApplication app = getAwfulApplication();
-        if(app != null && request != null){
+        if(request != null){
             if(cancelOnDestroy){
                 request.setTag(this);
             }
-            app.queueRequest(request);
+            NetworkUtils.queueRequest(request);
         }
     }
 
     protected void cancelNetworkRequests(){
-        AwfulApplication app = getAwfulApplication();
-        if(app != null){
-            app.cancelRequests(this);
-        }
+        NetworkUtils.cancelRequests(this);
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulFragment.java
@@ -306,6 +306,16 @@ public abstract class AwfulFragment extends Fragment implements ActionMode.Callb
     public void queueRequest(Request request){
         queueRequest(request, false);
     }
+
+    /**
+     * Queue a network {@link Request}.
+     * Set true to tag the request with the fragment, so it will be cancelled
+     * when the fragment is destroyed. Set false if you want to retain the request's
+     * default tag, e.g. so pending {@link com.ferg.awfulapp.task.PostRequest}s can
+     * be cancelled when starting a new one.
+     * @param request           A Volley request
+     * @param cancelOnDestroy   Whether to tag with the fragment and automatically cancel
+     */
     public void queueRequest(Request request, boolean cancelOnDestroy){
         if(request != null){
             if(cancelOnDestroy){

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulFragment.java
@@ -56,6 +56,7 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 import com.androidquery.AQuery;
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.task.AwfulRequest;
@@ -306,27 +307,16 @@ public abstract class AwfulFragment extends Fragment implements ActionMode.Callb
         queueRequest(request, false);
     }
     public void queueRequest(Request request, boolean cancelOnDestroy){
-        AwfulApplication app = getAwfulApplication();
-        if(app != null && request != null){
+        if(request != null){
             if(cancelOnDestroy){
                 request.setTag(this);
             }
-            app.queueRequest(request);
+            NetworkUtils.queueRequest(request);
         }
     }
 
     protected void cancelNetworkRequests(){
-        AwfulApplication app = getAwfulApplication();
-        if(app != null){
-            app.cancelRequests(this);
-        }
-    }
-
-    public ImageLoader getImageLoader(){
-        if(getAwfulApplication() != null){
-            return getAwfulApplication().getImageLoader();
-        }
-        return null;
+        NetworkUtils.cancelRequests(this);
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
@@ -69,6 +69,8 @@ public class AwfulLoginActivity extends AwfulActivity {
 
         setContentView(R.layout.login);
 
+        NetworkUtils.logCookies();
+
         mLogin = (Button) findViewById(R.id.login);
         mUsername = (EditText) findViewById(R.id.username);
         mPassword = (EditText) findViewById(R.id.password);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -275,11 +275,6 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
 			}
 		});
 	}
-
-    @Override
-    public void onStart() {
-        super.onStart();
-    }
     
     @Override
     public void onResume() {
@@ -304,37 +299,29 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
 //		}
         refreshInfo();
 	}
-	
+
 	@Override
 	public void onPageHidden() {
-		
+
 	}
-    
-    @Override
-    public void onPause() {
-        super.onPause();
-    }
-    
+
     @Override
 	public void onSaveInstanceState(Bundle outState) {
 		super.onSaveInstanceState(outState); if(DEBUG) Log.e(TAG,"onSaveInstanceState");
         outState.putInt(Constants.FORUM_PAGE, getPage());
     	outState.putInt(Constants.FORUM_ID, getForumId());
 	}
-    
-	@Override
+
+    @Override
+    protected void cancelNetworkRequests() {
+        super.cancelNetworkRequests();
+        NetworkUtils.cancelRequests(ThreadListRequest.REQUEST_TAG);
+    }
+
+    @Override
     public void onStop() {
-        super.onStop(); if(DEBUG) Log.e(TAG, "Stop");
+        super.onStop();
         closeLoaders();
-    }
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView(); if(DEBUG) Log.e(TAG, "DestroyView");
-    }
-    
-    @Override
-    public void onDetach() {
-        super.onDetach(); if(DEBUG) Log.e(TAG, "Detach");
     }
 
 
@@ -612,7 +599,9 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
 
 	public void syncForum() {
 		if(getActivity() != null && getForumId() > 0){
-
+            // cancel pending thread list loading requests
+            NetworkUtils.cancelRequests(ThreadListRequest.REQUEST_TAG);
+            // call this with cancelOnDestroy=false to retain the request's specific type tag
             queueRequest(new ThreadListRequest(getActivity(), getForumId(), getPage()).build(this,
                     new AwfulRequest.AwfulResultCallback<Void>() {
                         @Override
@@ -639,7 +628,7 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
                             mListView.setSelectionAfterHeaderView();
                         }
                     }
-            ));
+            ), false);
 
 		}
     }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -629,6 +629,7 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
                         public void failure(VolleyError error) {
                             if(null != error.getMessage() && error.getMessage().startsWith("java.net.ProtocolException: Too many redirects")){
                                 Log.e(TAG, "Error: "+error.getMessage());
+                                Log.e(TAG, "!!!Failed to sync thread list - You are now LOGGED OUT");
                                 NetworkUtils.clearLoginCookies(getAwfulActivity());
                                 getAwfulActivity().startActivity(new Intent().setClass(getAwfulActivity(), AwfulLoginActivity.class));
                             }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
@@ -67,10 +67,14 @@ import android.widget.TextView;
 import com.androidquery.AQuery;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.dialog.LogOutDialog;
+import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.preferences.SettingsActivity;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.provider.StringProvider;
+import com.ferg.awfulapp.task.IndexRequest;
+import com.ferg.awfulapp.task.PostRequest;
+import com.ferg.awfulapp.task.ThreadListRequest;
 import com.ferg.awfulapp.thread.AwfulURL;
 import com.ferg.awfulapp.util.AwfulUtils;
 import com.ferg.awfulapp.widget.ToggleViewPager;
@@ -743,20 +747,6 @@ public class ForumsIndexActivity extends AwfulActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-//        switch (item.getItemId()) {
-//            case android.R.id.home:
-//                if(mViewPager != null && mViewPager.getCurrentItem() > 0){
-//                    if(mViewPager.getCurrentItem() == 2 && mThreadFragment != null && mThreadFragment.getParentForumId() > 0){
-//                        displayForum(mThreadFragment.getParentForumId(), 1);
-//                    }else{
-//                        mViewPager.setCurrentItem(mViewPager.getCurrentItem()-1);
-//                    }
-//                    return true;
-//                }
-//                break;
-//            default:
-//                break;
-//        }
         if (mDrawerToggle.onOptionsItemSelected(item)) {
             return true;
         }
@@ -916,5 +906,11 @@ public class ForumsIndexActivity extends AwfulActivity {
 
     public void reenableSwipe() {
         this.mViewPager.setSwipeEnabled(true);
+    }
+
+
+    @Override
+    protected void onStop() {
+        super.onStop();
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
@@ -241,6 +241,7 @@ public class ForumsIndexFragment extends AwfulFragment implements SwipyRefreshLa
                 public void failure(VolleyError error) {
                     if(null != error.getMessage() && error.getMessage().startsWith("java.net.ProtocolException: Too many redirects")){
                         Log.e(TAG, "Error: "+error.getMessage());
+						Log.e(TAG, "!!!Failed to sync forum index - You are now LOGGED OUT");
                         NetworkUtils.clearLoginCookies(getAwfulActivity());
                         getAwfulActivity().startActivity(new Intent().setClass(getAwfulActivity(), AwfulLoginActivity.class));
                     }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
@@ -143,7 +143,7 @@ public class ForumsIndexFragment extends AwfulFragment implements SwipyRefreshLa
 
     @Override
     public void onActivityCreated(Bundle aSavedState) {
-        super.onActivityCreated(aSavedState); if(DEBUG) Log.e(TAG, "Start");
+        super.onActivityCreated(aSavedState);
 
         dataManager = new InMemoryTreeStateManager<ForumEntry>();
         dataManager.setVisibleByDefault(false);
@@ -151,15 +151,10 @@ public class ForumsIndexFragment extends AwfulFragment implements SwipyRefreshLa
         mForumTree.setAdapter(mTreeAdapter);
         syncForums();
     }
-
-    @Override
-    public void onStart() {
-        super.onStart(); if(DEBUG) Log.e(TAG, "Start");
-    }
     
     @Override
     public void onResume() {
-        super.onResume(); if(DEBUG) Log.e(TAG, "Resume");
+        super.onResume();
 		restartLoader(Constants.FORUM_INDEX_LOADER_ID, null, mForumLoaderCallback);
         getActivity().getContentResolver().registerContentObserver(AwfulForum.CONTENT_URI, true, forumObserver);
 		updateProbationBar();
@@ -183,32 +178,19 @@ public class ForumsIndexFragment extends AwfulFragment implements SwipyRefreshLa
         return TAG;
     }
 
-    @Override
+
+	@Override
+	protected void cancelNetworkRequests() {
+		super.cancelNetworkRequests();
+		NetworkUtils.cancelRequests(IndexRequest.REQUEST_TAG);
+	}
+
+	@Override
     public void onPause() {
-        super.onPause(); if(DEBUG) Log.e(TAG, "Pause");
+        super.onPause();
         getActivity().getContentResolver().unregisterContentObserver(forumObserver);
 		getLoaderManager().destroyLoader(Constants.FORUM_INDEX_LOADER_ID);
     }
-        
-    @Override
-    public void onStop() {
-        super.onStop(); if(DEBUG) Log.e(TAG, "Stop");
-    }
-    
-    @Override
-    public void onDestroyView() {
-        super.onDestroyView(); if(DEBUG) Log.e(TAG, "DestroyView");
-    }
-    
-    @Override
-    public void onDestroy() {
-        super.onDestroy(); if(DEBUG) Log.e(TAG, "Destroy");
-    }
-
-	@Override
-	public void onDetach() {
-		super.onDetach(); if(DEBUG) Log.e(TAG, "Detach");
-	}
 
     public void displayUserCP() {
     	if (getActivity() != null) {
@@ -231,6 +213,9 @@ public class ForumsIndexFragment extends AwfulFragment implements SwipyRefreshLa
 	
 	private void syncForums() {
         if(getActivity() != null){
+			// cancel pending forum index loading requests
+			NetworkUtils.cancelRequests(IndexRequest.REQUEST_TAG);
+			// call this with cancelOnDestroy=false to retain the request's specific type tag
             queueRequest(new IndexRequest(getActivity()).build(this, new AwfulRequest.AwfulResultCallback<Void>() {
                 @Override
                 public void success(Void result) {
@@ -247,7 +232,7 @@ public class ForumsIndexFragment extends AwfulFragment implements SwipyRefreshLa
                     }
                     restartLoader(Constants.FORUM_INDEX_LOADER_ID, null, mForumLoaderCallback);
                 }
-            }));
+            }), false);
         }
     }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageListFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageListFragment.java
@@ -178,6 +178,7 @@ public class PrivateMessageListFragment extends AwfulFragment implements SwipeRe
                 public void failure(VolleyError error) {
                     if(null != error.getMessage() && error.getMessage().startsWith("java.net.ProtocolException: Too many redirects")){
                         Log.e(TAG, "Error: "+error.getMessage());
+                        Log.e(TAG, "!!!Failed to sync PMs - You are now LOGGED OUT");
                         NetworkUtils.clearLoginCookies(getAwfulActivity());
                         getAwfulActivity().startActivity(new Intent().setClass(getAwfulActivity(), AwfulLoginActivity.class));
                     }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -472,11 +472,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 			}
 		});
 	}
-
-    @Override
-    public void onStart() {
-        super.onStart(); if(DEBUG) Log.e(TAG, "onStart");
-    }
     
 
     @Override
@@ -544,30 +539,22 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
         	mThreadView.onPause();
         }
     }
-        
-    @Override
-    public void onStop() {
-        super.onStop(); if(DEBUG) Log.e(TAG, "onStop");
-    }
-    
-    @Override
-    public void onDestroyView(){
-    	super.onDestroyView(); if(DEBUG) Log.e(TAG, "onDestroyView");
-    }
+
+	@Override
+	protected void cancelNetworkRequests() {
+		super.cancelNetworkRequests();
+		NetworkUtils.cancelRequests(PostRequest.REQUEST_TAG);
+	}
+
 
     @Override
     public void onDestroy() {
-        super.onDestroy(); if(DEBUG) Log.e(TAG, "onDestroy");
+        super.onDestroy();
         getLoaderManager().destroyLoader(Constants.POST_LOADER_ID);
     }
 
-    @Override
-    public void onDetach() {
-        super.onDetach(); if(DEBUG) Log.e(TAG, "onDetach");
-    }
-
     
-    public void refreshSessionCookie(){
+    public synchronized void refreshSessionCookie(){
         if(mThreadView != null){
         	if(DEBUG) Log.e(TAG,"SETTING COOKIES");
         	CookieSyncManager.createInstance(getActivity());
@@ -833,9 +820,10 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
     
     private void syncThread() {
         if(getActivity() != null){
-			// this call should always happen surely, not just when calling goToPage()?
-			cancelNetworkRequests();
+			// cancel pending post loading requests
+			NetworkUtils.cancelRequests(PostRequest.REQUEST_TAG);
         	bodyHtml = "";
+			// call this with cancelOnDestroy=false to retain the request's specific type tag
             queueRequest(new PostRequest(getActivity(), getThreadId(), getPage(), mUserId).build(this, new AwfulRequest.AwfulResultCallback<Integer>() {
 				@Override
 				public void success(Integer result) {
@@ -865,7 +853,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 					mPrevPage.setColorFilter(0);
 					mRefreshBar.setColorFilter(0);
 				}
-			}), true);
+			}), false);
         }
     }
     

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -464,10 +464,10 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 		mProbationBar.setVisibility(View.VISIBLE);
 		mProbationMessage.setText(String.format(this.getResources().getText(R.string.probation_message).toString(),new Date(mPrefs.probationTime).toLocaleString()));
 		mProbationButton.setOnClickListener(new OnClickListener() {
-			
+
 			@Override
 			public void onClick(View v) {
-				Intent openThread = new Intent(Intent.ACTION_VIEW, Uri.parse(Constants.FUNCTION_BANLIST+'?'+Constants.PARAM_USER_ID+"="+mPrefs.userId));
+				Intent openThread = new Intent(Intent.ACTION_VIEW, Uri.parse(Constants.FUNCTION_BANLIST + '?' + Constants.PARAM_USER_ID + "=" + mPrefs.userId));
 				startActivity(openThread);
 			}
 		});
@@ -833,6 +833,8 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
     
     private void syncThread() {
         if(getActivity() != null){
+			// this call should always happen surely, not just when calling goToPage()?
+			cancelNetworkRequests();
         	bodyHtml = "";
             queueRequest(new PostRequest(getActivity(), getThreadId(), getPage(), mUserId).build(this, new AwfulRequest.AwfulResultCallback<Integer>() {
 				@Override
@@ -853,6 +855,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 				public void failure(VolleyError error) {
 					if (null != error.getMessage() && error.getMessage().startsWith("java.net.ProtocolException: Too many redirects")) {
 						Log.e(TAG, "Error: " + error.getMessage());
+						Log.e(TAG, "!!!Failed to sync thread - You are now LOGGED OUT");
 						NetworkUtils.clearLoginCookies(getAwfulActivity());
 						getAwfulActivity().startActivity(new Intent().setClass(getAwfulActivity(), AwfulLoginActivity.class));
 					}
@@ -863,12 +866,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 					mRefreshBar.setColorFilter(0);
 				}
 			}), true);
-        }
-    }
-
-    private void cancelOldSync(){
-        if(getActivity() != null){
-            cancelNetworkRequests();
         }
     }
     
@@ -1449,7 +1446,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 			if(mThreadView != null){
                 mThreadView.loadUrl("javascript:loadpagehtml()");
 			}
-            cancelOldSync();
 	        syncThread();
 		}
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
@@ -30,12 +30,19 @@ package com.ferg.awfulapp.network;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import android.net.http.HttpResponseCache;
 import android.os.Messenger;
 import android.util.Log;
 
+import com.android.volley.Cache;
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.ImageLoader;
+import com.android.volley.toolbox.Volley;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.thread.AwfulURL;
+import com.ferg.awfulapp.util.LRUImageCache;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.http.Header;
@@ -74,6 +81,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -86,8 +94,63 @@ public class NetworkUtils {
 
     private static DefaultHttpClient sHttpClient;
 
+    private static RequestQueue     mNetworkQueue;
+    private static LRUImageCache    mImageCache;
+    private static ImageLoader      mImageLoader;
+
     private static String cookie = null;
     private static final String COOKIE_HEADER = "Cookie";
+
+
+    /**
+     * Initialise request handling and caching - call this early!
+     * @param context   A context used to create a cache dir
+     */
+    public static void init(Context context) {
+        mNetworkQueue   = Volley.newRequestQueue(context);
+        // TODO: find out if this is even being used anywhere
+        mImageCache     = new LRUImageCache();
+        mImageLoader    = new ImageLoader(mNetworkQueue, mImageCache);
+
+        try {
+            HttpResponseCache.install(new File(context.getCacheDir(), "httpcache"), 5242880);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    public static void clearImageCache() {
+        if (mImageCache != null) {
+            mImageCache.clear();
+        }
+    }
+
+
+    public static void clearDiskCache() {
+        Cache diskCache;
+        if (mNetworkQueue != null && (diskCache = mNetworkQueue.getCache()) != null) {
+            diskCache.clear();
+        }
+    }
+
+
+    public static void queueRequest(Request request){
+        if (mNetworkQueue != null) {
+            mNetworkQueue.add(request);
+        } else {
+            Log.w(TAG, "Can't queue request - NetworkQueue is null, has NetworkUtils been initialised?");
+        }
+    }
+
+    public static void cancelRequests(Object tag){
+        if (mNetworkQueue != null) {
+            mNetworkQueue.cancelAll(tag);
+        } else {
+            Log.w(TAG, "Can't cancel requests - NetworkQueue is null, has NetworkUtils been initialised?");
+        }
+    }
+
 
     public static void setCookieHeaders(Map<String, String> headers) {
         if (cookie.length() > 0) {
@@ -113,56 +176,42 @@ public class NetworkUtils {
         long expiry = prefs.getLong(Constants.COOKIE_PREF_EXPIRY_DATE, -1);
 
         if (useridCookieValue != null && passwordCookieValue != null && expiry != -1) {
+            cookie = String.format("%s=%s;%s=%s;%s=%s;%s=%s;",
+                    Constants.COOKIE_PREF_USERID, useridCookieValue,
+                    Constants.COOKIE_PREF_PASSWORD, passwordCookieValue,
+                    Constants.COOKIE_PREF_SESSIONID, sessionidCookieValue,
+                    Constants.COOKIE_PREF_SESSIONHASH, sessionhashCookieValue);
 
-            @SuppressWarnings("StringBufferReplaceableByString")
-            StringBuilder cookieBuilder = new StringBuilder();
-            cookieBuilder.append(Constants.COOKIE_PREF_USERID);
-            cookieBuilder.append('=');
-            cookieBuilder.append(useridCookieValue);
-            cookieBuilder.append(';');
-            cookieBuilder.append(Constants.COOKIE_PREF_PASSWORD);
-            cookieBuilder.append('=');
-            cookieBuilder.append(passwordCookieValue);
-            cookieBuilder.append(';');
-            cookieBuilder.append(Constants.COOKIE_PREF_SESSIONID);
-            cookieBuilder.append('=');
-            cookieBuilder.append(sessionidCookieValue);
-            cookieBuilder.append(';');
-            cookieBuilder.append(Constants.COOKIE_PREF_SESSIONHASH);
-            cookieBuilder.append('=');
-            cookieBuilder.append(sessionhashCookieValue);
-            cookieBuilder.append(';');
-            cookie = cookieBuilder.toString();
+            BasicClientCookie useridCookie =
+                    new BasicClientCookie(Constants.COOKIE_NAME_USERID, useridCookieValue);
+            BasicClientCookie passwordCookie =
+                    new BasicClientCookie(Constants.COOKIE_NAME_PASSWORD, passwordCookieValue);
+            BasicClientCookie sessionidCookie =
+                    new BasicClientCookie(Constants.COOKIE_NAME_SESSIONID, sessionidCookieValue);
+            BasicClientCookie sessionhashCookie =
+                    new BasicClientCookie(Constants.COOKIE_NAME_SESSIONHASH, sessionhashCookieValue);
 
             Date expiryDate = new Date(expiry);
-
-            BasicClientCookie useridCookie = new BasicClientCookie(Constants.COOKIE_NAME_USERID, useridCookieValue);
-            useridCookie.setDomain(Constants.COOKIE_DOMAIN);
-            useridCookie.setExpiryDate(expiryDate);
-            useridCookie.setPath(Constants.COOKIE_PATH);
-
-            BasicClientCookie passwordCookie = new BasicClientCookie(Constants.COOKIE_NAME_PASSWORD, passwordCookieValue);
-            passwordCookie.setDomain(Constants.COOKIE_DOMAIN);
-            passwordCookie.setExpiryDate(expiryDate);
-            passwordCookie.setPath(Constants.COOKIE_PATH);
-
-            BasicClientCookie sessionidCookie = new BasicClientCookie(Constants.COOKIE_NAME_SESSIONID, sessionidCookieValue);
-            sessionidCookie.setDomain(Constants.COOKIE_DOMAIN);
-            sessionidCookie.setExpiryDate(expiryDate);
-            sessionidCookie.setPath(Constants.COOKIE_PATH);
-
-            BasicClientCookie sessionhashCookie = new BasicClientCookie(Constants.COOKIE_NAME_SESSIONHASH, sessionhashCookieValue);
-            sessionhashCookie.setDomain(Constants.COOKIE_DOMAIN);
-            sessionhashCookie.setExpiryDate(expiryDate);
-            sessionhashCookie.setPath(Constants.COOKIE_PATH);
+            BasicClientCookie[] allCookies = {useridCookie, passwordCookie, sessionidCookie, sessionhashCookie};
+            for (BasicClientCookie tempCookie : allCookies) {
+                tempCookie.setDomain(Constants.COOKIE_DOMAIN);
+                tempCookie.setExpiryDate(expiryDate);
+                tempCookie.setPath(Constants.COOKIE_PATH);
+            }
 
             CookieStore jar = new BasicCookieStore();
             jar.addCookie(useridCookie);
             jar.addCookie(passwordCookie);
             sHttpClient.setCookieStore(jar);
 
+            Log.w(TAG, "Cookies restored from prefs");
             return true;
         } else {
+            String logMsg = "Unable to restore cookies! Reasons:\n";
+            logMsg += (useridCookieValue == null) ? "USER_ID is NULL\n" : "";
+            logMsg += (passwordCookieValue == null) ? "PASSWORD is NULL\n" : "";
+            logMsg += (expiry == -1) ? "EXPIRY is -1" : "";
+            Log.w(TAG, logMsg);
             cookie = "";
         }
 
@@ -209,40 +258,48 @@ public class NetworkUtils {
         List<Cookie> cookies = sHttpClient.getCookieStore().getCookies();
         for (Cookie cookie : cookies) {
             if (cookie.getDomain().contains(Constants.COOKIE_DOMAIN)) {
-                if (cookie.getName().equals(Constants.COOKIE_NAME_USERID)) {
-                    useridValue = cookie.getValue();
-                    expires = cookie.getExpiryDate();
-                } else if (cookie.getName().equals(Constants.COOKIE_NAME_PASSWORD)) {
-                    passwordValue = cookie.getValue();
-                    expires = cookie.getExpiryDate();
-                } else if (cookie.getName().equals(Constants.COOKIE_NAME_SESSIONID)) {
-                    sessionId = cookie.getValue();
-                    expires = cookie.getExpiryDate();
-                } else if (cookie.getName().equals(Constants.COOKIE_NAME_SESSIONHASH)) {
-                    sessionHash = cookie.getValue();
-                    expires = cookie.getExpiryDate();
+                final String cookieName = cookie.getName();
+                switch (cookieName) {
+                    case Constants.COOKIE_NAME_USERID:
+                        useridValue = cookie.getValue();
+                        break;
+                    case Constants.COOKIE_NAME_PASSWORD:
+                        passwordValue = cookie.getValue();
+                        break;
+                    case Constants.COOKIE_NAME_SESSIONID:
+                        sessionId = cookie.getValue();
+                        break;
+                    case Constants.COOKIE_NAME_SESSIONHASH:
+                        sessionHash = cookie.getValue();
+                        break;
+                }
+                // keep the soonest valid expiry in case they don't match
+                Date cookieExpiryDate = cookie.getExpiryDate();
+                if (expires == null || (cookieExpiryDate != null && cookieExpiryDate.before(expires))) {
+                    expires = cookieExpiryDate;
                 }
             }
         }
 
-        if (useridValue != null && passwordValue != null) {
-            Editor edit = prefs.edit();
-            edit.putString(Constants.COOKIE_PREF_USERID, useridValue);
-            edit.putString(Constants.COOKIE_PREF_PASSWORD, passwordValue);
-            if (sessionId != null && sessionId.length() > 0) {
-                edit.putString(Constants.COOKIE_PREF_SESSIONID, sessionId);
-            }
-            if (sessionHash != null && sessionHash.length() > 0) {
-                edit.putString(Constants.COOKIE_PREF_SESSIONHASH, sessionHash);
-            }
-            edit.putLong(Constants.COOKIE_PREF_EXPIRY_DATE, expires.getTime());
-
-            edit.apply();
-
-            return true;
+        if (useridValue == null || passwordValue == null) {
+            return false;
         }
 
-        return false;
+        Editor edit = prefs.edit();
+        edit.putString(Constants.COOKIE_PREF_USERID, useridValue);
+        edit.putString(Constants.COOKIE_PREF_PASSWORD, passwordValue);
+        if (sessionId != null && sessionId.length() > 0) {
+            edit.putString(Constants.COOKIE_PREF_SESSIONID, sessionId);
+        }
+        if (sessionHash != null && sessionHash.length() > 0) {
+            edit.putString(Constants.COOKIE_PREF_SESSIONHASH, sessionHash);
+        }
+        if (expires != null) {
+            edit.putLong(Constants.COOKIE_PREF_EXPIRY_DATE, expires.getTime());
+        }
+
+        edit.apply();
+        return true;
     }
 
     public static String getCookieString(String type) {
@@ -250,19 +307,11 @@ public class NetworkUtils {
         for (Cookie cookie : cookies) {
             if (cookie.getDomain().contains(Constants.COOKIE_DOMAIN)) {
                 if (cookie.getName().contains(type)) {
-
-                    @SuppressWarnings("StringBufferReplaceableByString")
-                    StringBuilder oven = new StringBuilder();
-
-                    oven.append(type);
-                    oven.append("=");
-                    oven.append(cookie.getValue());
-                    oven.append("; domain=");
-                    oven.append(cookie.getDomain());
-                    return oven.toString();
+                    return String.format("%s=%s; domain=%s", type, cookie.getValue(), cookie.getDomain());
                 }
             }
         }
+        Log.w(TAG, "getCookieString couldn't find type: " + type);
         return "";
     }
 
@@ -287,12 +336,7 @@ public class NetworkUtils {
 
         Log.i(TAG, "Fetching " + location);
 
-        HttpGet httpGet;
-        HttpResponse httpResponse;
-
-        httpGet = new HttpGet(location);
-        httpResponse = sHttpClient.execute(httpGet);
-
+        HttpResponse httpResponse = sHttpClient.execute(new HttpGet(location));
         HttpEntity entity = httpResponse.getEntity();
 
         if (entity != null) {
@@ -315,7 +359,6 @@ public class NetworkUtils {
 
 
     public static String getRedirect(String aUrl, HashMap<String, String> aParams) throws Exception {
-        String redirect = null;
         URI location;
         if (aParams != null) {
             location = new URI(aUrl + getQueryStringParameters(aParams));
@@ -323,13 +366,12 @@ public class NetworkUtils {
             location = new URI(aUrl);
         }
 
-        HttpGet httpGet = new HttpGet(location);
-        HttpResponse httpResponse = sHttpClient.execute(httpGet);
+        HttpResponse httpResponse = sHttpClient.execute(new HttpGet(location));
         Header redirectLocation = httpResponse.getFirstHeader("Location");
         if (redirectLocation != null) {
-            redirect = redirectLocation.getValue();
+            return redirectLocation.getValue();
         }
-        return redirect;
+        return null;
     }
 
     public static InputStream getStream(String aUrl) throws Exception {
@@ -337,10 +379,8 @@ public class NetworkUtils {
 
         Log.i(TAG, "Fetching " + location);
 
-        HttpGet httpGet;
         HttpResponse httpResponse;
-        httpGet = new HttpGet(location);
-        httpResponse = sHttpClient.execute(httpGet);
+        httpResponse = sHttpClient.execute(new HttpGet(location));
         return httpResponse.getEntity().getContent();
     }
 
@@ -381,9 +421,7 @@ public class NetworkUtils {
             httpPost.setEntity(post.build());
         }
 
-
         HttpResponse httpResponse = sHttpClient.execute(httpPost);
-
         HttpEntity entity = httpResponse.getEntity();
 
         if (entity != null) {
@@ -522,5 +560,43 @@ public class NetworkUtils {
         }
         fixCharMatch.appendTail(unencodedContent);
         return unencodedContent.toString();
+    }
+
+
+
+    /*
+        Stupid garbage to stave off forced logouts
+     */
+
+    private static final int MAX_REPEATED_LOGOUT_DODGES = 4;
+    private static AtomicInteger remaining_dodges = new AtomicInteger(MAX_REPEATED_LOGOUT_DODGES);
+
+    /**
+     * If a request hits the 'not registered' page, check if the user actually has
+     * login cookies, and ignore a few of them. Call {@link #resetDodges()} when a
+     * request succeeds normally, to reset the allowed failures counter
+     * @return  True if the problem should be ignored, false if the user should be logged out
+     */
+    public synchronized static boolean dodgeLogoutBullet() {
+        String username = NetworkUtils.getCookieString(Constants.COOKIE_NAME_USERID);
+        String password = NetworkUtils.getCookieString(Constants.COOKIE_NAME_PASSWORD);
+        if ("".equals(username) || "".equals(password)) {
+            Log.w(TAG, "Your cookie is broken though, better log in");
+            return false;
+        }
+        Log.w(TAG, "Looks like you're logged in to me though...");
+        if (remaining_dodges.decrementAndGet() <= 0) {
+            Log.w(TAG, "But it's happened " + MAX_REPEATED_LOGOUT_DODGES + " times in a row, logging out");
+            return false;
+        }
+        Log.w(TAG, "Letting it slide, " + remaining_dodges.get() + " chances remaining");
+        return true;
+    }
+
+    /**
+     * Reset the failure counter, call this after a request passes the 'unregistered' check
+     */
+    public static void resetDodges() {
+        remaining_dodges.set(MAX_REPEATED_LOGOUT_DODGES);
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/AccountSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/AccountSettings.java
@@ -9,6 +9,7 @@ import android.widget.Toast;
 import com.android.volley.VolleyError;
 import com.ferg.awfulapp.AwfulApplication;
 import com.ferg.awfulapp.R;
+import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.task.FeatureRequest;
 
@@ -41,21 +42,20 @@ public class AccountSettings extends SettingsFragment {
         @Override
         public boolean onPreferenceClick(Preference preference) {
             final Dialog dialog = ProgressDialog.show(getActivity(), "Loading", "Fetching Account Features", true);
-            ((AwfulApplication)getActivity().getApplication())
-                    .queueRequest(new FeatureRequest(getActivity())
-                            .build(null, new AwfulRequest.AwfulResultCallback<Void>() {
-                                @Override
-                                public void success(Void result) {
-                                    dialog.dismiss();
-                                    setSummaries();
-                                }
+            NetworkUtils.queueRequest(new FeatureRequest(getActivity())
+                    .build(null, new AwfulRequest.AwfulResultCallback<Void>() {
+                        @Override
+                        public void success(Void result) {
+                            dialog.dismiss();
+                            setSummaries();
+                        }
 
-                                @Override
-                                public void failure(VolleyError error) {
-                                    dialog.dismiss();
-                                    Toast.makeText(getActivity(), "An error occured", Toast.LENGTH_LONG).show();
-                                }
-                            }));
+                        @Override
+                        public void failure(VolleyError error) {
+                            dialog.dismiss();
+                            Toast.makeText(getActivity(), "An error occured", Toast.LENGTH_LONG).show();
+                        }
+                    }));
             return true;
         }
     }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
@@ -24,7 +24,6 @@ import com.ferg.awfulapp.util.AwfulError;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
-import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
@@ -42,6 +41,10 @@ import java.util.Map;
  * Created by Matt Shepard on 8/7/13.
  */
 public abstract class AwfulRequest<T> {
+
+    /** Used for identifying request types when cancelling, reassign this in subclasses */
+    public static final Object REQUEST_TAG = new Object();
+
     private Context cont;
     private String baseUrl;
     private Handler handle;
@@ -70,6 +73,12 @@ public abstract class AwfulRequest<T> {
          */
         public void failure(VolleyError error);
     }
+
+
+    public Object getRequestTag() {
+        return REQUEST_TAG;
+    }
+
 
     protected void addPostParam(String key, String value){
         if(key == null || value == null){
@@ -167,7 +176,9 @@ public abstract class AwfulRequest<T> {
                 helper = null;
             }
         }
-        return new ActualRequest(generateUrl(helper), successListener, errorListener);
+        final ActualRequest actualRequest = new ActualRequest(generateUrl(helper), successListener, errorListener);
+        actualRequest.setTag(getRequestTag());
+        return actualRequest;
     }
 
     /**

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/IndexRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/IndexRequest.java
@@ -18,9 +18,19 @@ import java.util.regex.Pattern;
  * Created by matt on 8/7/13.
  */
 public class IndexRequest extends AwfulRequest<Void> {
+
+    public static final Object REQUEST_TAG = new Object();
+
     public IndexRequest(Context context) {
         super(context, null);
     }
+
+
+    @Override
+    public Object getRequestTag() {
+        return REQUEST_TAG;
+    }
+
 
     @Override
     protected String generateUrl(Uri.Builder build) {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
@@ -14,6 +14,9 @@ import org.jsoup.nodes.Document;
  * Created by matt on 8/7/13.
  */
 public class PostRequest extends AwfulRequest<Integer> {
+
+    public static final Object REQUEST_TAG = new Object();
+
     private int threadId, page, userId;
     public PostRequest(Context context, int threadId, int page, int userId) {
         super(context, Constants.FUNCTION_THREAD);
@@ -21,6 +24,13 @@ public class PostRequest extends AwfulRequest<Integer> {
         this.page = page;
         this.userId = userId;
     }
+
+
+    @Override
+    public Object getRequestTag() {
+        return REQUEST_TAG;
+    }
+
 
     @Override
     protected String generateUrl(Uri.Builder urlBuilder) {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
@@ -13,12 +13,22 @@ import org.jsoup.nodes.Document;
  * Created by matt on 8/7/13.
  */
 public class ThreadListRequest extends AwfulRequest<Void> {
+
+    public static final Object REQUEST_TAG = new Object();
+
     private int forumId, page;
     public ThreadListRequest(Context context, int forumId, int page) {
         super(context, forumId == Constants.USERCP_ID ? Constants.FUNCTION_BOOKMARK : Constants.FUNCTION_FORUM);
         this.forumId = forumId;
         this.page = page;
     }
+
+
+    @Override
+    public Object getRequestTag() {
+        return REQUEST_TAG;
+    }
+
 
     @Override
     protected String generateUrl(Uri.Builder urlBuilder) {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPagedItem.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPagedItem.java
@@ -32,6 +32,7 @@ import android.util.Log;
 import com.ferg.awfulapp.constants.Constants;
 
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
 import java.util.regex.Pattern;
@@ -42,31 +43,19 @@ public abstract class AwfulPagedItem {
 	private static final Pattern pageNumber_regex = Pattern.compile("Pages \\((\\d+)\\)");
 	
     public static int parseLastPage(Document pagedItem){
-    	int pagesTop, pagesBottom;
-    	try{
-    		Elements pages = pagedItem.getElementsByClass("pages");
-            pagesTop = Integer.parseInt(pages.first().getElementsByTag("option").last().text());
-       	}catch(NumberFormatException ex){
-       		Log.e(TAG, "NumberFormatException thrown while parseLastPage");
-            pagesTop = 1;
-    	}catch(NullPointerException ex){
-            Log.e(TAG, "NullPointerException thrown while parseLastPage");
-            ex.printStackTrace();
-            pagesTop = 1;
-    	}
-        try{
-            Elements pages = pagedItem.getElementsByClass("pages");
-            pagesBottom = Integer.parseInt(pages.last().getElementsByTag("option").last().text());
-        }catch(NumberFormatException ex){
-            Log.e(TAG, "NumberFormatException thrown while parseLastPage");
-            pagesBottom = 1;
-        }catch(NullPointerException ex){
-            Log.e(TAG, "NullPointerException thrown while parseLastPage");
-            ex.printStackTrace();
-            pagesBottom = 1;
-        }
-        return Math.max(pagesTop, pagesBottom);
+		Elements pages = pagedItem.getElementsByClass("pages");
+        return Math.max(getPageNum(pages.first()), getPageNum(pages.last()));
     }
+
+	private static int getPageNum(Element pageElement) {
+		try {
+			return Integer.parseInt(pageElement.getElementsByTag("option").last().text());
+		} catch (NumberFormatException e) {
+				Log.e(TAG, "NumberFormatException thrown during parseLastPage()");
+				e.printStackTrace();
+		} catch (NullPointerException e) { } // not actually exceptional in 1-page threads!
+		return 1;
+	}
     
 	public static int indexToPage(int index, int perPage){
 		return (index-1)/perPage+1;//easier than using math.ceil.

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
@@ -112,8 +112,8 @@ public class AwfulError extends VolleyError{
             NetworkUtils.logCookies();
 
             CookieManager ckiemonster = CookieManager.getInstance();
-            String cookie = ckiemonster.getCookie(Constants.BASE_URL);
-            Log.w(TAG, "WebView CookieManager cookie for BASE_URL:" + cookie);
+            String cookie = ckiemonster.getCookie(Constants.COOKIE_DOMAIN);
+            Log.w(TAG, "WebView CookieManager cookie for COOKIE_DOMAIN:" + cookie);
 
             // TODO fix the actual problem, probably repeated network requests in a short space of time
             if (!NetworkUtils.dodgeLogoutBullet()) {

--- a/libraries/tree-view-list-android/src/pl/polidea/treeview/AbstractTreeViewAdapter.java
+++ b/libraries/tree-view-list-android/src/pl/polidea/treeview/AbstractTreeViewAdapter.java
@@ -156,17 +156,17 @@ public abstract class AbstractTreeViewAdapter<T> extends BaseAdapter implements
     @Override
     public final View getView(final int position, final View convertView,
             final ViewGroup parent) {
-        Log.d(TAG, "Creating a view based on " + convertView
-                + " with position " + position);
+//        Log.d(TAG, "Creating a view based on " + convertView
+//                + " with position " + position);
         final TreeNodeInfo<T> nodeInfo = getTreeNodeInfo(position);
         if (convertView == null) {
-            Log.d(TAG, "Creating the view a new");
+//            Log.d(TAG, "Creating the view a new");
             final LinearLayout layout = (LinearLayout) layoutInflater.inflate(
                     getTreeListItemWrapperId(), null);
             return populateTreeItem(layout, getNewChildView(nodeInfo),
                     nodeInfo, true);
         } else {
-            Log.d(TAG, "Reusing the view");
+//            Log.d(TAG, "Reusing the view");
             final LinearLayout linear = (LinearLayout) convertView;
             final FrameLayout frameLayout = (FrameLayout) linear
                     .findViewById(R.id.treeview_list_item_frame);


### PR DESCRIPTION
I couldn't find the definite cause of the logouts, but I did notice a few potential issues like cookie state handling that wasn't atomic (and multiple threads diving in on these methods) and the ability to spam network requests (and app updates) by hitting refresh a lot or zipping through lots of pages with the prev/next buttons.

I added a little synchronization and made the requests tag themselves by type, so a pending request of the same type can be cancelled if you want to start a new one - like loading a page and then doing another page load. It reins things in a bit, and who knows it might avoid some of the logouts too