### PR TITLE
Fix vector drawables with support lib, disable Crashlytics in debug, …

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
@@ -73,10 +73,6 @@ public class AwfulLoginActivity extends AwfulActivity {
         NetworkUtils.logCookies();
 
         mLogin = (Button) findViewById(R.id.login);
-        // hack to set 'drawableRight' to a vector drawable, the support library doesn't have a compat attribute in xml yet
-        if (mLogin != null) {
-            mLogin.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ic_arrow_forward, 0);
-        }
         mUsername = (EditText) findViewById(R.id.username);
         mPassword = (EditText) findViewById(R.id.password);
         mPassword.setOnEditorActionListener(new OnEditorActionListener() {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
@@ -4,12 +4,10 @@ import android.content.Intent;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.animation.Animation;
-import android.webkit.CookieManager;
 
 import com.android.volley.VolleyError;
 import com.ferg.awfulapp.AwfulLoginActivity;
 import com.ferg.awfulapp.R;
-import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.preferences.Keys;
@@ -111,10 +109,6 @@ public class AwfulError extends VolleyError{
 
             Log.w(TAG, "HttpClient CookieStore dump:");
             NetworkUtils.logCookies();
-
-            CookieManager ckiemonster = CookieManager.getInstance();
-            String cookie = ckiemonster.getCookie(Constants.COOKIE_DOMAIN);
-            Log.w(TAG, "WebView CookieManager cookie for COOKIE_DOMAIN:" + cookie);
 
             // TODO fix the actual problem, probably repeated network requests in a short space of time
             if (!NetworkUtils.dodgeLogoutBullet()) {


### PR DESCRIPTION
…stop webview crash

Remove broken drawable stuff and use srcCompat where appropriate

Crashlytics is only enabled in DEBUG after the app has been installed for
a few hours, to avoid crash spam when you're poking at code

AwfulError was dumping WebView cookies, which could happen before a WebView was
actually created (e.g. completing a network request while staring at the login screen)