### PR TITLE
Allow probies to log in, fix NPE on login errors

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/LoginRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/LoginRequest.java
@@ -41,7 +41,7 @@ public class LoginRequest extends AwfulRequest<Boolean> {
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        if(error.networkResponse.statusCode == 302){
+        if(error.networkResponse != null && error.networkResponse.statusCode == 302){
             Boolean result = NetworkUtils.saveLoginCookies(getContext());
             if(result){
                 AwfulPreferences prefs = AwfulPreferences.getInstance(getContext());
@@ -49,7 +49,7 @@ public class LoginRequest extends AwfulRequest<Boolean> {
             }
             return result;
         }else{
-            return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+            return error.isCritical();
         }
     }
 }


### PR DESCRIPTION
Page parses throw a special probation AwfulError when there are signs that someone is on probation.
Some requests ignore this, the login one was treating it as a dealbreaker for some reason, so I removed
that and fixed an NPE when parsing the error's status code (which also caused login failure)