### PR TITLE
Fix NullPointerException in onNewIntent->openForum (Fabric 181/184)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -584,13 +584,13 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
         }
     	closeLoaders();
     	setForumId(id);//if the fragment isn't attached yet, just set the values and let the lifecycle handle it
-        ((ForumsIndexActivity) getActivity()).setNavIds(id, null);
     	updateColors();
     	mPage = page;
     	mLastPage = 0;
     	lastRefresh = 0;
     	loadFailed = false;
     	if(getActivity() != null){
+			((ForumsIndexActivity) getActivity()).setNavIds(id, null);
 			getActivity().invalidateOptionsMenu();
 			refreshInfo();
 			syncForum();


### PR DESCRIPTION
I'm not terribly convinced that the "not crashing" alternative of "do nothing" is a big improvement, but that's what we've already been doing with the other getActivity() call since 2012.