### PR TITLE
Ensure buildFinalRequest is always called

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
@@ -345,6 +345,9 @@ public abstract class AwfulRequest<T> {
         @Override
         public byte[] getBody() throws AuthFailureError {
             if(attachParams != null){
+                if (httpEntity == null) {
+                    buildFinalRequest();
+                }
                 try{
                     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
                     httpEntity.writeTo(bytes);
@@ -359,6 +362,9 @@ public abstract class AwfulRequest<T> {
         @Override
         public String getBodyContentType() {
             if(attachParams != null){
+                if (httpEntity == null) {
+                    buildFinalRequest();
+                }
                 return httpEntity.getContentType().getValue();
             }
             return super.getBodyContentType();


### PR DESCRIPTION
Most of the requests are failing because the HttpEntity is null when they're run - things like PMs, rating, bookmarks and so on. I made it run the builder method at the last minute if necessary, but I don't *really* know if that's what's meant to happen! Maybe @drasticactions wants to check it over?