### PR TITLE
Rework prefs to use type-validated references instead of string literals

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
@@ -32,7 +32,6 @@ package com.ferg.awfulapp;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.graphics.drawable.AnimationDrawable;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -48,17 +47,13 @@ import android.widget.Toast;
 
 import com.android.volley.NetworkResponse;
 import com.android.volley.VolleyError;
-import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.task.LoginRequest;
-import com.ferg.awfulapp.task.SendEditRequest;
 
 import org.apache.http.HttpStatus;
-import org.apache.http.protocol.HTTP;
-
-import java.util.HashMap;
 
 public class AwfulLoginActivity extends AwfulActivity {
     private static final String TAG = "LoginActivity";
@@ -169,7 +164,7 @@ public class AwfulLoginActivity extends AwfulActivity {
                     Boolean result = NetworkUtils.saveLoginCookies(getApplicationContext());
                     if(result){
                         AwfulPreferences prefs = AwfulPreferences.getInstance(getApplicationContext());
-                        prefs.setStringPreference("username", username);
+                        prefs.setPreference(Keys.USERNAME, username);
                         onLoginSuccess();
                     }else{
                         onLoginFailed();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
@@ -73,6 +73,7 @@ import com.ferg.awfulapp.dialog.ChangelogDialog;
 import com.ferg.awfulapp.dialog.LogOutDialog;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.preferences.SettingsActivity;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.provider.StringProvider;
@@ -576,11 +577,11 @@ public class ForumsIndexActivity extends AwfulActivity {
                         }
                     })
                     .show();
-            mPrefs.setIntegerPreference("alert_id_shown", 1);
+            mPrefs.setPreference(Keys.ALERT_ID_SHOWN, 1);
         } else if (mPrefs.lastVersionSeen != versionCode) {
             Log.i(TAG, String.format("App version changed from %d to %d - showing changelog", mPrefs.lastVersionSeen, versionCode));
             ChangelogDialog.show(this);
-            mPrefs.setIntegerPreference("last_version_seen", versionCode);
+            mPrefs.setPreference(Keys.LAST_VERSION_SEEN, versionCode);
         }
     }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -38,7 +38,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.content.res.TypedArray;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.graphics.Color;
@@ -90,6 +89,7 @@ import com.android.volley.VolleyError;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.provider.AwfulProvider;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.task.AwfulRequest;
@@ -749,7 +749,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 			@Override
 			public void onClick(DialogInterface dialog, int which) {
                 try{
-                    mPrefs.setBooleanPreference("show_ignore_warning", false);
+					mPrefs.setPreference(Keys.SHOW_IGNORE_WARNING, false);
                 }catch(Exception e){
                     e.printStackTrace();
                 }
@@ -897,7 +897,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
 	private void toggleYospos() {
 		mPrefs.amberDefaultPos = !mPrefs.amberDefaultPos;
-		mPrefs.setBooleanPreference("amber_default_pos", mPrefs.amberDefaultPos);
+		mPrefs.setPreference(Keys.AMBER_DEFAULT_POS, mPrefs.amberDefaultPos);
 		mThreadView.loadUrl("javascript:changeCSS('"+AwfulUtils.determineCSS(mParentForumId)+"')");
 	}
     

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
@@ -40,10 +40,14 @@ import android.content.res.Resources;
 import android.net.ConnectivityManager;
 import android.os.Environment;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.util.Log;
 import android.util.TypedValue;
 import android.widget.Toast;
 
+import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.util.AwfulUtils;
 import com.google.gson.Gson;
@@ -78,6 +82,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 
 
     private Context mContext;
+	private final Resources mResources;
 	private final WeakHashMap<AwfulPreferenceUpdate, Object> mCallback = new WeakHashMap<>();
 
     //GENERAL STUFF
@@ -174,8 +179,9 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 	 * Constructs a new AwfulPreferences object, registers preference change listener, and updates values.
 	 * @param context
 	 */
-	private AwfulPreferences(Context context) {
+	private AwfulPreferences(@NonNull Context context) {
 		mContext = context;
+		mResources = context.getResources();
 		// this is sort of redundant with what's going on in updateValues(), but best to be sure eh
 		SettingsActivity.setDefaultsFromXml(context);
 		mPrefs = PreferenceManager.getDefaultSharedPreferences(mContext);
@@ -184,7 +190,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 		upgradePreferences();
 		
 		longKeys = new HashSet<>();
-		longKeys.add("probation_time");
+		longKeys.add(mResources.getString(R.string.pref_key_probation_time));
 	}
 
 	
@@ -234,115 +240,166 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 	private void updateValues(SharedPreferences prefs) {
 		Resources res = mContext.getResources();
 		scaleFactor				 = res.getDisplayMetrics().density;
-		username                 = mPrefs.getString("username", "Username");
-        userTitle                = mPrefs.getString("user_title", null);
-		hasPlatinum              = mPrefs.getBoolean("has_platinum", false);
-		hasArchives              = mPrefs.getBoolean("has_archives", false);
-		hasNoAds         	     = mPrefs.getBoolean("has_no_ads", false);
-		postFontSizeDip            = mPrefs.getInt("default_post_font_size_dip", Constants.DEFAULT_FONT_SIZE);
-        postFixedFontSizeDip     = mPrefs.getInt("default_post_fixed_font_size_dip", Constants.DEFAULT_FIXED_FONT_SIZE);
+		username                 = getPreference(Keys.USERNAME, "Username");
+        userTitle                = getPreference(Keys.USER_TITLE, (String) null);
+		hasPlatinum              = getPreference(Keys.HAS_PLATINUM, false);
+		hasArchives              = getPreference(Keys.HAS_ARCHIVES, false);
+		hasNoAds         	     = getPreference(Keys.HAS_NO_ADS, false);
+		postFontSizeDip            = getPreference(Keys.POST_FONT_SIZE_DIP, Constants.DEFAULT_FONT_SIZE);
+        postFixedFontSizeDip     = getPreference(Keys.POST_FIXED_FONT_SIZE_DIP, Constants.DEFAULT_FIXED_FONT_SIZE);
 		postFontSizePx = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, postFontSizeDip, mContext.getResources().getDisplayMetrics());
-		theme					 = mPrefs.getString("theme", "default.css");
-		layout					 = mPrefs.getString("layouts", "default");
-        imagesEnabled            = mPrefs.getBoolean("images_enabled", true);
-        no3gImages	             = mPrefs.getBoolean("no_3g_images", false);
-        avatarsEnabled           = mPrefs.getBoolean("avatars_enabled", true);
-        hideOldImages            = mPrefs.getBoolean("hide_read_images", false);
-        showSmilies              = mPrefs.getBoolean("show_smilies", true);
-        postPerPage              = mPrefs.getInt("posts_per_page", Constants.ITEMS_PER_PAGE);
-       	alternateBackground      = mPrefs.getBoolean("alternate_backgrounds", false);
-        highlightUserQuote       = mPrefs.getBoolean("user_quotes", true);
-        highlightUsername        = mPrefs.getBoolean("user_highlight", true);
-        highlightSelf			 = mPrefs.getBoolean("self_highlight", true);
-        highlightOP				 = mPrefs.getBoolean("op_highlight", true);
-		inlineYoutube            = mPrefs.getBoolean("inline_youtube", false);
-		inlineTweets             = mPrefs.getBoolean("inline_tweets", false);
-		inlineVines            	 = mPrefs.getBoolean("inline_vines", false);
-		inlineWebm            	 = mPrefs.getBoolean("inline_webm", false);
-		autostartWebm            = mPrefs.getBoolean("autostart_webm", true);
-        enableHardwareAcceleration = mPrefs.getBoolean("enable_hardware_acceleration", AwfulUtils.isJellybean());
-        debugMode            	 = false;//= mPrefs.getBoolean("debug_mode", false);
-        wrapThreadTitles		 = mPrefs.getBoolean("wrap_thread_titles", false);
-        showAllSpoilers			 = mPrefs.getBoolean("show_all_spoilers", false);
-        threadInfo_Rating		 = mPrefs.getBoolean("threadinfo_rating", true);
-        threadInfo_Tag		 	 = mPrefs.getBoolean("threadinfo_tag", true);
-        imgurThumbnails			 = mPrefs.getString("imgur_thumbnails", "d");
-        newThreadsFirstUCP		 = mPrefs.getBoolean("new_threads_first_ucp", false);
-        newThreadsFirstForum	 = mPrefs.getBoolean("new_threads_first_forum", false);
-        preferredFont			 = mPrefs.getString("preferred_font", "default");
-        upperNextArrow		     = mPrefs.getBoolean("upper_next_arrow", false);
-        sendUsernameInReport	 = mPrefs.getBoolean("send_username_in_report", true);
-        disableGifs	 			 = mPrefs.getBoolean("disable_gifs2", true);
-        hideOldPosts	 	 	 = mPrefs.getBoolean("hide_old_posts", true);
-        alwaysOpenUrls	 	 	 = mPrefs.getBoolean("always_open_urls", false);
-        lockScrolling			 = mPrefs.getBoolean("lock_scrolling", false);
-        disableTimgs			 = mPrefs.getBoolean("disable_timgs", false);
-        currPrefVersion          = mPrefs.getInt("curr_pref_version", 0);
-        disablePullNext          = mPrefs.getBoolean("disable_pull_next", false);
-        alertIDShown             = mPrefs.getInt("alert_id_shown", 0);
-		lastVersionSeen 		 = mPrefs.getInt("last_version_seen", 0);
-		volumeScroll         	 = mPrefs.getBoolean("volume_scroll", false);
-		forceForumThemes		 = mPrefs.getBoolean("force_forum_themes", true);
-		noFAB					 = mPrefs.getBoolean("no_fab", false);
-        probationTime			 = mPrefs.getLong("probation_time", 0);
-        userId					 = mPrefs.getInt("user_id", 0);
-        showIgnoreWarning		 = mPrefs.getBoolean("show_ignore_warning", true);
-        ignoreFormkey			 = mPrefs.getString("ignore_formkey", null);
-		orientation				 = mPrefs.getString("orientation", "default");
-		pageLayout				 = mPrefs.getString("page_layout", "auto");
-        coloredBookmarks		 = mPrefs.getBoolean("color_bookmarks", false);
-        p2rDistance				 = mPrefs.getFloat("pull_to_refresh_distance", 0.5f);
-        immersionMode			 = AwfulUtils.isKitKat() && mPrefs.getBoolean("immersion_mode", false);
-        hideSignatures  		 = mPrefs.getBoolean("hide_signatures", false);
-        transformer  		     = mPrefs.getString("transformer", "Default");
-		amberDefaultPos  		 = mPrefs.getBoolean("amber_default_pos", false);
-		hideIgnoredPosts  		 = mPrefs.getBoolean("hide_ignored_posts", false);
-        markedUsers				 = mPrefs.getStringSet("marked_users", new HashSet<String>());
+		theme					 = getPreference(Keys.THEME, "default.css");
+		layout					 = getPreference(Keys.LAYOUT, "default");
+        imagesEnabled            = getPreference(Keys.IMAGES_ENABLED, true);
+        no3gImages	             = getPreference(Keys.NO_3G_IMAGES, false);
+        avatarsEnabled           = getPreference(Keys.AVATARS_ENABLED, true);
+        hideOldImages            = getPreference(Keys.HIDE_OLD_IMAGES, false);
+        showSmilies              = getPreference(Keys.SHOW_SMILIES, true);
+        postPerPage              = getPreference(Keys.POST_PER_PAGE, Constants.ITEMS_PER_PAGE);
+       	alternateBackground      = getPreference(Keys.ALTERNATE_BACKGROUND, false);
+        highlightUserQuote       = getPreference(Keys.HIGHLIGHT_USER_QUOTE, true);
+        highlightUsername        = getPreference(Keys.HIGHLIGHT_USERNAME, true);
+        highlightSelf			 = getPreference(Keys.HIGHLIGHT_SELF, true);
+        highlightOP				 = getPreference(Keys.HIGHLIGHT_OP, true);
+		inlineYoutube            = getPreference(Keys.INLINE_YOUTUBE, false);
+		inlineTweets             = getPreference(Keys.INLINE_TWEETS, false);
+		inlineVines            	 = getPreference(Keys.INLINE_VINES, false);
+		inlineWebm            	 = getPreference(Keys.INLINE_WEBM, false);
+		autostartWebm            = getPreference(Keys.AUTOSTART_WEBM, true);
+        enableHardwareAcceleration = getPreference(Keys.ENABLE_HARDWARE_ACCELERATION, AwfulUtils.isJellybean());
+        debugMode            	 = false;//= getPreference("debug_mode", false);
+        wrapThreadTitles		 = getPreference(Keys.WRAP_THREAD_TITLES, false);
+        showAllSpoilers			 = getPreference(Keys.SHOW_ALL_SPOILERS, false);
+        threadInfo_Rating		 = getPreference(Keys.THREAD_INFO_RATING, true);
+        threadInfo_Tag		 	 = getPreference(Keys.THREAD_INFO_TAG, true);
+        imgurThumbnails			 = getPreference(Keys.IMGUR_THUMBNAILS, "d");
+        newThreadsFirstUCP		 = getPreference(Keys.NEW_THREADS_FIRST_UCP, false);
+        newThreadsFirstForum	 = getPreference(Keys.NEW_THREADS_FIRST_FORUM, false);
+        preferredFont			 = getPreference(Keys.PREFERRED_FONT, "default");
+        upperNextArrow		     = getPreference(Keys.UPPER_NEXT_ARROW, false);
+        sendUsernameInReport	 = getPreference(Keys.SEND_USERNAME_IN_REPORT, true);
+        disableGifs	 			 = getPreference(Keys.DISABLE_GIFS, true);
+        hideOldPosts	 	 	 = getPreference(Keys.HIDE_OLD_POSTS, true);
+        alwaysOpenUrls	 	 	 = getPreference(Keys.ALWAYS_OPEN_URLS, false);
+        lockScrolling			 = getPreference(Keys.LOCK_SCROLLING, false);
+        disableTimgs			 = getPreference(Keys.DISABLE_TIMGS, false);
+        currPrefVersion          = getPreference(Keys.CURR_PREF_VERSION, 0);
+        disablePullNext          = getPreference(Keys.DISABLE_PULL_NEXT, false);
+        alertIDShown             = getPreference(Keys.ALERT_ID_SHOWN, 0);
+		lastVersionSeen 		 = getPreference(Keys.LAST_VERSION_SEEN, 0);
+		volumeScroll         	 = getPreference(Keys.VOLUME_SCROLL, false);
+		forceForumThemes		 = getPreference(Keys.FORCE_FORUM_THEMES, true);
+		noFAB					 = getPreference(Keys.NO_FAB, false);
+		probationTime			 = getPreference(Keys.PROBATION_TIME, 0L);
+        userId					 = getPreference(Keys.USER_ID, 0);
+		showIgnoreWarning		 = getPreference(Keys.SHOW_IGNORE_WARNING, true);
+		ignoreFormkey			 = getPreference(Keys.IGNORE_FORMKEY, (String) null);
+		orientation				 = getPreference(Keys.ORIENTATION, "default");
+		pageLayout				 = getPreference(Keys.PAGE_LAYOUT, "auto");
+		coloredBookmarks		 = getPreference(Keys.COLORED_BOOKMARKS, false);
+		p2rDistance				 = getPreference(Keys.P2R_DISTANCE, 0.5f);
+		immersionMode = AwfulUtils.isKitKat() && getPreference(Keys.IMMERSION_MODE, false);
+		hideSignatures  		 = getPreference(Keys.HIDE_SIGNATURES, false);
+		transformer  		     = getPreference(Keys.TRANSFORMER, "Default");
+		amberDefaultPos  		 = getPreference(Keys.AMBER_DEFAULT_POS, false);
+		hideIgnoredPosts  		 = getPreference(Keys.HIDE_IGNORED_POSTS, false);
+		markedUsers = getPreference(Keys.MARKED_USERS, new HashSet<String>());
 
         //I have never seen this before oh god
     }
 
-	public void setBooleanPreference(String key, boolean value) {
-		mPrefs.edit().putBoolean(key, value).apply();
+	/*
+		Type-checked preference getters
+
+		Lint can't infer the correct signature by the type annotation, so if there's any
+		ambiguity (e.g. int/long) then cast the value parameter according to the key type
+
+		The @StringRes annotation is there to enforce storing keys as resource strings!
+	 */
+
+	@Nullable
+	private String getPreference(@Keys.StringPreference @StringRes int key,
+								 @Nullable String defaultValue) {
+		return mPrefs.getString(mResources.getString(key), defaultValue);
 	}
 
-	public void setStringPreference(String key, String value) {
-        mPrefs.edit().putString(key, value).apply();
+	@NonNull
+	private Set<String> getPreference(@Keys.StringSetPreference @StringRes int key,
+									  @NonNull Set<String> defaultValue) {
+		return mPrefs.getStringSet(mResources.getString(key), defaultValue);
 	}
 
-	public void setLongPreference(String key, long value) {
-
-		mPrefs.edit().putLong(key, value).apply();
+	private boolean getPreference(@Keys.BooleanPreference @StringRes int key, boolean defaultValue) {
+		return mPrefs.getBoolean(mResources.getString(key), defaultValue);
 	}
 
-	public void setIntegerPreference(String key, int value) {
-		mPrefs.edit().putInt(key, value).apply();
+	private int getPreference(@Keys.IntPreference @StringRes int key, int defaultValue) {
+		return mPrefs.getInt(mResources.getString(key), defaultValue);
 	}
-	
-	public void setFloatPreference(String key, float value) {
-		mPrefs.edit().putFloat(key, value).apply();
+
+	private long getPreference(@Keys.LongPreference @StringRes int key, long defaultValue) {
+		return mPrefs.getLong(mResources.getString(key), defaultValue);
 	}
-	
-	public void setStringSetPreference(String key, Set<String> value){
-    	mPrefs.edit().putStringSet(key, value).apply();
+
+	private float getPreference(@Keys.FloatPreference @StringRes int key, float defaultValue) {
+		return mPrefs.getFloat(mResources.getString(key), defaultValue);
 	}
+
+
+	/*
+		Type-checked preference setters
+
+		Lint can't infer the correct signature by the type annotation, so if there's any
+		ambiguity (e.g. int/long) then cast the value parameter according to the key type
+
+		The @StringRes annotation is there to enforce storing keys as resource strings!
+	 */
+
+	public void setPreference(@Keys.StringPreference @StringRes int key,
+							  @Nullable String value) {
+		mPrefs.edit().putString(mResources.getString(key), value).apply();
+	}
+
+	public void setPreference(@Keys.StringSetPreference @StringRes int key,
+							  @NonNull Set<String> value) {
+		mPrefs.edit().putStringSet(mResources.getString(key), value).apply();
+	}
+
+	public void setPreference(@Keys.BooleanPreference @StringRes int key, boolean value) {
+		mPrefs.edit().putBoolean(mResources.getString(key), value).apply();
+	}
+
+	public void setPreference(@Keys.IntPreference @StringRes int key, int value) {
+		mPrefs.edit().putInt(mResources.getString(key), value).apply();
+	}
+
+	public void setPreference(@Keys.LongPreference @StringRes int key, long value) {
+		mPrefs.edit().putLong(mResources.getString(key), value).apply();
+	}
+
+	public void setPreference(@Keys.FloatPreference @StringRes int key, float value) {
+		mPrefs.edit().putFloat(mResources.getString(key), value).apply();
+	}
+
 	
 	public void upgradePreferences() {
 		if(currPrefVersion < PREFERENCES_VERSION) {
 			switch(currPrefVersion) {//this switch intentionally falls through!
 			case 0:
-				// Removing new_threads_first preference and applying it to new new_threads_first_ucp preference
-				boolean newPrefsFirst = mPrefs.getBoolean("new_threads_first", false);
-        		setBooleanPreference("new_threads_first_ucp", newPrefsFirst);
-        		mPrefs.edit().remove("new_threads_first").apply();
-        		newThreadsFirstUCP = newPrefsFirst;
+				// Get the current value of the obsolete preference, then remove it
+				String obsoleteKey = "new_threads_first";
+				boolean newThreadsFirst = mPrefs.getBoolean(obsoleteKey, false);
+				mPrefs.edit().remove(obsoleteKey).apply();
+				// transfer the value to the new key
+				setPreference(Keys.NEW_THREADS_FIRST_UCP, newThreadsFirst);
+        		newThreadsFirstUCP = newThreadsFirst;
 				break;
 			default://make sure to keep this break statement on the last case of this switch
 				break;
 			}
 
 			//update the preferences so this doesn't run again
-    		setIntegerPreference("curr_pref_version", PREFERENCES_VERSION);
+    		setPreference(Keys.CURR_PREF_VERSION, PREFERENCES_VERSION);
     		currPrefVersion = PREFERENCES_VERSION;
 		}
 	}
@@ -357,7 +414,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 			return false;
 		}else{
 			if(new Date(probationTime).compareTo(new Date()) < 0){
-				setLongPreference("probation_time", 0);
+				setPreference(Keys.PROBATION_TIME, 0L);
 				return false;
 			}
 			return true;
@@ -416,7 +473,8 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 
 		Toast.makeText(getContext(), "Settings exported", Toast.LENGTH_LONG).show();
 	}
-	
+
+
 	public void importSettings(File settingsFile){
 		Log.i(TAG, "importing settings from file: "+settingsFile.getName());
 		BufferedReader br;
@@ -433,19 +491,19 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 			HashMap.Entry entry = (HashMap.Entry) setting;
 			String classname = entry.getValue().getClass().getSimpleName();
             String key = (String)entry.getKey();
-			if("Boolean".equals(classname)){
-				setBooleanPreference(key, (Boolean)entry.getValue());
-			}else if("String".equals(classname)){
-				setStringPreference(key, (String)entry.getValue());
-			}else if("Float".equals(classname)) {
-				setFloatPreference(key, (Float) entry.getValue());
-			}else if("ArrayList".equals(classname)){
-				setStringSetPreference(key, new HashSet<String>((ArrayList<String>)entry.getValue()));
-			}else{
-				if(longKeys.contains(key)){
-					setLongPreference(key, ((Double)entry.getValue()).longValue());
-				}else{
-					setIntegerPreference(key, ((Double)entry.getValue()).intValue());
+			if ("Boolean".equals(classname)){
+				mPrefs.edit().putBoolean(key, (Boolean) entry.getValue()).apply();
+			} else if ("String".equals(classname)){
+				mPrefs.edit().putString(key, (String) entry.getValue()).apply();
+			} else if ("Float".equals(classname)) {
+				mPrefs.edit().putFloat(key, (Float) entry.getValue()).apply();
+			} else if ("ArrayList".equals(classname)) {
+				mPrefs.edit().putStringSet(key, new HashSet<>((ArrayList<String>) entry.getValue())).apply();
+			} else {
+				if (longKeys.contains(key)) {
+					mPrefs.edit().putLong(key, ((Double)entry.getValue()).longValue()).apply();
+				} else {
+					mPrefs.edit().putInt(key, ((Double)entry.getValue()).intValue()).apply();
 				}
 			}
 		}
@@ -461,14 +519,14 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
 	public void markUser(String username){
 		Set<String> newMarkedUsers = new HashSet<String>(markedUsers);
 		newMarkedUsers.add(username);
-		setStringSetPreference("marked_users", newMarkedUsers);
+		setPreference(Keys.MARKED_USERS, newMarkedUsers);
 		markedUsers = newMarkedUsers;
 	}
 	
 	public void unmarkUser(String username){
 		Set<String> newMarkedUsers = new HashSet<String>(markedUsers);
 		newMarkedUsers.remove(username);
-		setStringSetPreference("marked_users", newMarkedUsers);
+		setPreference(Keys.MARKED_USERS, newMarkedUsers);
 		markedUsers = newMarkedUsers;
 	}
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
@@ -1,0 +1,195 @@
+package com.ferg.awfulapp.preferences;
+
+import android.support.annotation.IntDef;
+
+import com.ferg.awfulapp.R;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Created by baka kaba on 24/03/2016.
+ *
+ * <p>This class holds constants for preference keys that the app can get and set,
+ * grouped by type, to enforce consistency and type checking.</p>
+ *
+ * <p>The actual key values are stored as string resources, so that the settings XML files can
+ * reference them too. Any code that needs to set a preference should call the relevant
+ * setPreference() method (e.g. {@link AwfulPreferences#setPreference(int, boolean)},
+ * passing a key constant from here.</p>
+ */
+public abstract class Keys {
+
+
+    // strings
+    @IntDef({
+            USERNAME,
+            USER_TITLE,
+            THEME,
+            LAYOUT,
+            IMGUR_THUMBNAILS,
+            PREFERRED_FONT,
+            IGNORE_FORMKEY,
+            ORIENTATION,
+            PAGE_LAYOUT,
+            TRANSFORMER
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface StringPreference{}
+
+
+    // string sets
+    @IntDef({
+            MARKED_USERS
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface StringSetPreference{}
+
+
+    // ints
+    @IntDef({
+            POST_FONT_SIZE_DIP,
+            POST_FIXED_FONT_SIZE_DIP,
+            POST_PER_PAGE,
+            CURR_PREF_VERSION,
+            ALERT_ID_SHOWN,
+            USER_ID,
+            LAST_VERSION_SEEN
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface IntPreference{}
+
+
+    // floats
+    @IntDef({
+            P2R_DISTANCE
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface FloatPreference{}
+
+    // longs
+    @IntDef({
+            PROBATION_TIME
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface LongPreference{}
+
+    // bools
+    @IntDef({
+            HAS_PLATINUM,
+            HAS_ARCHIVES,
+            HAS_NO_ADS,
+            IMAGES_ENABLED,
+            NO_3G_IMAGES,
+            AVATARS_ENABLED,
+            HIDE_OLD_IMAGES,
+            SHOW_SMILIES,
+            ALTERNATE_BACKGROUND,
+            HIGHLIGHT_USER_QUOTE,
+            HIGHLIGHT_USERNAME,
+            HIGHLIGHT_SELF,
+            HIGHLIGHT_OP,
+            INLINE_YOUTUBE,
+            INLINE_TWEETS,
+            INLINE_VINES,
+            INLINE_WEBM,
+            AUTOSTART_WEBM,
+            ENABLE_HARDWARE_ACCELERATION,
+            WRAP_THREAD_TITLES,
+            SHOW_ALL_SPOILERS,
+            THREAD_INFO_RATING,
+            THREAD_INFO_TAG,
+            NEW_THREADS_FIRST_UCP,
+            NEW_THREADS_FIRST_FORUM,
+            UPPER_NEXT_ARROW,
+            SEND_USERNAME_IN_REPORT,
+            DISABLE_GIFS,
+            HIDE_OLD_POSTS,
+            ALWAYS_OPEN_URLS,
+            LOCK_SCROLLING,
+            DISABLE_TIMGS,
+            DISABLE_PULL_NEXT,
+            VOLUME_SCROLL,
+            FORCE_FORUM_THEMES,
+            NO_FAB,
+            SHOW_IGNORE_WARNING,
+            COLORED_BOOKMARKS,
+            HIDE_SIGNATURES,
+            AMBER_DEFAULT_POS,
+            HIDE_IGNORED_POSTS,
+            IMMERSION_MODE
+    })
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface BooleanPreference{}
+
+
+    public static final int USERNAME = R.string.pref_key_username;
+    public static final int USER_TITLE = R.string.pref_key_user_title;
+    public static final int THEME = R.string.pref_key_theme;
+    public static final int LAYOUT = R.string.pref_key_layout;
+    public static final int IMGUR_THUMBNAILS = R.string.pref_key_imgur_thumbnails;
+    public static final int PREFERRED_FONT = R.string.pref_key_preferred_font;
+    public static final int IGNORE_FORMKEY = R.string.pref_key_ignore_formkey;
+    public static final int ORIENTATION = R.string.pref_key_orientation;
+    public static final int PAGE_LAYOUT = R.string.pref_key_page_layout;
+    public static final int TRANSFORMER = R.string.pref_key_transformer;
+
+    public static final int POST_FONT_SIZE_DIP = R.string.pref_key_post_font_size_dip;
+    public static final int POST_FIXED_FONT_SIZE_DIP = R.string.pref_key_post_fixed_font_size_dip;
+    public static final int POST_PER_PAGE = R.string.pref_key_post_per_page;
+    public static final int CURR_PREF_VERSION = R.string.pref_key_curr_pref_version;
+    public static final int ALERT_ID_SHOWN = R.string.pref_key_alert_id_shown;
+    public static final int USER_ID = R.string.pref_key_user_id;
+    public static final int LAST_VERSION_SEEN = R.string.pref_key_last_version_seen;
+
+    public static final int PROBATION_TIME = R.string.pref_key_probation_time;
+
+    public static final int P2R_DISTANCE = R.string.pref_key_pull_to_refresh_distance;
+
+    public static final int HAS_PLATINUM = R.string.pref_key_has_platinum;
+    public static final int HAS_ARCHIVES = R.string.pref_key_has_archives;
+    public static final int HAS_NO_ADS = R.string.pref_key_has_no_ads;
+    public static final int IMAGES_ENABLED = R.string.pref_key_images_enabled;
+    public static final int NO_3G_IMAGES = R.string.pref_key_no_3g_images;
+    public static final int AVATARS_ENABLED = R.string.pref_key_avatars_enabled;
+    public static final int HIDE_OLD_IMAGES = R.string.pref_key_hide_old_images;
+    public static final int SHOW_SMILIES = R.string.pref_key_show_smilies;
+    public static final int ALTERNATE_BACKGROUND = R.string.pref_key_alternate_background;
+    public static final int HIGHLIGHT_USER_QUOTE = R.string.pref_key_highlight_user_quote;
+    public static final int HIGHLIGHT_USERNAME = R.string.pref_key_highlight_username;
+    public static final int HIGHLIGHT_SELF = R.string.pref_key_highlight_self;
+    public static final int HIGHLIGHT_OP = R.string.pref_key_highlight_op;
+    public static final int INLINE_YOUTUBE = R.string.pref_key_inline_youtube;
+    public static final int INLINE_TWEETS = R.string.pref_key_inline_tweets;
+    public static final int INLINE_VINES = R.string.pref_key_inline_vines;
+    public static final int INLINE_WEBM = R.string.pref_key_inline_webm;
+    public static final int AUTOSTART_WEBM = R.string.pref_key_autostart_webm;
+    public static final int ENABLE_HARDWARE_ACCELERATION = R.string.pref_key_enable_hardware_acceleration;
+    public static final int WRAP_THREAD_TITLES = R.string.pref_key_wrap_thread_titles;
+    public static final int SHOW_ALL_SPOILERS = R.string.pref_key_show_all_spoilers;
+    public static final int THREAD_INFO_RATING = R.string.pref_key_thread_info_rating;
+    public static final int THREAD_INFO_TAG = R.string.pref_key_thread_info_tag;
+    public static final int NEW_THREADS_FIRST_UCP = R.string.pref_key_new_threads_first_ucp;
+    public static final int NEW_THREADS_FIRST_FORUM = R.string.pref_key_new_threads_first_forum;
+    public static final int UPPER_NEXT_ARROW = R.string.pref_key_upper_next_arrow;
+    public static final int SEND_USERNAME_IN_REPORT = R.string.pref_key_send_username_in_report;
+    public static final int DISABLE_GIFS = R.string.pref_key_disable_gifs;
+    public static final int HIDE_OLD_POSTS = R.string.pref_key_hide_old_posts;
+    public static final int ALWAYS_OPEN_URLS = R.string.pref_key_always_open_urls;
+    public static final int LOCK_SCROLLING = R.string.pref_key_lock_scrolling;
+    public static final int DISABLE_TIMGS = R.string.pref_key_disable_timgs;
+    public static final int DISABLE_PULL_NEXT = R.string.pref_key_disable_pull_next;
+    public static final int VOLUME_SCROLL = R.string.pref_key_volume_scroll;
+    public static final int FORCE_FORUM_THEMES = R.string.pref_key_force_forum_themes;
+    public static final int NO_FAB = R.string.pref_key_no_fab;
+    public static final int SHOW_IGNORE_WARNING = R.string.pref_key_show_ignore_warning;
+    public static final int COLORED_BOOKMARKS = R.string.pref_key_colored_bookmarks;
+    public static final int HIDE_SIGNATURES = R.string.pref_key_hide_signatures;
+    public static final int AMBER_DEFAULT_POS = R.string.pref_key_amber_default_pos;
+    public static final int HIDE_IGNORED_POSTS = R.string.pref_key_hide_ignored_posts;
+    public static final int IMMERSION_MODE = R.string.pref_key_immersion_mode;
+
+    public static final int MARKED_USERS = R.string.pref_key_marked_users;
+
+
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/AccountSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/AccountSettings.java
@@ -20,21 +20,21 @@ public class AccountSettings extends SettingsFragment {
 
     {
         SETTINGS_XML_RES_ID = R.xml.accountsettings;
-        prefClickListeners.put(new FeaturesListener(), new String[] {
-                "account_features"
+        prefClickListeners.put(new FeaturesListener(), new int[] {
+                R.string.pref_key_account_features_menu_item
         });
     }
 
     @Override
     protected void onSetSummaries() {
-        findPreference("username").setSummary(mPrefs.username);
+        findPrefById(R.string.pref_key_username).setSummary(mPrefs.username);
         //Set summary for the 'Refresh account options' option
         String platinum = "Platinum: " + ((mPrefs.hasPlatinum) ? "Yes" : "No");
         String archives = "Archives: " + ((mPrefs.hasArchives) ? "Yes" : "No");
         String noAds    = "No Ads: " + ((mPrefs.hasNoAds) ? "Yes" : "No");
         String separator = " "+" "+" "+" ";
         String summaryText = TextUtils.join(separator, new String[] {platinum, archives, noAds});
-        findPreference("account_features").setSummary(summaryText);
+        findPrefById(R.string.pref_key_account_features_menu_item).setSummary(summaryText);
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ImageSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ImageSettings.java
@@ -9,8 +9,8 @@ public class ImageSettings extends SettingsFragment {
 
     {
         SETTINGS_XML_RES_ID = R.xml.imagesettings;
-        VALUE_SUMMARY_PREF_KEYS = new String[] {
-                "imgur_thumbnails"
+        VALUE_SUMMARY_PREF_KEYS = new int[] {
+                R.string.pref_key_imgur_thumbnails
         };
     }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/MiscSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/MiscSettings.java
@@ -11,6 +11,7 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 
 import com.ferg.awfulapp.R;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.util.AwfulUtils;
 
 /**
@@ -20,17 +21,17 @@ public class MiscSettings extends SettingsFragment {
 
     {
         SETTINGS_XML_RES_ID = R.xml.miscsettings;
-        VALUE_SUMMARY_PREF_KEYS = new String[] {
-                "orientation"
+        VALUE_SUMMARY_PREF_KEYS = new int[] {
+                R.string.pref_key_orientation
         };
-        VERSION_DEPENDENT_SUMMARY_PREF_KEYS = new String[] {
-                "disable_gifs2",
-                "enable_hardware_acceleration",
-                "immersion_mode",
-                "transformer"
+        VERSION_DEPENDENT_SUMMARY_PREF_KEYS = new int[] {
+                R.string.pref_key_disable_gifs,
+                R.string.pref_key_enable_hardware_acceleration,
+                R.string.pref_key_immersion_mode,
+                R.string.pref_key_transformer
         };
-        prefClickListeners.put(new P2RDistanceListener(), new String[] {
-                "pull_to_refresh_distance"
+        prefClickListeners.put(new P2RDistanceListener(), new int[] {
+                R.string.pref_key_pull_to_refresh_distance
         });
     }
 
@@ -38,22 +39,17 @@ public class MiscSettings extends SettingsFragment {
     @Override
     protected void initialiseSettings() {
         super.initialiseSettings();
-        SwitchPreference pref = (SwitchPreference) findPreference("enable_hardware_acceleration");
-        if (pref != null) {
-            pref.setEnabled(true);
-            // Not for you
-            if (!AwfulUtils.isJellybean()) pref.setChecked(false);
-        }
-        pref = (SwitchPreference) findPreference("disable_gifs2");
-        if (pref != null) {
-            pref.setEnabled(true);
-        }
+        Preference pref = findPrefById(R.string.pref_key_enable_hardware_acceleration);
+        pref.setEnabled(true);
+        // Not for you
+        if (!AwfulUtils.isJellybean()) ((SwitchPreference) pref).setChecked(false);
 
-        findPreference("immersion_mode").setEnabled(AwfulUtils.isKitKat());
+        findPrefById(R.string.pref_key_disable_gifs).setEnabled(true);
+        findPrefById(R.string.pref_key_immersion_mode).setEnabled(AwfulUtils.isKitKat());
         boolean tab = AwfulUtils.isTablet(getActivity(), true);
         boolean jellybeanMr1 = AwfulUtils.isAtLeast(Build.VERSION_CODES.JELLY_BEAN_MR1);
-        findPreference("page_layout").setEnabled(tab);
-        findPreference("transformer").setEnabled(jellybeanMr1&&!tab);
+        findPrefById(R.string.pref_key_page_layout).setEnabled(tab);
+        findPrefById(R.string.pref_key_transformer).setEnabled(jellybeanMr1 && !tab);
 //        if(!tab){
 //            findPreference("page_layout").setSummary(getString(R.string.page_layout_summary_disabled));
 //        }
@@ -66,14 +62,15 @@ public class MiscSettings extends SettingsFragment {
         String summary = getString(R.string.pull_to_refresh_distance_summary);
         summary += "\n" + String.valueOf(Math.round(mPrefs.p2rDistance * 100.f)) + "%";
         summary += " of the screen's height";
-        findPreference("pull_to_refresh_distance").setSummary(summary);
+        findPrefById(R.string.pref_key_pull_to_refresh_distance).setSummary(summary);
 
         // Thread layout option
-        ListPreference p = (ListPreference) findPreference("page_layout");
+        ListPreference p = (ListPreference) findPrefById(R.string.pref_key_page_layout);
         if (p.isEnabled()) {
             p.setSummary(p.getEntry());
+        } else {
+            p.setSummary(getString(R.string.page_layout_summary_disabled));
         }
-        else p.setSummary(getString(R.string.page_layout_summary_disabled));
     }
 
 
@@ -104,7 +101,7 @@ public class MiscSettings extends SettingsFragment {
                 @Override
                 public void onStopTrackingTouch(SeekBar seekBar) {
                     float distanceFloat = seekBar.getProgress();
-                    mPrefs.setFloatPreference("pull_to_refresh_distance", (distanceFloat/100));
+                    mPrefs.setPreference(Keys.P2R_DISTANCE, (distanceFloat / 100));
                 }
 
                 @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostSettings.java
@@ -1,5 +1,6 @@
 package com.ferg.awfulapp.preferences.fragments;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
@@ -15,6 +16,7 @@ import android.widget.TextView;
 
 import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.preferences.Keys;
 
 /**
  * Created by baka kaba on 04/05/2015.
@@ -23,47 +25,52 @@ public class PostSettings extends SettingsFragment {
 
     {
         SETTINGS_XML_RES_ID = R.xml.postsettings;
-        VERSION_DEPENDENT_SUMMARY_PREF_KEYS = new String[] {
-                "inline_youtube"
+        VERSION_DEPENDENT_SUMMARY_PREF_KEYS = new int[] {
+                R.string.pref_key_inline_youtube
         };
 
-        SUBMENU_OPENING_KEYS = new String[] {
-                "highlighting"
+        SUBMENU_OPENING_KEYS = new int[] {
+                R.string.pref_key_highlighting_menu_item
         };
 
-        prefClickListeners.put(new FontSizeListener(), new String[] {
-                "default_post_font_size_dip",
-                "default_post_fixed_font_size_dip"
+        prefClickListeners.put(new FontSizeListener(), new int[] {
+                R.string.pref_key_post_font_size_dip,
+                R.string.pref_key_post_fixed_font_size_dip
         });
 
-        prefClickListeners.put(new PostsPerPageListener(), new String[] {
-                "posts_per_page"
+        prefClickListeners.put(new PostsPerPageListener(), new int[] {
+                R.string.pref_key_post_per_page
         });
     }
 
     @Override
     protected void onSetSummaries() {
-        findPreference("default_post_font_size_dip")
+        findPrefById(R.string.pref_key_post_font_size_dip)
                 .setSummary(String.valueOf(mPrefs.postFontSizeDip));
-        findPreference("default_post_fixed_font_size_dip")
+        findPrefById(R.string.pref_key_post_fixed_font_size_dip)
                 .setSummary(String.valueOf(mPrefs.postFixedFontSizeDip));
-        findPreference("posts_per_page")
+        findPrefById(R.string.pref_key_post_per_page)
                 .setSummary(String.valueOf(mPrefs.postPerPage));
     }
 
-    /** Listener for the default post font size options */
+    /**
+     * Listener for the default post font size options
+     */
     private class FontSizeListener implements Preference.OnPreferenceClickListener {
         @Override
         public boolean onPreferenceClick(Preference preference) {
             final String prefKey = preference.getKey();
-            final int minSize = Constants.MINIMUM_FONT_SIZE;
+            final String FONT_SIZE_KEY = getString(R.string.pref_key_post_font_size_dip);
+            final String FIXED_FONT_SIZE_KEY = getString(R.string.pref_key_post_fixed_font_size_dip);
+            final String SIZE_PICKER_FORMAT_STRING = getString(R.string.font_size_picker_format_string);
+            final int    MIN_SIZE = Constants.MINIMUM_FONT_SIZE;
             final Dialog mFontSizeDialog = new Dialog(getActivity());
 
             mFontSizeDialog.setContentView(R.layout.font_size);
-            if (prefKey.equals("default_post_font_size_dip")){
+            if (prefKey.equals(FONT_SIZE_KEY)){
                 mFontSizeDialog.setTitle(getString(R.string.default_font_size_dialog_title));
             }
-            else if (prefKey.equals("default_post_fixed_font_size_dip")) {
+            else if (prefKey.equals(FIXED_FONT_SIZE_KEY)) {
                 mFontSizeDialog.setTitle(getString(R.string.default_fixed_font_size_dialog_title));
             }
             final TextView mFontSizeText = (TextView) mFontSizeDialog.findViewById(R.id.fontSizeText);
@@ -82,7 +89,11 @@ public class PostSettings extends SettingsFragment {
 
                 @Override
                 public void onStopTrackingTouch(SeekBar seekBar) {
-                    mPrefs.setIntegerPreference(prefKey, seekBar.getProgress()+minSize);
+                    if (prefKey.equals(FONT_SIZE_KEY)) {
+                        mPrefs.setPreference(Keys.POST_FONT_SIZE_DIP, seekBar.getProgress() + MIN_SIZE);
+                    } else if (prefKey.equals(FIXED_FONT_SIZE_KEY)) {
+                        mPrefs.setPreference(Keys.POST_FIXED_FONT_SIZE_DIP, seekBar.getProgress() + MIN_SIZE);
+                    }
                 }
 
                 @Override
@@ -91,21 +102,24 @@ public class PostSettings extends SettingsFragment {
 
                 @Override
                 public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                    mFontSizeText.setText((progress+minSize)+ "  Get out");
-                    mFontSizeText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, (progress+minSize));
+                    int selectedSize = progress + MIN_SIZE;
+                    mFontSizeText.setText(String.format(SIZE_PICKER_FORMAT_STRING, selectedSize));
+                    mFontSizeText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, selectedSize);
                 }
             });
-            if (prefKey.equals("default_post_font_size_dip")){
-                bar.setProgress(mPrefs.postFontSizeDip-minSize);
+
+            if (prefKey.equals(FONT_SIZE_KEY)){
+                bar.setProgress(mPrefs.postFontSizeDip - MIN_SIZE);
             }
-            else if (prefKey.equals("default_post_fixed_font_size_dip")) {
-                bar.setProgress(mPrefs.postFixedFontSizeDip-minSize);
+            else if (prefKey.equals(FIXED_FONT_SIZE_KEY)) {
+                bar.setProgress(mPrefs.postFixedFontSizeDip - MIN_SIZE);
                 mFontSizeText.setTypeface(Typeface.MONOSPACE);
             }
             else Log.w(TAG, "Tried to set font size for: " + prefKey + ", not a valid key!");
 
-            mFontSizeText.setText((bar.getProgress()+minSize)+ "  Get out");
-            mFontSizeText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, (bar.getProgress()+minSize));
+            int selectedSize = bar.getProgress() + MIN_SIZE;
+            mFontSizeText.setText(String.format(SIZE_PICKER_FORMAT_STRING, selectedSize));
+            mFontSizeText.setTextSize(TypedValue.COMPLEX_UNIT_DIP, selectedSize);
             mFontSizeDialog.show();
             return true;
         }
@@ -116,6 +130,7 @@ public class PostSettings extends SettingsFragment {
         @Override
         public boolean onPreferenceClick(final Preference preference) {
 
+            @SuppressLint("InflateParams")
             final View pickerView = getActivity().getLayoutInflater().inflate(R.layout.number_picker, null);
             final NumberPicker  picker = (NumberPicker) pickerView.findViewById(R.id.pagePicker);
             final Button        minButton = (Button) pickerView.findViewById(R.id.min);
@@ -126,8 +141,8 @@ public class PostSettings extends SettingsFragment {
             picker.setMinValue(minPages);
             picker.setMaxValue(maxPages);
             picker.setValue(mPrefs.postPerPage);
-            minButton.setText(Integer.toString(minPages));
-            maxButton.setText(Integer.toString(maxPages));
+            minButton.setText(String.format("%d", minPages));
+            maxButton.setText(String.format("%d", maxPages));
 
             View.OnClickListener buttonsListener = new View.OnClickListener() {
                 @Override
@@ -143,15 +158,18 @@ public class PostSettings extends SettingsFragment {
             maxButton.setOnClickListener(buttonsListener);
 
             new AlertDialog.Builder(getActivity())
-                    .setTitle("Posts per page")
+                    .setTitle(R.string.setting_posts_per_page)
                     .setView(pickerView)
-                    .setPositiveButton("OK",
+                    .setPositiveButton(R.string.alert_ok,
                             new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface aDialog, int aWhich) {
-                                    mPrefs.setIntegerPreference(preference.getKey(), picker.getValue());
+                                    String key = preference.getKey();
+                                    if (key.equals(getString(R.string.pref_key_post_per_page))) {
+                                        mPrefs.setPreference(Keys.POST_PER_PAGE, picker.getValue());
+                                    }
                                 }
                             })
-                    .setNegativeButton("Cancel", null)
+                    .setNegativeButton(R.string.cancel, null)
                     .show();
             return true;
         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/RootSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/RootSettings.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.preference.Preference;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.widget.Toast;
 
@@ -26,29 +27,30 @@ public class RootSettings extends SettingsFragment {
     {
         SETTINGS_XML_RES_ID = R.xml.rootsettings;
 
-        SUBMENU_OPENING_KEYS = new String[] {
-                "theme",
-                "thread",
-                "posts",
-                "images",
-                "misc",
-                "account"
+        SUBMENU_OPENING_KEYS = new int[] {
+                R.string.pref_key_theme_menu_item,
+                R.string.pref_key_thread_menu_item,
+                R.string.pref_key_posts_menu_item,
+                R.string.pref_key_images_menu_item,
+                R.string.pref_key_misc_menu_item,
+                R.string.pref_key_account_menu_item
         };
 
-        prefClickListeners.put(new AboutListener(), new String[] {
-                "about"
+        prefClickListeners.put(new AboutListener(), new int[] {
+                R.string.pref_key_about_menu_item
         });
-        prefClickListeners.put(new ChangelogListener(), new String[] {
-                "changelog"
+        prefClickListeners.put(new ThreadListener(), new int[]{
+                R.string.pref_key_open_thread_menu_item
         });
-        prefClickListeners.put(new ThreadListener(), new String[] {
-                "open_thread"
+        // TODO: fix
+        prefClickListeners.put(new ChangelogListener(), new int[] {
+                R.string.pref_key_changelog_menu_item
         });
-        prefClickListeners.put(new ExportListener(), new String[]{
-                "export_settings"
+        prefClickListeners.put(new ExportListener(), new int[]{
+                R.string.pref_key_export_settings_menu_item
         });
-        prefClickListeners.put(new ImportListener(), new String[] {
-                "import_settings"
+        prefClickListeners.put(new ImportListener(), new int[] {
+                R.string.pref_key_import_settings_menu_item
         });
     }
 
@@ -120,7 +122,7 @@ public class RootSettings extends SettingsFragment {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         switch (requestCode) {
             case Constants.AWFUL_PERMISSION_WRITE_EXTERNAL_STORAGE: {
                 // If request is cancelled, the result arrays are empty.

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThemeSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThemeSettings.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.content.pm.PackageManager;
 import android.os.Environment;
 import android.preference.ListPreference;
+import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
@@ -28,8 +29,10 @@ public class ThemeSettings extends SettingsFragment {
 
     {
         SETTINGS_XML_RES_ID = R.xml.themesettings;
-        VALUE_SUMMARY_PREF_KEYS = new String[] {
-                "theme", "layouts", "preferred_font"
+        VALUE_SUMMARY_PREF_KEYS = new int[] {
+                R.string.pref_key_theme,
+                R.string.pref_key_layout,
+                R.string.pref_key_preferred_font
         };
     }
 
@@ -50,7 +53,7 @@ public class ThemeSettings extends SettingsFragment {
             loadExternalOptions();
         }
 
-        ListPreference f = (ListPreference) findPreference("preferred_font");
+        ListPreference f = (ListPreference) findPrefById(R.string.pref_key_preferred_font);
         String[] fontList = ((AwfulApplication) getActivity().getApplication()).getFontList();
         String[] fontNames = new String[fontList.length];
         String thisFontName;
@@ -69,8 +72,8 @@ public class ThemeSettings extends SettingsFragment {
     }
 
     private void loadExternalOptions(){
-        ListPreference themePref = (ListPreference) findPreference("theme");
-        ListPreference layoutPref = (ListPreference) findPreference("layouts");
+        ListPreference themePref = (ListPreference) findPrefById(R.string.pref_key_theme);
+        ListPreference layoutPref = (ListPreference) findPrefById(R.string.pref_key_layout);
         File[] SDcard = Environment.getExternalStorageDirectory().listFiles();
         if (SDcard != null) {
             for (File folder: SDcard){
@@ -85,7 +88,7 @@ public class ThemeSettings extends SettingsFragment {
                     layouts.addAll(Arrays.asList(layoutPref.getEntries()));
                     layoutValues.addAll(Arrays.asList(layoutPref.getEntryValues()));
                     for(File folderFile: files){
-                        if(folderFile.canRead() && folderFile.getName() != null){
+                        if(folderFile.canRead()){
                             String[] fileName = folderFile.getName().split("\\.");
                             if("css".equals(fileName[fileName.length-1])){
                                 if(StringUtils.countMatches(folderFile.getName(), ".")>1){
@@ -115,7 +118,7 @@ public class ThemeSettings extends SettingsFragment {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         switch (requestCode) {
             case Constants.AWFUL_PERMISSION_READ_EXTERNAL_STORAGE: {
                 // If request is cancelled, the result arrays are empty.

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/FeatureRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/FeatureRequest.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
@@ -38,17 +39,17 @@ public class FeatureRequest extends AwfulRequest<Void> {
                 archives = feature_dts.get(1).hasClass("enabled");
                 noads = feature_dts.get(2).hasClass("enabled");
                 try {
-                    getPreferences().setBooleanPreference("has_platinum", premium);
+                    getPreferences().setPreference(Keys.HAS_PLATINUM, premium);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
                 try {
-                    getPreferences().setBooleanPreference("has_archives", archives);
+                    getPreferences().setPreference(Keys.HAS_ARCHIVES, archives);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
                 try {
-                    getPreferences().setBooleanPreference("has_no_ads", noads);
+                    getPreferences().setPreference(Keys.HAS_NO_ADS, noads);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/IndexIconRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/IndexIconRequest.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.thread.AwfulForum;
 import com.ferg.awfulapp.util.AwfulError;
 
@@ -54,7 +55,7 @@ public class IndexIconRequest extends AwfulRequest<Void> {
                     }
                     Log.v("IndexRequest", "text: " + name + " - " + unreadCount);
                     if (name != null && name.length() > 0) {
-                        getPreferences().setStringPreference("username", name);
+                        getPreferences().setPreference(Keys.USERNAME, name);
                     }
                 }
             }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/LoginRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/LoginRequest.java
@@ -1,15 +1,12 @@
 package com.ferg.awfulapp.task;
 
-import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
-import android.widget.Toast;
 
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
-import com.ferg.awfulapp.thread.AwfulMessage;
-import com.ferg.awfulapp.thread.AwfulPost;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
@@ -37,7 +34,7 @@ public class LoginRequest extends AwfulRequest<Boolean> {
         Boolean result = NetworkUtils.saveLoginCookies(getContext());
         if(result){
             AwfulPreferences prefs = AwfulPreferences.getInstance(getContext());
-            prefs.setStringPreference("username", username);
+            prefs.setPreference(Keys.USERNAME, username);
         }
         return result;
     }
@@ -48,7 +45,7 @@ public class LoginRequest extends AwfulRequest<Boolean> {
             Boolean result = NetworkUtils.saveLoginCookies(getContext());
             if(result){
                 AwfulPreferences prefs = AwfulPreferences.getInstance(getContext());
-                prefs.setStringPreference("username", username);
+                prefs.setPreference(Keys.USERNAME, username);
             }
             return result;
         }else{

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ProfileRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ProfileRequest.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.text.TextUtils;
 
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
@@ -37,7 +38,7 @@ public class ProfileRequest extends AwfulRequest<Void> {
         Element formkey = doc.getElementsByAttributeValue("name", "formkey").first();
         if (formkey != null) {
             try {
-                getPreferences().setStringPreference("ignore_formkey", formkey.val());
+                getPreferences().setPreference(Keys.IGNORE_FORMKEY, formkey.val());
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -58,7 +59,7 @@ public class ProfileRequest extends AwfulRequest<Void> {
                 }
             }
             try {
-                getPreferences().setStringPreference("user_title", userTitle);
+                getPreferences().setPreference(Keys.USER_TITLE, userTitle);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
@@ -12,6 +12,7 @@ import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.preferences.Keys;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -140,7 +141,7 @@ public class AwfulError extends VolleyError{
             try {
                 Element userlink = probation.getElementsByTag("a").first();
                 int userId = Integer.parseInt(userlink.attr("href").substring(userlink.attr("href").lastIndexOf("=")+1));
-                prefs.setIntegerPreference("user_id", userId);
+                prefs.setPreference(Keys.USER_ID, userId);
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -160,7 +161,7 @@ public class AwfulError extends VolleyError{
                 long probTimestamp = probDate.getTime();
                 //FUCK PRE ICS
                 try {
-                    prefs.setLongPreference("probation_time", probTimestamp);
+                    prefs.setPreference(Keys.PROBATION_TIME, probTimestamp);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -168,7 +169,7 @@ public class AwfulError extends VolleyError{
         }else{
             if(AwfulPreferences.getInstance().probationTime > 0) {
                 try {
-                    prefs.setLongPreference("probation_time", 0);
+                    prefs.setPreference(Keys.PROBATION_TIME, 0);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/Awful.apk/src/main/res/values/preference_keys.xml
+++ b/Awful.apk/src/main/res/values/preference_keys.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--keys for preferences that store a value in the SharedPreferences -->
+    <string name="pref_key_username">username</string>
+    <string name="pref_key_user_title">user_title</string>
+    <string name="pref_key_theme">theme</string>
+    <string name="pref_key_layout">layouts</string>
+    <string name="pref_key_imgur_thumbnails">imgur_thumbnails</string>
+    <string name="pref_key_preferred_font">preferred_font</string>
+    <string name="pref_key_ignore_formkey">ignore_formkey</string>
+    <string name="pref_key_orientation">orientation</string>
+    <string name="pref_key_page_layout">page_layout</string>
+    <string name="pref_key_transformer">transformer</string>
+    <string name="pref_key_post_font_size_dip">default_post_font_size_dip</string>
+    <string name="pref_key_post_fixed_font_size_dip">default_post_fixed_font_size_dip</string>
+    <string name="pref_key_post_per_page">posts_per_page</string>
+    <string name="pref_key_curr_pref_version">curr_pref_version</string>
+    <string name="pref_key_alert_id_shown">alert_id_shown</string>
+    <string name="pref_key_last_version_seen">last_version_seen</string>
+    <string name="pref_key_user_id">user_id</string>
+    <string name="pref_key_probation_time">probation_time</string>
+    <string name="pref_key_pull_to_refresh_distance">pull_to_refresh_distance</string>
+    <string name="pref_key_has_platinum">has_platinum</string>
+    <string name="pref_key_has_archives">has_archives</string>
+    <string name="pref_key_has_no_ads">has_no_ads</string>
+    <string name="pref_key_images_enabled">images_enabled</string>
+    <string name="pref_key_no_3g_images">no_3g_images</string>
+    <string name="pref_key_avatars_enabled">avatars_enabled</string>
+    <string name="pref_key_hide_old_images">hide_read_images</string>
+    <string name="pref_key_show_smilies">show_smilies</string>
+    <string name="pref_key_alternate_background">alternate_backgrounds</string>
+    <string name="pref_key_highlight_user_quote">user_quotes</string>
+    <string name="pref_key_highlight_username">user_highlight</string>
+    <string name="pref_key_highlight_self">self_highlight</string>
+    <string name="pref_key_highlight_op">op_highlight</string>
+    <string name="pref_key_inline_youtube">inline_youtube</string>
+    <string name="pref_key_inline_tweets">inline_tweets</string>
+    <string name="pref_key_inline_vines">inline_vines</string>
+    <string name="pref_key_inline_webm">inline_webm</string>
+    <string name="pref_key_autostart_webm">autostart_webm</string>
+    <string name="pref_key_enable_hardware_acceleration">enable_hardware_acceleration</string>
+    <string name="pref_key_wrap_thread_titles">wrap_thread_titles</string>
+    <string name="pref_key_show_all_spoilers">show_all_spoilers</string>
+    <string name="pref_key_thread_info_rating">threadinfo_rating</string>
+    <string name="pref_key_thread_info_tag">threadinfo_tag</string>
+    <string name="pref_key_new_threads_first_ucp">new_threads_first_ucp</string>
+    <string name="pref_key_new_threads_first_forum">new_threads_first_forum</string>
+    <string name="pref_key_upper_next_arrow">upper_next_arrow</string>
+    <string name="pref_key_send_username_in_report">send_username_in_report</string>
+    <string name="pref_key_disable_gifs">disable_gifs2</string>
+    <string name="pref_key_hide_old_posts">hide_old_posts</string>
+    <string name="pref_key_always_open_urls">always_open_urls</string>
+    <string name="pref_key_lock_scrolling">lock_scrolling</string>
+    <string name="pref_key_disable_timgs">disable_timgs</string>
+    <string name="pref_key_disable_pull_next">disable_pull_next</string>
+    <string name="pref_key_volume_scroll">volume_scroll</string>
+    <string name="pref_key_force_forum_themes">force_forum_themes</string>
+    <string name="pref_key_no_fab">no_fab</string>
+    <string name="pref_key_show_ignore_warning">show_ignore_warning</string>
+    <string name="pref_key_colored_bookmarks">color_bookmarks</string>
+    <string name="pref_key_hide_signatures">hide_signatures</string>
+    <string name="pref_key_amber_default_pos">amber_default_pos</string>
+    <string name="pref_key_hide_ignored_posts">hide_ignored_posts</string>
+    <string name="pref_key_immersion_mode">immersion_mode</string>
+    <string name="pref_key_marked_users">marked_users</string>
+
+
+    <!--keys for preferences that don't store a value (i.e. settings menu items that act as buttons)-->
+    <string name="pref_key_account_features_menu_item">account features</string>
+    <string name="pref_key_about_menu_item">about</string>
+    <string name="pref_key_changelog_menu_item">changelog</string>
+    <string name="pref_key_open_thread_menu_item">open_thread</string>
+    <string name="pref_key_account_menu_item">account</string>
+    <string name="pref_key_theme_menu_item">theme</string>
+    <string name="pref_key_thread_menu_item">thread</string>
+    <string name="pref_key_posts_menu_item">posts</string>
+    <string name="pref_key_images_menu_item">images</string>
+    <string name="pref_key_misc_menu_item">misc</string>
+    <string name="pref_key_export_settings_menu_item">export_settings</string>
+    <string name="pref_key_import_settings_menu_item">import_settings</string>
+    <string name="pref_key_highlighting_menu_item">highlighting</string>
+</resources>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -206,6 +206,7 @@
     <string name="default_font_size_dialog_title">Set default font size</string>
     <string name="default_post_fixed_font_size">Default fixed-width font size</string>
     <string name="default_fixed_font_size_dialog_title">Set fixed-width font size</string>
+    <string name="font_size_picker_format_string">%d Get out</string>
     <string name="setting_posts_per_page">Posts per page</string>
     <string name="hide_old_posts">Hide old posts</string>
     <string name="hide_old_posts_summary">Hide previously read posts</string>

--- a/Awful.apk/src/main/res/xml/accountsettings.xml
+++ b/Awful.apk/src/main/res/xml/accountsettings.xml
@@ -2,17 +2,17 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <EditTextPreference
-        android:key="username"
+        android:key="@string/pref_key_username"
         android:title="@string/username_pref"
         android:defaultValue="Username"
         />
     <Preference
-        android:key="account_features"
+        android:key="@string/pref_key_account_features_menu_item"
         android:title="@string/features"
         android:summary="@string/features_summary"
         />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
-        android:key="send_username_in_report"
+        android:key="@string/pref_key_send_username_in_report"
         android:title="@string/send_username_in_report"
         android:summary="@string/send_username_in_report_summary"
         android:defaultValue="true"

--- a/Awful.apk/src/main/res/xml/imagesettings.xml
+++ b/Awful.apk/src/main/res/xml/imagesettings.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="images_enabled"
+            android:key="@string/pref_key_images_enabled"
             android:title="@string/load_images"
             android:summary="@string/load_images_summary"
             android:defaultValue="true"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="no_3g_images"
+            android:key="@string/pref_key_no_3g_images"
             android:title="@string/no_3g_images"
             android:summary="@string/no_3g_images_summary"
             android:defaultValue="false"
-            android:dependency="images_enabled"
+            android:dependency="@string/pref_key_images_enabled"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="hide_read_images"
+            android:key="@string/pref_key_hide_old_images"
             android:title="@string/hide_read_images"
             android:summary="@string/hide_read_images_summary"
             android:defaultValue="false"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="avatars_enabled"
+            android:key="@string/pref_key_avatars_enabled"
             android:title="@string/load_avatars"
             android:defaultValue="true"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="show_smilies"
+            android:key="@string/pref_key_show_smilies"
             android:title="@string/show_smilies"
             android:summary="@string/show_smilies_summary"
             android:defaultValue="true"
             />
         <ListPreference
-            android:key="imgur_thumbnails"
+            android:key="@string/pref_key_imgur_thumbnails"
             android:title="@string/imgur_thumbnails"
             android:entries="@array/imgur_thumbnails"
             android:entryValues="@array/imgur_thumbnails_values"
             android:defaultValue="d"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="disable_timgs"
+            android:key="@string/pref_key_disable_timgs"
             android:title="@string/disable_timgs"
             android:summary="@string/disable_timgs_summary"
             android:defaultValue="false"

--- a/Awful.apk/src/main/res/xml/miscsettings.xml
+++ b/Awful.apk/src/main/res/xml/miscsettings.xml
@@ -3,14 +3,14 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
         <PreferenceCategory android:title="@string/misc_category_performance">
             <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="enable_hardware_acceleration"
+                android:key="@string/pref_key_enable_hardware_acceleration"
                 android:title="@string/enable_hardware_acceleration"
                 android:summary="@string/enable_hardware_acceleration_summary"
                 android:defaultValue="true"
                 android:enabled="false"
                 />
             <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="disable_gifs2"
+                android:key="@string/pref_key_disable_gifs"
                 android:title="@string/disable_gifs"
                 android:summary="@string/disable_gifs_summary"
                 android:defaultValue="true"
@@ -20,7 +20,7 @@
 
         <PreferenceCategory android:title="@string/misc_category_display">
             <ListPreference
-                android:key="page_layout"
+                android:key="@string/pref_key_page_layout"
                 android:title="@string/page_layout"
                 android:entries="@array/page_layouts"
                 android:entryValues="@array/page_layout_values"
@@ -28,27 +28,27 @@
                 android:enabled="false"
                 />
             <ListPreference
-                android:key="orientation"
+                android:key="@string/pref_key_orientation"
                 android:title="@string/orientation"
                 android:entries="@array/orientations"
                 android:entryValues="@array/orientation_values"
                 android:defaultValue="default"
                 />
             <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="no_fab"
+                android:key="@string/pref_key_no_fab"
                 android:title="@string/no_fab"
                 android:summary="@string/no_fab_summary"
                 android:defaultValue="false"
                 />
             <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="immersion_mode"
+                android:key="@string/pref_key_immersion_mode"
                 android:title="@string/immersion_mode"
                 android:summary="@string/immersion_mode_summary"
                 android:defaultValue="false"
                 android:enabled="false"
                 />
             <ListPreference
-                android:key="transformer"
+                android:key="@string/pref_key_transformer"
                 android:title="@string/transformer"
                 android:summary="%s"
                 android:entries="@array/transformer"
@@ -59,25 +59,25 @@
 
         <PreferenceCategory android:title="@string/misc_category_navigation">
             <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="disable_pull_next"
+                android:key="@string/pref_key_disable_pull_next"
                 android:title="@string/disable_pull_next"
                 android:summary="@string/disable_pull_next_summary"
                 android:defaultValue="false"
                 />
             <Preference
-                android:key="pull_to_refresh_distance"
+                android:key="@string/pref_key_pull_to_refresh_distance"
                 android:title="@string/pull_to_refresh_distance"
                 android:summary="@string/pull_to_refresh_distance_summary"
                 android:defaultValue="0.5"
                 />
             <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="lock_scrolling"
+                android:key="@string/pref_key_lock_scrolling"
                 android:title="@string/lock_scrolling"
                 android:summary="@string/lock_scrolling_summary"
                 android:defaultValue="false"
                 />
             <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="volume_scroll"
+                android:key="@string/pref_key_volume_scroll"
                 android:title="@string/volume_scroll"
                 android:summary="@string/volume_scroll_summary"
                 android:defaultValue="false"

--- a/Awful.apk/src/main/res/xml/post_highlighting_settings.xml
+++ b/Awful.apk/src/main/res/xml/post_highlighting_settings.xml
@@ -2,25 +2,25 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
-        android:key="user_highlight"
+        android:key="@string/pref_key_highlight_username"
         android:title="@string/user_highlight"
         android:summary="@string/user_highlight_summary"
         android:defaultValue="true"
         />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
-        android:key="user_quotes"
+        android:key="@string/pref_key_highlight_user_quote"
         android:title="@string/user_quote"
         android:summary="@string/user_quote_summary"
         android:defaultValue="true"
         />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
-        android:key="self_highlight"
+        android:key="@string/pref_key_highlight_self"
         android:title="@string/self_highlight"
         android:summary="@string/self_highlight_summary"
         android:defaultValue="true"
         />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
-        android:key="op_highlight"
+        android:key="@string/pref_key_highlight_op"
         android:title="@string/op_highlight"
         android:summary="@string/op_highlight_summary"
         android:defaultValue="true"

--- a/Awful.apk/src/main/res/xml/postsettings.xml
+++ b/Awful.apk/src/main/res/xml/postsettings.xml
@@ -3,72 +3,72 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <Preference
         android:defaultValue="16"
-        android:key="default_post_font_size_dip"
+        android:key="@string/pref_key_post_font_size_dip"
         android:title="@string/default_post_font_size" />
     <Preference
         android:defaultValue="13"
-        android:key="default_post_fixed_font_size_dip"
+        android:key="@string/pref_key_post_fixed_font_size_dip"
         android:title="@string/default_post_fixed_font_size" />
     <Preference
         android:defaultValue="40"
-        android:key="posts_per_page"
+        android:key="@string/pref_key_post_per_page"
         android:title="@string/setting_posts_per_page" />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="true"
-        android:key="hide_old_posts"
+        android:key="@string/pref_key_hide_old_posts"
         android:summary="@string/hide_old_posts_summary"
         android:title="@string/hide_old_posts" />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="false"
-        android:key="hide_ignored_posts"
+        android:key="@string/pref_key_hide_ignored_posts"
         android:summary="@string/hide_ignored_posts_summary"
         android:title="@string/hide_ignored_posts" />
 
     <PreferenceScreen
         android:fragment="com.ferg.awfulapp.preferences.fragments.PostHighlightingSettings"
-        android:key="highlighting"
+        android:key="@string/pref_key_highlighting_menu_item"
         android:title="@string/highlighting_settings_title"/>
 
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="true"
-        android:key="inline_youtube"
+        android:key="@string/pref_key_inline_youtube"
         android:summary="@string/inline_videos_summary"
         android:title="@string/inline_videos" />
 
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
-        android:key="inline_tweets"
+        android:key="@string/pref_key_inline_tweets"
         android:title="@string/inline_tweets"
         android:summary="@string/inline_tweets_summary"
         android:defaultValue="false"
         />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
     android:defaultValue="false"
-    android:key="inline_webm"
+    android:key="@string/pref_key_inline_webm"
     android:summary="@string/inline_webm_summary"
     android:title="@string/inline_webm" />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="true"
-        android:key="autostart_webm"
+        android:key="@string/pref_key_autostart_webm"
         android:summary="@string/autostart_webm_summary"
         android:title="@string/autostart_webm" />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="false"
-        android:key="inline_vines"
+        android:key="@string/pref_key_inline_vines"
         android:summary="@string/inline_vines_summary"
         android:title="@string/inline_vines" />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="false"
-        android:key="show_all_spoilers"
+        android:key="@string/pref_key_show_all_spoilers"
         android:summary="@string/show_spoilers_summary"
         android:title="@string/show_spoilers" />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="false"
-        android:key="hide_signatures"
+        android:key="@string/pref_key_hide_signatures"
         android:summary="@string/hide_signatures_summary"
         android:title="@string/hide_signatures" />
     <com.ferg.awfulapp.preferences.CustomSwitchPreference
         android:defaultValue="false"
-        android:key="always_open_urls"
+        android:key="@string/pref_key_always_open_urls"
         android:summary="@string/always_open_urls_summary"
         android:title="@string/always_open_urls" />
 </PreferenceScreen>

--- a/Awful.apk/src/main/res/xml/rootsettings.xml
+++ b/Awful.apk/src/main/res/xml/rootsettings.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <Preference
-        android:key="about"
+        android:key="@string/pref_key_about_menu_item"
         android:title="@string/about"
         android:summary="@string/about_summary"
         android:persistent="false" />
-    <Preference
-        android:key="changelog"
-        android:title="Changelog"
+    <Preference        
+        android:key="@string/pref_key_changelog_menu_item"
+        android:title="@string/changelog"
         android:summary="@string/changelog_summary"/>
     <Preference
-        android:key="open_thread"
+        android:key="@string/pref_key_open_thread_menu_item"
         android:title="@string/open_thread"
         android:summary="@string/open_thread_summary" />
     <Preference
-        android:key="account"
+        android:key="@string/pref_key_account_menu_item"
         android:fragment="com.ferg.awfulapp.preferences.fragments.AccountSettings"
         android:title="@string/prefs_account" />
 
     <PreferenceCategory
         android:title="@string/settings_divider_customisation">
         <Preference
-            android:key="theme"
+            android:key="@string/pref_key_theme_menu_item"
             android:fragment="com.ferg.awfulapp.preferences.fragments.ThemeSettings"
             android:title="@string/theme_settings" />
         <Preference
-            android:key="thread"
+            android:key="@string/pref_key_thread_menu_item"
             android:fragment="com.ferg.awfulapp.preferences.fragments.ThreadSettings"
             android:title="@string/thread_settings" />
         <Preference
-            android:key="posts"
+            android:key="@string/pref_key_posts_menu_item"
             android:fragment="com.ferg.awfulapp.preferences.fragments.PostSettings"
             android:title="@string/prefs_post_display" />
         <Preference
-            android:key="images"
+            android:key="@string/pref_key_images_menu_item"
             android:fragment="com.ferg.awfulapp.preferences.fragments.ImageSettings"
             android:title="@string/image_settings" />
     </PreferenceCategory>
@@ -41,15 +41,15 @@
     <PreferenceCategory
         android:title="@string/settings_divider_misc">
         <Preference
-            android:key="misc"
+            android:key="@string/pref_key_misc_menu_item"
             android:fragment="com.ferg.awfulapp.preferences.fragments.MiscSettings"
             android:title="@string/prefs_misc" />
         <Preference
-            android:key="export_settings"
+            android:key="@string/pref_key_export_settings_menu_item"
             android:title="@string/export_settings"
             android:summary="@string/export_settings_summary"/>
         <Preference
-            android:key="import_settings"
+            android:key="@string/pref_key_import_settings_menu_item"
             android:title="@string/import_settings"
             android:summary="@string/import_settings_summary"/>
     </PreferenceCategory>

--- a/Awful.apk/src/main/res/xml/themesettings.xml
+++ b/Awful.apk/src/main/res/xml/themesettings.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
         <ListPreference
-            android:key="theme"
+            android:key="@string/pref_key_theme"
             android:title="@string/theme"
             android:entries="@array/theme"
             android:entryValues="@array/schemas_values"
             android:defaultValue="default.css"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="force_forum_themes"
+            android:key="@string/pref_key_force_forum_themes"
             android:title="@string/force_forum_themes"
             android:summary="@string/force_forum_themes_summary"
             android:defaultValue="true"
             />
         <ListPreference
-            android:key="layouts"
+            android:key="@string/pref_key_layout"
             android:title="@string/layouts"
             android:entries="@array/layouts"
             android:entryValues="@array/layouts_values"
             android:defaultValue="default"
             />
         <ListPreference
-            android:key="preferred_font"
+            android:key="@string/pref_key_preferred_font"
             android:title="@string/select_font"
             android:entries="@array/theme"
             android:entryValues="@array/schemas_values"

--- a/Awful.apk/src/main/res/xml/threadinfosettings.xml
+++ b/Awful.apk/src/main/res/xml/threadinfosettings.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 		<com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="threadinfo_tag" 
+            android:key="@string/pref_key_thread_info_tag"
 			android:title="@string/threadinfo_tag"
 			android:summary="@string/threadinfo_tag_summary"
 			android:defaultValue="true"
 			/>
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-          android:key="wrap_thread_titles"
+          android:key="@string/pref_key_wrap_thread_titles"
           android:title="@string/wrap_titles"
           android:summary="@string/wrap_titles_summary"
           android:defaultValue="false"
           />
 		<com.ferg.awfulapp.preferences.CustomSwitchPreference
-            android:key="color_bookmarks" 
+            android:key="@string/pref_key_colored_bookmarks"
 			android:title="@string/color_bookmarks"
             android:summary="@string/color_bookmarks_summary"
 			android:defaultValue="false"
 			/>
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
-          android:key="threadinfo_rating"
+          android:key="@string/pref_key_thread_info_rating"
           android:title="@string/threadinfo_rating"
           android:defaultValue="true"
           />
       <PreferenceCategory android:title="@string/new_threads_first_category">
           <com.ferg.awfulapp.preferences.CustomSwitchPreference
-              android:key="new_threads_first_forum"
+              android:key="@string/pref_key_new_threads_first_forum"
               android:title="@string/new_threads_first_forum"
               android:summary="@string/new_threads_first_forum_summary"
               android:defaultValue="false"
               />
           <com.ferg.awfulapp.preferences.CustomSwitchPreference
-              android:key="new_threads_first_ucp"
+              android:key="@string/pref_key_new_threads_first_ucp"
               android:title="@string/new_threads_first_ucp"
               android:summary="@string/new_threads_first_ucp_summary"
               android:defaultValue="false"


### PR DESCRIPTION
I've centralised all the preference keys as string resources, so everything
can refer to a single variable instead of using string literals. I didn't like
how brittle it was to have copies of the same string that are at risk of typos
and hard to refactor, and the way the rest of the app needed to know the internals
of how preferences are handled.

The preference keys are stored as resource strings (so the settings XML can
refer to them), and there's a set of constants in the Keys file which the app
can use. Those are passed to set and get methods in AwfulPreferences, and they're
grouped in typedefs according to the type of preference they set (int, boolean etc).
So you can set any preference by its key constant, and passing the correct type is
enforced by the typedef-annotated method.

Hopefully this'll avoid any future bugs where someone accidentally mistypes something
or uses the wrong type and then who knows what's going on in there