### PR TITLE
Notification for PMs

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageActivity.java
@@ -28,6 +28,7 @@
 package com.ferg.awfulapp;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.widget.Toolbar;
@@ -53,8 +54,9 @@ public class PrivateMessageActivity extends AwfulActivity {
         setContentView(R.layout.fragment_pane);
         mPrefs = AwfulPreferences.getInstance(this, this);
 
-        if (getIntent().getData() != null && getIntent().getData().getScheme().equals("http")) {
-        	pmIntentID = getIntent().getData().getQueryParameter(Constants.PARAM_PRIVATE_MESSAGE_ID);
+		Uri data = getIntent().getData();
+		if (data != null) {
+        	pmIntentID = data.getQueryParameter(Constants.PARAM_PRIVATE_MESSAGE_ID);
         }
 
         pane_two = findViewById(R.id.fragment_pane_two);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/messages/PmManager.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/messages/PmManager.java
@@ -1,0 +1,86 @@
+package com.ferg.awfulapp.messages;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Created by baka kaba on 16/08/2016.
+ * <p/>
+ * A class that takes care of Private Messages, keeping track of notified state and
+ * informing listeners when there's a change.
+ * <p/>
+ * Pretty barebones right now, it could be expanded to manage all the PM access, do
+ * filtering, run periodic background updates etc. Or whatever
+ */
+public class PmManager {
+
+    private static final String TAG = "PmManager";
+
+    /**
+     * Gotta synchronise things since the html to parse is coming in on a network thread
+     */
+    private static Map<Listener, Object> callbacks = Collections.synchronizedMap(new WeakHashMap<Listener, Object>());
+
+    @Nullable
+    private volatile static String lastNotifiedPmUrl = null;
+
+    /**
+     * Parse the UCP html to find and extract the new PM notification, if there is one.
+     *
+     * @param page The UCP page's html
+     */
+    public static void parseUcpPage(Document page) {
+        Elements senderElements = page.select(".private_messages td.sender");
+        Elements hrefElements = page.select(".private_messages [href*='privatemessageid']");
+
+        // get the first message details - the page potentially shows several
+        String sender = (senderElements.isEmpty()) ? "" : senderElements.get(0).text();
+        String href = (hrefElements.isEmpty()) ? "" : hrefElements.get(0).attr("abs:href");
+
+        // just log an error if we couldn't get all the details for some reason
+        if ("".equals(href) || "".equals(sender)) {
+            String message = "Unable to correctly parse UCP for PMs!\nHref: {}, Sender: {}";
+            Log.w(TAG, String.format(message, href, sender));
+        } else if (!href.equals(lastNotifiedPmUrl)) {
+            // otherwise let all the listeners know
+            int numDisplayed = hrefElements.size();
+            for (Listener listener : callbacks.keySet()) {
+                listener.onNewPm(href, sender, numDisplayed);
+            }
+            lastNotifiedPmUrl = href;
+        }
+    }
+
+    /**
+     * Register a listener for private message updates.
+     * <p/>
+     * Only holds a weak reference, so keep your own reference if necessary.
+     */
+    public static void registerListener(@NonNull Listener listener) {
+        callbacks.put(listener, new Object());
+    }
+
+
+    public interface Listener {
+        /**
+         * Called when the app first identifies an unread PM alert.
+         *
+         * This will currently trigger when a 'new' PM is listed on the bookmarks page.
+         * This can happen when the app is first opened, when a new PM arrives, or when
+         * the top PM is read and another unread message takes the top spot.
+         * @param messageUrl    The full URL to the message
+         * @param sender        The name of the sender
+         * @param unreadCount   The number of unread messages listed on the UCP page (may not be all?)
+         */
+        void onNewPm(@NonNull String messageUrl, @NonNull String sender, int unreadCount);
+    }
+
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.messages.PmManager;
 import com.ferg.awfulapp.thread.AwfulForum;
 import com.ferg.awfulapp.util.AwfulError;
 
@@ -18,7 +19,7 @@ public class ThreadListRequest extends AwfulRequest<Void> {
 
     private int forumId, page;
     public ThreadListRequest(Context context, int forumId, int page) {
-        super(context, forumId == Constants.USERCP_ID ? Constants.FUNCTION_BOOKMARK : Constants.FUNCTION_FORUM);
+        super(context, forumId == Constants.USERCP_ID ? Constants.FUNCTION_USERCP : Constants.FUNCTION_FORUM);
         this.forumId = forumId;
         this.page = page;
     }
@@ -44,6 +45,7 @@ public class ThreadListRequest extends AwfulRequest<Void> {
         try {
             if(forumId == Constants.USERCP_ID){
                 AwfulForum.parseUCPThreads(doc, page, getContentResolver());
+                PmManager.parseUcpPage(doc);
             }else{
                 AwfulForum.parseThreads(doc, forumId, page, getContentResolver());
             }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
@@ -30,10 +30,12 @@ package com.ferg.awfulapp.thread;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
 
 import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.messages.PmManager;
 import com.ferg.awfulapp.provider.AwfulProvider;
 
 import org.jsoup.nodes.Document;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulURL.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulURL.java
@@ -146,7 +146,7 @@ public class AwfulURL {
 		switch(type){
 		case FORUM:
 			if(id == Constants.USERCP_ID){
-				url = Uri.parse(Constants.FUNCTION_BOOKMARK).buildUpon();
+				url = Uri.parse(Constants.FUNCTION_USERCP).buildUpon();
 			}else{
 				url = Uri.parse(Constants.FUNCTION_FORUM).buildUpon();
 			}


### PR DESCRIPTION
Added a basic PM manager class that parses the UCP page and looks for a new message alert.
It calls back to the main activity so it can pop up a snackbar with a link for the PM activity intent.

I also changed stuff to use the real UCP url constant, it's necessary for getting PMs from
the bookmark list network request, but it probably should be used everywhere in general? Seems to
 work ok so far.