### PR TITLE
Fixed SwitchPreferences randomly flipping themselves

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/CustomSwitchPreference.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/CustomSwitchPreference.java
@@ -1,0 +1,30 @@
+package com.ferg.awfulapp.preferences;
+
+import android.content.Context;
+import android.preference.SwitchPreference;
+import android.util.AttributeSet;
+
+/**
+ * Created by baka kaba on 13/06/2015.
+ *
+ * <p>Hey guess what - SwitchPreference didn't actually properly work properly until Lollipop!
+ * Scrolling them out of view can actually make them flip randomly.
+ * {@see <a href="https://code.google.com/p/android/issues/detail?id=26194">Fun!</a>}</p>
+ *
+ * Thanks google!
+ */
+public class CustomSwitchPreference extends SwitchPreference {
+
+    public CustomSwitchPreference(Context context) {
+        this(context, null);
+    }
+
+    public CustomSwitchPreference(Context context, AttributeSet attrs) {
+        this(context, attrs, android.R.attr.switchPreferenceStyle);
+    }
+
+    public CustomSwitchPreference(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/SettingsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/SettingsFragment.java
@@ -38,6 +38,11 @@ public abstract class SettingsFragment extends PreferenceFragment {
     protected OnSubmenuSelectedListener submenuSelectedListener;
 
     /*
+        !!!!! DON'T USE STANDARD SWITCH PREFERENCES !!!!!!
+        They're broken, use CustomSwitchPreference instead
+     */
+
+    /*
         CONFIGURATION
 
         The following fields allow you to apply settings and basic

--- a/Awful.apk/src/main/res/xml/accountsettings.xml
+++ b/Awful.apk/src/main/res/xml/accountsettings.xml
@@ -11,7 +11,7 @@
         android:title="@string/features"
         android:summary="@string/features_summary"
         />
-    <SwitchPreference
+    <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:key="send_username_in_report"
         android:title="@string/send_username_in_report"
         android:summary="@string/send_username_in_report_summary"

--- a/Awful.apk/src/main/res/xml/imagesettings.xml
+++ b/Awful.apk/src/main/res/xml/imagesettings.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="images_enabled"
             android:title="@string/load_images"
             android:summary="@string/load_images_summary"
             android:defaultValue="true"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="no_3g_images"
             android:title="@string/no_3g_images"
             android:summary="@string/no_3g_images_summary"
             android:defaultValue="false"
             android:dependency="images_enabled"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="hide_read_images"
             android:title="@string/hide_read_images"
             android:summary="@string/hide_read_images_summary"
             android:defaultValue="false"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="avatars_enabled"
             android:title="@string/load_avatars"
             android:defaultValue="true"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="show_smilies"
             android:title="@string/show_smilies"
             android:summary="@string/show_smilies_summary"
@@ -37,7 +37,7 @@
             android:entryValues="@array/imgur_thumbnails_values"
             android:defaultValue="d"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="disable_timgs"
             android:title="@string/disable_timgs"
             android:summary="@string/disable_timgs_summary"

--- a/Awful.apk/src/main/res/xml/miscsettings.xml
+++ b/Awful.apk/src/main/res/xml/miscsettings.xml
@@ -2,14 +2,14 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
         <PreferenceCategory android:title="@string/misc_category_performance">
-            <SwitchPreference
+            <com.ferg.awfulapp.preferences.CustomSwitchPreference
                 android:key="enable_hardware_acceleration"
                 android:title="@string/enable_hardware_acceleration"
                 android:summary="@string/enable_hardware_acceleration_summary"
                 android:defaultValue="true"
                 android:enabled="false"
                 />
-            <SwitchPreference
+            <com.ferg.awfulapp.preferences.CustomSwitchPreference
                 android:key="disable_gifs2"
                 android:title="@string/disable_gifs"
                 android:summary="@string/disable_gifs_summary"
@@ -34,13 +34,13 @@
                 android:entryValues="@array/orientation_values"
                 android:defaultValue="default"
                 />
-            <SwitchPreference
+            <com.ferg.awfulapp.preferences.CustomSwitchPreference
                 android:key="no_fab"
                 android:title="@string/no_fab"
                 android:summary="@string/no_fab_summary"
                 android:defaultValue="false"
                 />
-            <SwitchPreference
+            <com.ferg.awfulapp.preferences.CustomSwitchPreference
                 android:key="immersion_mode"
                 android:title="@string/immersion_mode"
                 android:summary="@string/immersion_mode_summary"
@@ -58,7 +58,7 @@
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/misc_category_navigation">
-            <SwitchPreference
+            <com.ferg.awfulapp.preferences.CustomSwitchPreference
                 android:key="disable_pull_next"
                 android:title="@string/disable_pull_next"
                 android:summary="@string/disable_pull_next_summary"
@@ -70,13 +70,13 @@
                 android:summary="@string/pull_to_refresh_distance_summary"
                 android:defaultValue="0.5"
                 />
-            <SwitchPreference
+            <com.ferg.awfulapp.preferences.CustomSwitchPreference
                 android:key="lock_scrolling"
                 android:title="@string/lock_scrolling"
                 android:summary="@string/lock_scrolling_summary"
                 android:defaultValue="false"
                 />
-            <SwitchPreference
+            <com.ferg.awfulapp.preferences.CustomSwitchPreference
                 android:key="volume_scroll"
                 android:title="@string/volume_scroll"
                 android:summary="@string/volume_scroll_summary"

--- a/Awful.apk/src/main/res/xml/post_highlighting_settings.xml
+++ b/Awful.apk/src/main/res/xml/post_highlighting_settings.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <SwitchPreference
+    <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:key="user_highlight"
         android:title="@string/user_highlight"
         android:summary="@string/user_highlight_summary"
         android:defaultValue="true"
         />
-    <SwitchPreference
+    <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:key="user_quotes"
         android:title="@string/user_quote"
         android:summary="@string/user_quote_summary"
         android:defaultValue="true"
         />
-    <SwitchPreference
+    <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:key="self_highlight"
         android:title="@string/self_highlight"
         android:summary="@string/self_highlight_summary"
         android:defaultValue="true"
         />
-    <SwitchPreference
+    <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:key="op_highlight"
         android:title="@string/op_highlight"
         android:summary="@string/op_highlight_summary"

--- a/Awful.apk/src/main/res/xml/postsettings.xml
+++ b/Awful.apk/src/main/res/xml/postsettings.xml
@@ -16,7 +16,7 @@
             android:title="@string/setting_posts_per_page"
             android:defaultValue="40"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="hide_old_posts"
             android:title="@string/hide_old_posts"
             android:summary="@string/hide_old_posts_summary"
@@ -28,44 +28,45 @@
             android:fragment="com.ferg.awfulapp.preferences.fragments.PostHighlightingSettings">
         </PreferenceScreen>
 
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="inline_youtube"
             android:title="@string/inline_videos"
             android:summary="@string/inline_videos_summary"
             android:defaultValue="true"
             />
         <!-- doesn't work yet
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="inline_tweets"
             android:title="@string/inline_tweets"
             android:summary="@string/inline_tweets_summary"
             android:defaultValue="false"
             />-->
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="inline_webm"
             android:title="@string/inline_webm"
             android:summary="@string/inline_webm_summary"
             android:defaultValue="false"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="inline_vines"
             android:title="@string/inline_vines"
             android:summary="@string/inline_vines_summary"
             android:defaultValue="false"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="show_all_spoilers"
             android:title="@string/show_spoilers"
             android:summary="@string/show_spoilers_summary"
             android:defaultValue="false"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="hide_signatures"
             android:title="@string/hide_signatures"
             android:summary="@string/hide_signatures_summary"
             android:defaultValue="false"
             />
-        <SwitchPreference android:key="always_open_urls"
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
+            android:key="always_open_urls"
             android:title="@string/always_open_urls"
             android:summary="@string/always_open_urls_summary"
             android:defaultValue="false" />

--- a/Awful.apk/src/main/res/xml/themesettings.xml
+++ b/Awful.apk/src/main/res/xml/themesettings.xml
@@ -7,7 +7,7 @@
             android:entryValues="@array/schemas_values"
             android:defaultValue="default.css"
             />
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="force_forum_themes"
             android:title="@string/force_forum_themes"
             android:summary="@string/force_forum_themes_summary"

--- a/Awful.apk/src/main/res/xml/threadinfosettings.xml
+++ b/Awful.apk/src/main/res/xml/threadinfosettings.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-		<SwitchPreference
+		<com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="threadinfo_tag" 
 			android:title="@string/threadinfo_tag"
 			android:summary="@string/threadinfo_tag_summary"
 			android:defaultValue="true"
 			/>
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
           android:key="wrap_thread_titles"
           android:title="@string/wrap_titles"
           android:summary="@string/wrap_titles_summary"
           android:defaultValue="false"
           />
-		<SwitchPreference
+		<com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="color_bookmarks" 
 			android:title="@string/color_bookmarks"
             android:summary="@string/color_bookmarks_summary"
 			android:defaultValue="false"
 			/>
-        <SwitchPreference
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
           android:key="threadinfo_rating"
           android:title="@string/threadinfo_rating"
           android:defaultValue="true"
           />
       <PreferenceCategory android:title="@string/new_threads_first_category">
-          <SwitchPreference
+          <com.ferg.awfulapp.preferences.CustomSwitchPreference
               android:key="new_threads_first_forum"
               android:title="@string/new_threads_first_forum"
               android:summary="@string/new_threads_first_forum_summary"
               android:defaultValue="false"
               />
-          <SwitchPreference
+          <com.ferg.awfulapp.preferences.CustomSwitchPreference
               android:key="new_threads_first_ucp"
               android:title="@string/new_threads_first_ucp"
               android:summary="@string/new_threads_first_ucp_summary"


### PR DESCRIPTION
Turns out this is a bug that only just got fixed in Lollipop.
SwitchPreferences can flip themselves at random if you scroll them out of view.
Seriously, you couldn't make this up