### PR TITLE
Tweak the post actions layouts to fit Material guidelines

### DIFF
--- a/Awful.apk/src/main/res/layout/action_item.xml
+++ b/Awful.apk/src/main/res/layout/action_item.xml
@@ -3,23 +3,26 @@
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:minHeight="64dp"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+              android:paddingRight="24dp">
 
     <ImageView
         android:id="@+id/actionTag"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:layout_marginBottom="12dp"
-        android:layout_marginLeft="16dp"
-        android:layout_marginRight="16dp"
-        android:layout_marginTop="12dp"/>
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginLeft="12dp"
+        android:layout_marginRight="20dp"
+        android:layout_marginTop="8dp"
+        android:src="@android:drawable/ic_menu_share"
+        android:padding="12dp"/>
 
     <TextView
         android:id="@+id/actionTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textColor="@color/default_post_font"
-        android:textSize="20sp"
+        android:textSize="@dimen/abc_text_size_medium_material"
         android:maxLines="2"
         android:ellipsize="end"
         android:layout_gravity="center_vertical" />

--- a/Awful.apk/src/main/res/layout/select_action_dialog.xml
+++ b/Awful.apk/src/main/res/layout/select_action_dialog.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="@dimen/dialog_size"
     android:layout_height="match_parent"
+    android:layout_marginLeft="40dp"
+    android:layout_marginRight="40dp"
+    android:layout_marginTop="24dp"
+    android:layout_marginBottom="24dp"
     android:background="?attr/background"
     tools:context=".PostActionFragment"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:paddingBottom="24dp"
+    android:elevation="24dp">
 
     <TextView
         android:layout_width="match_parent"
@@ -15,11 +22,16 @@
         android:id="@+id/actionTitle"
         android:layout_gravity="center_horizontal"
         android:background="?attr/colorPrimary"
-        android:padding="8dp"
         android:textColor="@color/actionbar_font_color"
-        android:gravity="center_horizontal"
+        android:gravity="left"
         android:maxLines="3"
-        android:scrollbars = "vertical" />
+        android:scrollbars = "vertical"
+        android:minHeight="72dp"
+        android:paddingBottom="20dp"
+        android:paddingLeft="24dp"
+        android:paddingTop="24dp"
+        android:paddingRight="24dp"
+        android:textSize="@dimen/abc_text_size_headline_material"/>
 
     <android.support.v7.widget.RecyclerView
         android:layout_width="@dimen/dialog_size"

--- a/Awful.apk/src/main/res/values/dimens.xml
+++ b/Awful.apk/src/main/res/values/dimens.xml
@@ -6,5 +6,5 @@
 	<dimen name="app_minimumsize_w">316.0dip</dimen>
 	<dimen name="app_minimumsize_h">299.0dip</dimen>
     <dimen name="popup_size">140dp</dimen>
-    <dimen name="dialog_size">300dp</dimen>
+    <dimen name="dialog_size">280dp</dimen>
 </resources>


### PR DESCRIPTION
Basically I've
- shrunk the icons to 24dp
- adjusted the margins and padding to fit the
  Simple Dialog keyline recommendations
- changed the width to the 5 * 56dp minimum (280dp)
- added the minimum margins around the dialog
- tried to adjust the font sizes except they don't list those anywhere