### PR TITLE
Catch IllegalArgumentExceptions when the support lib handles touch events

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/widget/ToggleViewPager.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/widget/ToggleViewPager.java
@@ -1,15 +1,9 @@
 package com.ferg.awfulapp.widget;
 
 import android.content.Context;
-import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.MotionEvent;
-import android.view.View;
-
-import com.ferg.awfulapp.ForumsIndexActivity;
-import com.ferg.awfulapp.ThreadDisplayFragment;
 
 public class ToggleViewPager extends ViewPager{
     private boolean swipeEnabled = true;
@@ -23,12 +17,31 @@ public class ToggleViewPager extends ViewPager{
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
-        return swipeEnabled && super.onInterceptTouchEvent(ev);
+        return antiCrashEventHandler(ev, true);
     }
 
     @Override
     public boolean onTouchEvent(MotionEvent ev) {
-        return swipeEnabled && super.onTouchEvent(ev);
+        return antiCrashEventHandler(ev, false);
+    }
+
+
+    /**
+     * Fix to avoid apparent bug in the support library, with infrequent crashing from an IAE.
+     * (See <a href="https://code.google.com/p/android/issues/detail?id=64553">this issue</a>.)
+     * @param ev            Event being passed
+     * @param intercepting  Set true when handling onInterceptTouchEvent
+     * @return              False if swiping is disabled or the exception was thrown,
+     *                      otherwise the result of the superclass call
+     */
+    private boolean antiCrashEventHandler(MotionEvent ev, boolean intercepting) {
+        boolean result = false;
+        try {
+            result = intercepting ? super.onInterceptTouchEvent(ev) : super.onTouchEvent(ev);
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+        }
+        return swipeEnabled && result;
     }
 
     public void setSwipeEnabled(boolean swipe){


### PR DESCRIPTION
There's a bug apparently, that sometimes causes an invalid argument in motion event handling
https://code.google.com/p/android/issues/detail?id=64553
A few people seem to get it on Crashlytics (e.g. issue 206), probably worth just catching it since it's the library that's choking?