### PR TITLE
Remove "Always Open Links" option from link context menu in threads

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -1333,15 +1333,13 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 			"Show Image Inline",
 			"Open URL",
 			"Copy URL",
-			"Share URL",
-			"Always Open URL"
+			"Share URL"
 	};
 	
 	private String[] urlMenuItems = new String[]{
 			"Open URL",
 			"Copy URL",
-			"Share URL",
-			"Always Open URL",
+			"Share URL"
 	};
 	
 	
@@ -1382,10 +1380,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
             	case 4:
             		startActivity(createShareIntent(url));
             		break;
-            	case 5:
-        			mPrefs.setBooleanPreference("always_open_urls", true);
-        			startUrlIntent(url);
-        			break;
             	}
             }
         }).show();


### PR DESCRIPTION
There was a request for this and personally I think it's a good idea - leaving the option as a switch in the settings, so there's no accidental enabling, and if you do turn it on you know exactly where to turn it back off again. See what you reckon