### PR TITLE
Safer swipy refresh layout

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/widget/SwipyRefreshLayout.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/widget/SwipyRefreshLayout.java
@@ -1,17 +1,25 @@
 package com.ferg.awfulapp.widget;
 
 import android.content.Context;
-import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
-public class ToggleViewPager extends ViewPager{
-    private boolean swipeEnabled = true;
-    public ToggleViewPager(Context context) {
+/**
+ * Created by baka kaba on 15/08/2015.
+ *
+ * <p>This is a (hopefully) temporary extension of the SwipyRefreshLayout library,
+ * to catch and swallow an exception that seems to be caused by an
+ * <a href="https://code.google.com/p/android/issues/detail?id=64553">internal bug</a>.</p>
+ *
+ * <p>When/if this is fixed, remove the same code from {@link ToggleViewPager} too thanks!</p>
+ */
+public class SwipyRefreshLayout extends com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout{
+
+    public SwipyRefreshLayout(Context context) {
         super(context);
     }
 
-    public ToggleViewPager(Context context, AttributeSet attrs) {
+    public SwipyRefreshLayout(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
 
@@ -29,26 +37,17 @@ public class ToggleViewPager extends ViewPager{
     /**
      * Fix to avoid apparent bug in the support library, with infrequent crashing from an IAE.
      * (See <a href="https://code.google.com/p/android/issues/detail?id=64553">this issue</a>.)
-     * @param ev            Event being passed
+     * @param ev            Motion event being passed
      * @param intercepting  Set true when handling onInterceptTouchEvent
-     * @return              False if swiping is disabled or the exception was thrown,
-     *                      otherwise the result of the superclass call
+     * @return              False if the exception was thrown, otherwise the result of the superclass call
      */
     private boolean antiCrashEventHandler(MotionEvent ev, boolean intercepting) {
-        /*
-            When/if this is fixed, remove the internal SwipyRefreshLayout class and
-            refactor the XML layouts to use the external library version again, thanks!
-         */
         boolean result = false;
         try {
             result = intercepting ? super.onInterceptTouchEvent(ev) : super.onTouchEvent(ev);
         } catch (IllegalArgumentException e) {
             e.printStackTrace();
         }
-        return swipeEnabled && result;
-    }
-
-    public void setSwipeEnabled(boolean swipe){
-        swipeEnabled = swipe;
+        return result;
     }
 }

--- a/Awful.apk/src/main/res/layout/forum_display.xml
+++ b/Awful.apk/src/main/res/layout/forum_display.xml
@@ -16,7 +16,7 @@
         android:id="@+id/probationbar"
         layout="@layout/probationbar" />
 
-    <com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout
+    <com.ferg.awfulapp.widget.SwipyRefreshLayout
         android:id="@+id/forum_swipe"
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -31,7 +31,7 @@
             android:cacheColorHint="@color/background"
             android:divider="?attr/listDividerColor"
             android:dividerHeight="1dp" />
-    </com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout>
+    </com.ferg.awfulapp.widget.SwipyRefreshLayout>
 
     <include
         android:id="@+id/pagebar"

--- a/Awful.apk/src/main/res/layout/forum_index.xml
+++ b/Awful.apk/src/main/res/layout/forum_index.xml
@@ -14,8 +14,7 @@
 
     <include
         android:id="@+id/probationbar"
-        layout="@layout/probationbar"
-        android:layout_height="40dp" />
+        layout="@layout/probationbar" />
     <!--
           <pl.polidea.treeview.TreeViewList 
         android:id="@+id/index_tree_view" 

--- a/Awful.apk/src/main/res/layout/forum_index.xml
+++ b/Awful.apk/src/main/res/layout/forum_index.xml
@@ -25,7 +25,7 @@
 		android:smoothScrollbar="true"
 		/>
     -->
-    <com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout
+    <com.ferg.awfulapp.widget.SwipyRefreshLayout
         android:id="@+id/index_swipe"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -40,5 +40,5 @@
             android:dividerHeight="1dp"
             android:groupIndicator="@android:color/transparent"
             android:drawSelectorOnTop="false" />
-    </com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout>
+    </com.ferg.awfulapp.widget.SwipyRefreshLayout>
 </LinearLayout>

--- a/Awful.apk/src/main/res/layout/thread_display.xml
+++ b/Awful.apk/src/main/res/layout/thread_display.xml
@@ -30,7 +30,7 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
-            <com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout
+            <com.ferg.awfulapp.widget.SwipyRefreshLayout
                 android:id="@+id/thread_swipe"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -41,7 +41,7 @@
                     android:layout_width="fill_parent"
                     android:layout_height="fill_parent"
                     android:background="@color/background" />
-            </com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout>
+            </com.ferg.awfulapp.widget.SwipyRefreshLayout>
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/just_post"
             android:layout_width="wrap_content"


### PR DESCRIPTION
I've made an internal version of SwipyRefreshLayout that just overrides the touch event callbacks to catch those rogue IllegalArgumentExceptions, basically the same code as in #353. It feels even hackier than the first one, but what can you do? Hopefully it should keep the crashes down until the issue's fixed (an Android dev actually looked at it the other day!!!)

I also removed a conflict that was causing an XML warning for the probation bar, but someone who knows what the size should be should probably take a look at it, the include and the layout had different values