### PR TITLE
Fix 'CalledFromWrongThreadException' on PM menu entry show/hide

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
@@ -355,10 +355,16 @@ public class ForumsIndexActivity extends AwfulActivity {
         }
 
         // private messages - show 'em if you got 'em
-        MenuItem pmItem = navMenu.findItem(R.id.sidebar_pm);
+        final MenuItem pmItem = navMenu.findItem(R.id.sidebar_pm);
         if (pmItem != null) {
-            pmItem.setEnabled(mPrefs.hasPlatinum);
-            pmItem.setVisible(mPrefs.hasPlatinum);
+            if (pmItem.isEnabled() != mPrefs.hasPlatinum || pmItem.isVisible() != mPrefs.hasPlatinum) {
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        pmItem.setEnabled(mPrefs.hasPlatinum).setVisible(mPrefs.hasPlatinum);
+                    }
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Should take care of Fabric crashers 169 (v3.2.0.6e) and 175 (v3.2.0.7)