### PR TITLE
Rework theming and colour/CSS handling methods

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.graphics.Typeface;
 import android.net.http.HttpResponseCache;
 import android.os.Bundle;
-import android.os.Message;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.method.ScrollingMovementMethod;
@@ -17,12 +16,12 @@ import android.widget.TextView;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.provider.AwfulTheme;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.task.FeatureRequest;
 import com.ferg.awfulapp.task.ProfileRequest;
 
 import java.io.File;
-import java.util.LinkedList;
 
 /**
  * Convenience class to avoid having to call a configurator's lifecycle methods everywhere. This
@@ -53,21 +52,7 @@ public class AwfulActivity extends AppCompatActivity implements AwfulPreferences
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         mPrefs = AwfulPreferences.getInstance(this,this);
-        if(mPrefs.theme.equals(ColorProvider.DEFAULT) || mPrefs.theme.equals(ColorProvider.CLASSIC)){
-            setTheme(R.style.Theme_AwfulTheme);
-        }else if(mPrefs.theme.equals(ColorProvider.FYAD)){
-            setTheme(R.style.Theme_AwfulTheme_FYAD);
-        }else if(mPrefs.theme.equals(ColorProvider.BYOB)){
-            setTheme(R.style.Theme_AwfulTheme_BYOB);
-        }else if(mPrefs.theme.equals(ColorProvider.YOSPOS)){
-            setTheme(R.style.Theme_AwfulTheme_YOSPOS);
-        }else if(mPrefs.theme.equals(ColorProvider.AMBERPOS)){
-            setTheme(R.style.Theme_AwfulTheme_AMBERPOS);
-        }else if(mPrefs.theme.equals(ColorProvider.OLED)){
-            setTheme(R.style.Theme_AwfulTheme_OLED);
-        }else{
-            setTheme(R.style.Theme_AwfulTheme_Dark);
-        }
+        setCurrentTheme();
         super.onCreate(savedInstanceState); if(DEBUG) Log.e(TAG, "onCreate");
         mConf = new ActivityConfigurator(this);
         mConf.onCreate();
@@ -150,7 +135,7 @@ public class AwfulActivity extends AppCompatActivity implements AwfulPreferences
         ActionBar action = getSupportActionBar();
         if(action != null && mTitleView != null){
 	        //action.setBackgroundDrawable(new ColorDrawable(ColorProvider.getActionbarColor()));
-	        mTitleView.setTextColor(ColorProvider.getActionbarFontColor());
+	        mTitleView.setTextColor(ColorProvider.ACTION_BAR_TEXT.getColor());
 	        setPreferredFont(mTitleView, Typeface.NORMAL);
         }
     }
@@ -212,21 +197,7 @@ public class AwfulActivity extends AppCompatActivity implements AwfulPreferences
 	public void onPreferenceChange(AwfulPreferences prefs, String key) {
         Log.d(TAG, "Key changed: "+key);
         if("theme".equals(key) || "page_layout".equals(key)) {
-            if (mPrefs.theme.equals(ColorProvider.DEFAULT) || mPrefs.theme.equals(ColorProvider.CLASSIC)) {
-                setTheme(R.style.Theme_AwfulTheme);
-            } else if (mPrefs.theme.equals(ColorProvider.FYAD)) {
-                setTheme(R.style.Theme_AwfulTheme_FYAD);
-            } else if (mPrefs.theme.equals(ColorProvider.BYOB)) {
-                setTheme(R.style.Theme_AwfulTheme_BYOB);
-            } else if (mPrefs.theme.equals(ColorProvider.YOSPOS)) {
-                setTheme(R.style.Theme_AwfulTheme_YOSPOS);
-            } else if (mPrefs.theme.equals(ColorProvider.AMBERPOS)) {
-                setTheme(R.style.Theme_AwfulTheme_AMBERPOS);
-            } else if (mPrefs.theme.equals(ColorProvider.OLED)) {
-                setTheme(R.style.Theme_AwfulTheme_OLED);
-            } else {
-                setTheme(R.style.Theme_AwfulTheme_Dark);
-            }
+            setCurrentTheme();
             afterThemeChange();
         }
 		updateActionbarTheme();
@@ -243,6 +214,10 @@ public class AwfulActivity extends AppCompatActivity implements AwfulPreferences
 		return true;
 	}
 
+
+    protected void setCurrentTheme() {
+        setTheme(AwfulTheme.forForum(null).themeResId);
+    }
 
 	
     public void afterThemeChange() {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulDialogFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulDialogFragment.java
@@ -46,7 +46,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.Animation;
 import android.widget.ImageView;
-import android.widget.PopupWindow;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -55,7 +54,6 @@ import com.android.volley.VolleyError;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
-import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.util.AwfulError;
 import com.ferg.awfulapp.widget.AwfulProgressBar;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/EmoteFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/EmoteFragment.java
@@ -104,7 +104,7 @@ public class EmoteFragment extends AwfulDialogFragment implements OnClickListene
 		Button deleteButton = (Button) v.findViewById(R.id.delete_button);
 		deleteButton.setOnClickListener(this);
 		filterText = (EditText) v.findViewById(R.id.filter_text);
-		filterText.setTextColor(ColorProvider.getTextColor());
+		filterText.setTextColor(ColorProvider.PRIMARY_TEXT.getColor());
 		filterText.addTextChangedListener(new TextWatcher() {
 			@Override
 			public void onTextChanged(CharSequence s, int start, int before, int count) {}
@@ -119,7 +119,7 @@ public class EmoteFragment extends AwfulDialogFragment implements OnClickListene
 		emoteGrid = (GridView) v.findViewById(R.id.emote_grid);
 		emoteGrid.setAdapter(adapter);
 		emoteGrid.setOnItemClickListener(this);
-		emoteGrid.setBackgroundColor(ColorProvider.getBackgroundColor());
+		emoteGrid.setBackgroundColor(ColorProvider.BACKGROUND.getColor());
 
 		return v;
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -181,8 +181,8 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
         // TODO: move P2R stuff into AwfulFragment
         mSRL = (SwipyRefreshLayout) view.findViewById(R.id.forum_swipe);
         mSRL.setOnRefreshListener(this);
-        mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColor());
-        mSRL.setProgressBackgroundColor(ColorProvider.getSRLBackgroundColor());
+        mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColors(null));
+        mSRL.setProgressBackgroundColor(ColorProvider.getSRLBackgroundColor(null));
     }
 
     @Override
@@ -730,32 +730,14 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
     }
 
 
-    // TODO: maybe refactor ColorProvider so it does the forum ID -> provider constant translation itself
     private void updateColors() {
         if (mPageBar != null) {
-            mPageBar.setTextColour(ColorProvider.getActionbarFontColor());
+            mPageBar.setTextColour(ColorProvider.ACTION_BAR_TEXT.getColor());
         }
         if (mListView == null) {
             return;
         }
-        String colorProvider = null;
-        // if we're forcing forum themes, see if we need a specific color provider
-        if (mPrefs.forceForumThemes) {
-            switch (mForumId) {
-                case Constants.FORUM_ID_YOSPOS:
-                    colorProvider = ColorProvider.YOSPOS;
-                    break;
-                case Constants.FORUM_ID_FYAD:
-                case Constants.FORUM_ID_FYAD_SUB:
-                    colorProvider = ColorProvider.FYAD;
-                    break;
-                case Constants.FORUM_ID_BYOB:
-                case Constants.FORUM_ID_COOL_CREW:
-                    colorProvider = ColorProvider.BYOB;
-                    break;
-            }
-        }
-        int backgroundColor = ColorProvider.getBackgroundColor(colorProvider);
+        int backgroundColor = ColorProvider.BACKGROUND.getColor(mForumId);
         mListView.setBackgroundColor(backgroundColor);
         mListView.setCacheColorHint(backgroundColor);
     }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
@@ -55,7 +55,6 @@ import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
-import android.support.v7.app.AppCompatDelegate;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -104,7 +103,6 @@ public class ForumsIndexActivity extends AwfulActivity implements PmManager.List
     private boolean skipLoad = false;
     private boolean isTablet;
     private AwfulURL url = new AwfulURL();
-    private Handler mHandler = new Handler();
 
     private ToggleViewPager mViewPager;
 
@@ -126,8 +124,6 @@ public class ForumsIndexActivity extends AwfulActivity implements PmManager.List
     private volatile int mForumPage     = 1;
     private volatile int mThreadId      = NULL_THREAD_ID;
     private volatile int mThreadPage    = 1;
-
-    private boolean mPrimeRecreate = false;
 
     private GestureDetector mImmersionGestureDetector = null;
     private boolean mIgnoreFling;
@@ -164,7 +160,7 @@ public class ForumsIndexActivity extends AwfulActivity implements PmManager.List
         if (isTablet) {
             mViewPager.setPageMargin(1);
             //TODO what color should it use here?
-            mViewPager.setPageMarginDrawable(new ColorDrawable(ColorProvider.getActionbarColor()));
+            mViewPager.setPageMarginDrawable(new ColorDrawable(ColorProvider.ACTION_BAR.getColor()));
         }
         pagerAdapter = new ForumPagerAdapter(getSupportFragmentManager());
         mViewPager.setAdapter(pagerAdapter);
@@ -588,13 +584,6 @@ public class ForumsIndexActivity extends AwfulActivity implements PmManager.List
     protected void onResume() {
         super.onResume();
 
-        if (mPrimeRecreate) {
-            mPrimeRecreate = false;
-            Intent intent = getIntent();
-            finish();
-            startActivity(intent);
-        }
-
         int versionCode = 0;
         try {
             versionCode = getPackageManager().getPackageInfo(getPackageName(), 0).versionCode;
@@ -943,7 +932,7 @@ public class ForumsIndexActivity extends AwfulActivity implements PmManager.List
             if (isTablet) {
                 mViewPager.setPageMargin(1);
                 //TODO what color should it use here?
-                mViewPager.setPageMarginDrawable(new ColorDrawable(ColorProvider.getActionbarColor()));
+                mViewPager.setPageMarginDrawable(new ColorDrawable(ColorProvider.ACTION_BAR.getColor()));
             } else {
                 mViewPager.setPageMargin(0);
             }
@@ -968,11 +957,6 @@ public class ForumsIndexActivity extends AwfulActivity implements PmManager.List
         mNavForumId = forumId;
         mNavThreadId = threadId != null ? threadId : NULL_THREAD_ID;
         updateNavigationMenu();
-    }
-
-    @Override
-    public void afterThemeChange() {
-        this.mPrimeRecreate = true;
     }
 
     public void preventSwipe() {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
@@ -146,7 +146,7 @@ public class ForumsIndexFragment extends AwfulFragment
      */
     private void updateViewColours() {
         if (forumRecyclerView != null) {
-            forumRecyclerView.setBackgroundColor(ColorProvider.getBackgroundColor());
+            forumRecyclerView.setBackgroundColor(ColorProvider.BACKGROUND.getColor());
         }
     }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
@@ -148,12 +148,13 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
 	}
 	
 	private void updateColors(View v, AwfulPreferences prefs){
-        messageComposer.setTextColor(ColorProvider.getTextColor());
-        mRecipient.setTextColor(ColorProvider.getTextColor());
-        mSubject.setTextColor(ColorProvider.getTextColor());
-        mUsername.setTextColor(ColorProvider.getTextColor());
-        mPostdate.setTextColor(ColorProvider.getTextColor());
-        mTitle.setTextColor(ColorProvider.getTextColor());
+		int color = ColorProvider.PRIMARY_TEXT.getColor();
+		messageComposer.setTextColor(color);
+		mRecipient.setTextColor(color);
+		mSubject.setTextColor(color);
+		mUsername.setTextColor(color);
+		mPostdate.setTextColor(color);
+		mTitle.setTextColor(color);
 	}
 	
 	@Override
@@ -417,7 +418,7 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
 
 
 	private String getBlankPage(){
-		return "<html><head></head><body style='{background-color:#"+ColorProvider.convertToARGB(ColorProvider.getBackgroundColor())+";'></body></html>";
+		return "<html><head></head><body style='{background-color:#"+ ColorProvider.convertToRGB(ColorProvider.BACKGROUND.getColor()) +";'></body></html>";
 	}
 	
     @SuppressLint("NewApi")

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
@@ -30,7 +30,6 @@ package com.ferg.awfulapp;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.text.method.ScrollingMovementMethod;
@@ -38,20 +37,13 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.CheckBox;
 import android.widget.ImageView;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.android.volley.VolleyError;
 import com.ferg.awfulapp.constants.Constants;
-import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.provider.ColorProvider;
-import com.ferg.awfulapp.task.AwfulRequest;
-import com.ferg.awfulapp.task.SearchForumsRequest;
 import com.ferg.awfulapp.thread.AwfulAction;
 import com.ferg.awfulapp.thread.AwfulMessage;
-import com.ferg.awfulapp.thread.AwfulSearchForum;
 
 import java.util.ArrayList;
 
@@ -94,7 +86,7 @@ public class PostActionsFragment extends AwfulDialogFragment {
 			public void onBindViewHolder(ActionHolder holder, final int position) {
 				final AwfulAction action = actions.get(position);
 				holder.actionText.setText(action.getActionTitle());
-				holder.actionText.setTextColor(ColorProvider.getTextColor());
+				holder.actionText.setTextColor(ColorProvider.PRIMARY_TEXT.getColor());
 				holder.actionTag.setImageResource(action.getActionIcon());
 				holder.actionView.setOnClickListener(new View.OnClickListener() {
 					@Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostReplyFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostReplyFragment.java
@@ -252,8 +252,8 @@ public class PostReplyFragment extends AwfulFragment {
         ButterKnife.bind(this, activity);
 
         messageComposer = (MessageComposer) getChildFragmentManager().findFragmentById(R.id.message_composer_fragment);
-        messageComposer.setBackgroundColor(ColorProvider.getBackgroundColor());
-        messageComposer.setTextColor(ColorProvider.getTextColor());
+        messageComposer.setBackgroundColor(ColorProvider.BACKGROUND.getColor());
+        messageComposer.setTextColor(ColorProvider.PRIMARY_TEXT.getColor());
         setTitle(getTitle());
 
         activity.getContentResolver().registerContentObserver(AwfulThread.CONTENT_URI, true, mThreadObserver);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
@@ -29,13 +29,10 @@ package com.ferg.awfulapp;
 
 import android.graphics.Color;
 import android.os.Bundle;
-import android.text.Html;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.webkit.ConsoleMessage;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
@@ -46,9 +43,6 @@ import android.widget.ProgressBar;
 
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
-import com.ferg.awfulapp.provider.ColorProvider;
-import com.ferg.awfulapp.thread.AwfulMessage;
-import com.ferg.awfulapp.thread.AwfulPost;
 import com.ferg.awfulapp.thread.AwfulThread;
 import com.ferg.awfulapp.util.AwfulUtils;
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageListFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageListFragment.java
@@ -127,8 +127,8 @@ public class PrivateMessageListFragment extends AwfulFragment implements SwipeRe
 
         mSRL = (SwipeRefreshLayout) view.findViewById(R.id.pm_swipe);
         mSRL.setOnRefreshListener(this);
-        mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColor());
-        mSRL.setProgressBackgroundColorSchemeResource(ColorProvider.getSRLBackgroundColor());
+        mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColors(null));
+        mSRL.setProgressBackgroundColorSchemeResource(ColorProvider.getSRLBackgroundColor(null));
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/SearchFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/SearchFragment.java
@@ -104,8 +104,8 @@ public class SearchFragment extends AwfulFragment implements SwipyRefreshLayout.
 
         mSRL = (SwipyRefreshLayout) result.findViewById(R.id.search_srl);
         mSRL.setOnRefreshListener(this);
-        mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColor());
-        mSRL.setProgressBackgroundColor(ColorProvider.getSRLBackgroundColor());
+        mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColors(null));
+        mSRL.setProgressBackgroundColor(ColorProvider.getSRLBackgroundColor(null));
         mSRL.setEnabled(false);
 
         mSearchResultList = (RecyclerView) result.findViewById(R.id.search_results);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -90,6 +90,7 @@ import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.provider.AwfulProvider;
+import com.ferg.awfulapp.provider.AwfulTheme;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.task.BookmarkRequest;
@@ -347,8 +348,8 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
 
         mSRL = (SwipyRefreshLayout) view.findViewById(R.id.thread_swipe);
-        mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColor());
-		mSRL.setProgressBackgroundColor(ColorProvider.getSRLBackgroundColor());
+		mSRL.setColorSchemeResources(ColorProvider.getSRLProgressColors(null));
+		mSRL.setProgressBackgroundColor(ColorProvider.getSRLBackgroundColor(null));
 		mSRL.setEnabled(!mPrefs.disablePullNext);
     }
 
@@ -972,7 +973,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 		mPrefs.amberDefaultPos = !mPrefs.amberDefaultPos;
 		mPrefs.setPreference(Keys.AMBER_DEFAULT_POS, mPrefs.amberDefaultPos);
 		if (mThreadView != null) {
-			mThreadView.loadUrl("javascript:changeCSS('"+AwfulUtils.determineCSS(mParentForumId)+"')");
+			mThreadView.loadUrl(String.format("javascript:changeCSS('%s')", AwfulTheme.forForum(mParentForumId).getCssPath()));
 		}
 	}
 
@@ -1202,7 +1203,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
         @JavascriptInterface
         public String getCSS(){
-            return AwfulUtils.determineCSS(mParentForumId);
+            return AwfulTheme.forForum(mParentForumId).getCssPath();
         }
         
         @SuppressWarnings("SpellCheckingInspection")
@@ -1361,7 +1362,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 		if(DEBUG) Log.i(TAG,"onPreferenceChange"+((key != null)?":"+key:""));
         if(null != getAwfulActivity() && pageBar != null){
 		    getAwfulActivity().setPreferredFont(pageBar.getTextView());
-			pageBar.setTextColour(ColorProvider.getActionbarFontColor());
+			pageBar.setTextColour(ColorProvider.ACTION_BAR_TEXT.getColor());
 		}
 
 		if(mThreadView != null){
@@ -1547,7 +1548,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 				mTitle = aData.getString(aData.getColumnIndex(AwfulThread.TITLE));
         		mParentForumId = aData.getInt(aData.getColumnIndex(AwfulThread.FORUM_ID));
 				if(mParentForumId != 0 && mThreadView != null){
-					mThreadView.loadUrl("javascript:changeCSS('"+AwfulUtils.determineCSS(mParentForumId)+"')");
+					mThreadView.loadUrl(String.format("javascript:changeCSS('%s')", AwfulTheme.forForum(mParentForumId).getCssPath()));
 				}
 
 				parentActivity.setNavIds(mParentForumId, getThreadId());
@@ -1558,8 +1559,8 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 					if (postFilterUserId != null) {
 						mUserPostNotice.setVisibility(View.VISIBLE);
 						mUserPostNotice.setText(String.format("Viewing posts by %s in this thread,\nPress the back button to return.", postFilterUsername));
-						mUserPostNotice.setTextColor(ColorProvider.getTextColor());
-						mUserPostNotice.setBackgroundColor(ColorProvider.getBackgroundColor());
+						mUserPostNotice.setTextColor(ColorProvider.PRIMARY_TEXT.getColor());
+						mUserPostNotice.setBackgroundColor(ColorProvider.BACKGROUND.getColor());
 					} else {
 						mUserPostNotice.setVisibility(View.GONE);
 					}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/forums/ForumListAdapter.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/forums/ForumListAdapter.java
@@ -173,9 +173,9 @@ public class ForumListAdapter extends ExpandableRecyclerAdapter<ForumListAdapter
      * @param mainView The main item layout, has its background set
      */
     private void setThemeColours(View mainView, TextView title, TextView subtitle) {
-        mainView.setBackgroundColor(ColorProvider.getBackgroundColor());
-        title.setTextColor(ColorProvider.getTextColor());
-        subtitle.setTextColor(ColorProvider.getAltTextColor());
+        mainView.setBackgroundColor(ColorProvider.BACKGROUND.getColor());
+        title.setTextColor(ColorProvider.PRIMARY_TEXT.getColor());
+        subtitle.setTextColor(ColorProvider.ALT_TEXT.getColor());
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/SettingsActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/SettingsActivity.java
@@ -27,7 +27,6 @@ import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.fragments.RootSettings;
 import com.ferg.awfulapp.preferences.fragments.SettingsFragment;
-import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.util.AwfulUtils;
 
 import org.apache.commons.lang3.StringUtils;
@@ -208,34 +207,12 @@ public class SettingsActivity extends AwfulActivity implements AwfulPreferences.
             }
         }
 
-        if(!prefs.theme.equals(this.currentThemeName)) {
-            this.currentThemeName = prefs.theme;
+        if(!mPrefs.theme.equals(this.currentThemeName)) {
+            this.currentThemeName = mPrefs.theme;
             setCurrentTheme();
             recreate();
         }
     }
-
-
-    private void setCurrentTheme() {
-        // TODO: this is yoinked out of AwfulActivity and could really do with being centralised
-        if(prefs.theme.equals(ColorProvider.DEFAULT) || prefs.theme.equals(ColorProvider.CLASSIC)){
-            setTheme(R.style.Theme_AwfulTheme);
-        }else if(prefs.theme.equals(ColorProvider.FYAD)){
-            setTheme(R.style.Theme_AwfulTheme_FYAD);
-        }else if(prefs.theme.equals(ColorProvider.BYOB)){
-            setTheme(R.style.Theme_AwfulTheme_BYOB);
-        }else if(prefs.theme.equals(ColorProvider.YOSPOS)){
-            setTheme(R.style.Theme_AwfulTheme_YOSPOS);
-        }else if(prefs.theme.equals(ColorProvider.AMBERPOS)){
-            setTheme(R.style.Theme_AwfulTheme_AMBERPOS);
-        }else if(prefs.theme.equals(ColorProvider.OLED)) {
-            setTheme(R.style.Theme_AwfulTheme_OLED);
-        }else{
-            setTheme(R.style.Theme_AwfulTheme_Dark);
-        }
-    }
-
-
 
 
     /*

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulTheme.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulTheme.java
@@ -1,0 +1,232 @@
+package com.ferg.awfulapp.provider;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
+import android.os.Environment;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StyleRes;
+import android.support.v4.content.ContextCompat;
+import android.widget.Toast;
+
+import com.ferg.awfulapp.R;
+import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.preferences.AwfulPreferences;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.ferg.awfulapp.util.AwfulUtils.isKitKat;
+
+/**
+ * Created by baka kaba on 03/01/2017.
+ * <p>
+ * Provides access to themed resources and values.
+ * <p>
+ * You'll generally use the {@link #forForum(Integer)} method to obtain an appropriate theme.
+ * Each enum represents one of the app's default themes, as well as two representing light and dark
+ * custom themes. Properties like {@link #displayName} give you access to that theme's specific details,
+ * and the {@link #getCssPath()} method resolves a path to a CSS file, falling back to a default if
+ * a user theme's CSS can't be accessed.
+ */
+
+public enum AwfulTheme {
+
+    // Themes need a display name, source CSS (for the thread webview) and a resource theme
+    DEFAULT("Default", "default.css", R.style.Theme_AwfulTheme),
+    DARK("Dark", "dark.css", R.style.Theme_AwfulTheme_Dark),
+    OLED("OLED", "oled.css", R.style.Theme_AwfulTheme_OLED),
+    GREENPOS("YOSPOS", "yospos.css", R.style.Theme_AwfulTheme_YOSPOS),
+    AMBERPOS("AMBERPOS", "amberpos.css", R.style.Theme_AwfulTheme_AMBERPOS),
+    FYAD("FYAD", "fyad.css", R.style.Theme_AwfulTheme_FYAD),
+    BYOB("BYOB", "byob.css", R.style.Theme_AwfulTheme_BYOB),
+    CLASSIC("Classic", "classic.css", R.style.Theme_AwfulTheme),
+
+    // These represent the basic variations for user themes, and are handled specially in the code.
+    // The CSS is the fallback file to use if there's a problem, the resource file is the actual app theme
+    // (users can't customise those... yet...)
+    CUSTOM("Custom", "default.css", R.style.Theme_AwfulTheme),
+    CUSTOM_DARK("Custom dark", "dark.css", R.style.Theme_AwfulTheme_Dark);
+
+    private static final String APP_CSS_PATH = "file:///android_asset/css/";
+    private static final String CUSTOM_THEME_PATH = Environment.getExternalStorageDirectory() + "/awful/";
+
+    /**
+     * Values representing custom, non-app themes
+     */
+    private static final List<AwfulTheme> CUSTOM_THEMES;
+    /**
+     * Values representing default app themes
+     */
+    public static final List<AwfulTheme> APP_THEMES;
+
+    static {
+        CUSTOM_THEMES = Collections.unmodifiableList(Arrays.asList(CUSTOM, CUSTOM_DARK));
+        List<AwfulTheme> allThemes = new ArrayList<>(Arrays.asList(AwfulTheme.values()));
+        allThemes.removeAll(CUSTOM_THEMES);
+        APP_THEMES = Collections.unmodifiableList(allThemes);
+    }
+
+    /**
+     * The ID of the style resource this theme uses
+     */
+    @StyleRes
+    public final int themeResId;
+    /**
+     * The display name for this theme
+     */
+    @NonNull
+    public final String displayName;
+    /**
+     * The name of this theme's CSS file, used as a unique identifier
+     */
+    @NonNull
+    public final String cssFilename;
+
+    /**
+     * Represents an app theme.
+     *
+     * @param displayName The name to display for this theme
+     * @param cssFilename The filename for the theme's CSS file - used to identify the theme, must be unique
+     * @param themeId     The ID of the style resource this theme uses
+     */
+    AwfulTheme(@NonNull String displayName, @NonNull String cssFilename, @StyleRes int themeId) {
+        this.displayName = displayName;
+        this.cssFilename = cssFilename;
+        this.themeResId = themeId;
+    }
+
+
+    /**
+     * The path to the location where custom themes should be stored.
+     */
+    @NonNull
+    public static String getCustomThemePath() {
+        return CUSTOM_THEME_PATH;
+    }
+
+
+    /**
+     * Get a forum's specific theme, if it has one.
+     *
+     * @param forumId the ID of the forum to check
+     * @param prefs   used to resolve user options, e.g. YOSPOS colours
+     * @return a specific theme to use, otherwise null
+     */
+    @Nullable
+    private static AwfulTheme themeForForumId(int forumId, @NonNull AwfulPreferences prefs) {
+        switch (forumId) {
+            case (Constants.FORUM_ID_FYAD):
+            case (Constants.FORUM_ID_FYAD_SUB):
+                return FYAD;
+            case (Constants.FORUM_ID_BYOB):
+            case (Constants.FORUM_ID_COOL_CREW):
+                return BYOB;
+            case (Constants.FORUM_ID_YOSPOS):
+                return (prefs.amberDefaultPos ? AMBERPOS : GREENPOS);
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Get the theme to display, resolving according to the given forum and user preferences.
+     * <p>
+     * Passing null to this method will return the user's currently selected theme. If you pass in
+     * a forum ID, and the user has 'display forum themes' enabled, that forum's theme will be returned
+     * instead, if it has one.
+     */
+    @NonNull
+    public static AwfulTheme forForum(@Nullable Integer forumId) {
+        // if we're using per-forum themes, try to get and return one, otherwise use the current theme in prefs
+        AwfulTheme forumTheme = null;
+        AwfulPreferences prefs = AwfulPreferences.getInstance();
+        if (forumId != null && prefs.forceForumThemes) {
+            forumTheme = themeForForumId(forumId, prefs);
+        }
+        return (forumTheme != null) ? forumTheme : themeForCssFilename(prefs.theme);
+    }
+
+    /**
+     * Get the AwfulTheme associated with a css filename
+     * <p>
+     * This is the main way of obtaining a theme, since preferences use css filenames to identify
+     * the user's desired theme. This method parses the filename, and returns the app theme
+     * it corresponds to. If it's unrecognised, it's treated as a custom theme.
+     */
+    @NonNull
+    private static AwfulTheme themeForCssFilename(@Nullable String themeName) {
+        if (StringUtils.isEmpty(themeName)) {
+            return DEFAULT;
+        }
+
+        for (AwfulTheme appTheme : APP_THEMES) {
+            if (appTheme.cssFilename.equalsIgnoreCase(themeName)) {
+                return appTheme;
+            }
+        }
+        // not an app theme, treat it as a user theme
+        return themeName.contains(".dark") ? CUSTOM_DARK : CUSTOM;
+    }
+
+
+    /**
+     * Returns the path to a CSS file for this theme.
+     * <p>
+     * If this is a user theme, and the specified CSS file can't be read, this will fall back
+     * to a default CSS file.
+     */
+    @NonNull
+    public String getCssPath() {
+        // non-custom themes just need the local css file
+        if (this != CUSTOM && this != CUSTOM_DARK) {
+            return APP_CSS_PATH + cssFilename;
+        }
+
+        // must be a user theme, try to read it from storage
+        String errorMessage;
+        AwfulPreferences prefs = AwfulPreferences.getInstance();
+        Context context = prefs.getContext();
+        @SuppressLint("InlinedApi")
+        int permission = ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE);
+        // external storage permission was introduced in API 16 but not enforced until 19
+        if (permission == PackageManager.PERMISSION_GRANTED || !isKitKat()) {
+            File cssFile = new File(CUSTOM_THEME_PATH, prefs.theme);
+            if (cssFile.isFile() && cssFile.canRead()) {
+                return "file:///" + cssFile.getPath();
+            }
+            errorMessage = "Theme CSS file error!";
+        } else {
+            errorMessage = context.getString(R.string.no_file_permission_theme);
+        }
+
+        // couldn't get the user css - fall back to the base theme
+        Toast.makeText(context, errorMessage, Toast.LENGTH_LONG).show();
+        return APP_CSS_PATH + cssFilename;
+
+    }
+
+    @Override
+    public String toString() {
+        return displayName;
+    }
+
+
+    /**
+     * Create an Android Theme from this theme's attributes.
+     */
+    @NonNull
+    public Resources.Theme getTheme(@NonNull AwfulPreferences prefs) {
+        Resources.Theme theme = prefs.getResources().newTheme();
+        theme.applyStyle(themeResId, true);
+        return theme;
+    }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulMessage.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulMessage.java
@@ -39,6 +39,7 @@ import android.widget.TextView;
 import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.provider.AwfulTheme;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.util.AwfulError;
 import com.ferg.awfulapp.util.AwfulUtils;
@@ -93,14 +94,14 @@ public class AwfulMessage extends AwfulPagedItem {
 		current.findViewById(R.id.unread_count).setVisibility(View.GONE);
 		if(t != null){
 			title.setText(t);
-			title.setTextColor(ColorProvider.getTextColor());
+			title.setTextColor(ColorProvider.PRIMARY_TEXT.getColor());
 		}
 		TextView author = (TextView) current.findViewById(R.id.thread_info);
 		String auth = data.getString(data.getColumnIndex(AUTHOR));
 		String date = data.getString(data.getColumnIndex(DATE));
 		if(auth != null && date != null){
 			author.setText(auth +" - "+date);
-			author.setTextColor(ColorProvider.getAltTextColor());
+			author.setTextColor(ColorProvider.ALT_TEXT.getColor());
 		}
 
 		ImageView unreadPM = (ImageView) current.findViewById(R.id.thread_tag);
@@ -139,7 +140,7 @@ public class AwfulMessage extends AwfulPagedItem {
 					// FTGE
 					GradientDrawable background = (GradientDrawable) current.getResources().getDrawable(R.drawable.overlay_background);
 					background.mutate();
-					background.setColor(ColorProvider.getBackgroundColor());
+					background.setColor(ColorProvider.BACKGROUND.getColor());
 					overlay.setBackgroundDrawable(background);
 				}
 				overlay.setVisibility(View.VISIBLE);
@@ -279,7 +280,7 @@ public class AwfulMessage extends AwfulPagedItem {
 						.append("' type='text/javascript'></script>\n");
 			}
 
-			buffer.append("<link rel='stylesheet' href='").append(AwfulUtils.determineCSS(0)).append("'>");
+			buffer.append("<link rel='stylesheet' href='").append(AwfulTheme.forForum(null).getCssPath()).append("'>");
 
 			if(!pref.preferredFont.contains("default")){
 				buffer.append("<style type='text/css'>@font-face { font-family: userselected; src: url('content://com.ferg.awfulapp.webprovider/").append(pref.preferredFont).append("'); }</style>\n");

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -56,6 +56,7 @@ import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.provider.AwfulProvider;
+import com.ferg.awfulapp.provider.AwfulTheme;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.util.AwfulUtils;
 import com.samskivert.mustache.Mustache;
@@ -398,7 +399,7 @@ public class AwfulThread extends AwfulPagedItem  {
 
         // build the link tag, using the custom css path if necessary
         buffer.append("<link rel='stylesheet' href='");
-        buffer.append(AwfulUtils.determineCSS(forumId));
+        buffer.append(AwfulTheme.forForum(forumId).getCssPath());
         buffer.append("'>\n");
         buffer.append("<link rel='stylesheet' href='file:///android_asset/css/general.css' />");
 
@@ -523,21 +524,9 @@ public class AwfulThread extends AwfulPagedItem  {
         Resources resources = current.getResources();
         Context context = current.getContext();
 
-        String ForumName = null;
-        if (prefs.forceForumThemes && ForumDisplayFragment.class.isInstance(parent)) {
-            switch (((ForumDisplayFragment) parent).getForumId()) {
-                case Constants.FORUM_ID_YOSPOS:
-                    ForumName = prefs.amberDefaultPos ? ColorProvider.AMBERPOS : ColorProvider.YOSPOS;
-                    break;
-                case Constants.FORUM_ID_FYAD:
-                case Constants.FORUM_ID_FYAD_SUB:
-                    ForumName = ColorProvider.FYAD;
-                    break;
-                case Constants.FORUM_ID_BYOB:
-                case Constants.FORUM_ID_COOL_CREW:
-                    ForumName = ColorProvider.BYOB;
-                    break;
-            }
+        Integer forumId = null;
+        if (ForumDisplayFragment.class.isInstance(parent)) {
+            forumId = ((ForumDisplayFragment) parent).getForumId();
         }
 
         TextView info   = (TextView) current.findViewById(R.id.thread_info);
@@ -646,18 +635,24 @@ public class AwfulThread extends AwfulPagedItem  {
         } else if (data.getInt(data.getColumnIndex(LOCKED)) > 0){
             //don't show lock if sticky, aka: every rules thread
             threadLocked.setVisibility(View.VISIBLE);
-            current.setBackgroundColor(ColorProvider.getBackgroundColor(ForumName));
+            current.setBackgroundColor(ColorProvider.BACKGROUND.getColor(forumId));
         }
 
         unread.setVisibility(View.GONE);
         if(hasViewedThread) {
             unread.setVisibility(View.VISIBLE);
-            unread.setTextColor(ColorProvider.getUnreadColorFont(ForumName));
+            unread.setTextColor(ColorProvider.UNREAD_TEXT.getColor(forumId));
             unread.setText(Integer.toString(unreadCount));
             GradientDrawable counter = (GradientDrawable) resources.getDrawable(R.drawable.unread_counter);
             if (counter != null) {
                 counter.mutate();
-                counter.setColor(ColorProvider.getUnreadColor(ForumName, unreadCount < 1, bookmarked));
+                boolean dim = unreadCount < 1;
+                if (bookmarked > 0 && prefs.coloredBookmarks) {
+                    counter.setColor(ColorProvider.getBookmarkColor(bookmarked, dim));
+                } else {
+                    ColorProvider colorAttr = dim ? ColorProvider.UNREAD_BACKGROUND_DIM : ColorProvider.UNREAD_BACKGROUND;
+                    counter.setColor(colorAttr.getColor(forumId));
+                }
                 unread.setBackgroundDrawable(counter);
             }
         }
@@ -666,8 +661,8 @@ public class AwfulThread extends AwfulPagedItem  {
         if(titleText != null){
 			title.setText(titleText);
 		}
-        title.setTextColor(ColorProvider.getTextColor(ForumName));
-        info.setTextColor(ColorProvider.getAltTextColor(ForumName));
+        title.setTextColor(ColorProvider.PRIMARY_TEXT.getColor(forumId));
+        info.setTextColor(ColorProvider.ALT_TEXT.getColor(forumId));
 	}
 
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulUtils.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulUtils.java
@@ -1,18 +1,14 @@
 package com.ferg.awfulapp.util;
 
-import android.Manifest;
 import android.content.ContentResolver;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.graphics.Point;
+import android.net.Uri;
 import android.os.Build;
-import android.os.Environment;
-import android.support.v4.content.ContextCompat;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
-import android.widget.Toast;
 
 import com.ToxicBakery.viewpager.transforms.ABaseTransformer;
 import com.ToxicBakery.viewpager.transforms.AccordionTransformer;
@@ -28,7 +24,6 @@ import com.ToxicBakery.viewpager.transforms.TabletTransformer;
 import com.ToxicBakery.viewpager.transforms.ZoomInTransformer;
 import com.ToxicBakery.viewpager.transforms.ZoomOutSlideTransformer;
 import com.ToxicBakery.viewpager.transforms.ZoomOutTranformer;
-import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.provider.AwfulProvider;
@@ -36,12 +31,12 @@ import com.ferg.awfulapp.thread.AwfulEmote;
 import com.ferg.awfulapp.thread.AwfulPost;
 import com.ferg.awfulapp.thread.AwfulThread;
 
-import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 
 /**
  * Created by matt on 9/11/13.
+ * <p>
+ * General utility functions and access to app resources.
  */
 public class AwfulUtils {
 
@@ -85,7 +80,7 @@ public class AwfulUtils {
         return isTablet(cont, false);
     }
 
-    public static double getScreenSizeInInch(Context cont) {
+    private static double getScreenSizeInInch(Context cont) {
         Display display = ((WindowManager) cont.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
         Point size = new Point();
         display.getSize(size);
@@ -128,15 +123,14 @@ public class AwfulUtils {
 
     public static void trimDbEntries(ContentResolver cr) {
         int rowCount = 0;
-        rowCount += cr.delete(AwfulThread.CONTENT_URI, AwfulProvider.UPDATED_TIMESTAMP + " < datetime('now','-7 days')", null);
-        rowCount += cr.delete(AwfulPost.CONTENT_URI, AwfulProvider.UPDATED_TIMESTAMP + " < datetime('now','-7 days')", null);
-        rowCount += cr.delete(AwfulThread.CONTENT_URI_UCP, AwfulProvider.UPDATED_TIMESTAMP + " < datetime('now','-7 days')", null);
-        rowCount += cr.delete(AwfulEmote.CONTENT_URI, AwfulProvider.UPDATED_TIMESTAMP + " < datetime('now','-7 days')", null);
+        for (Uri uri : new Uri[]{AwfulThread.CONTENT_URI, AwfulThread.CONTENT_URI_UCP, AwfulPost.CONTENT_URI, AwfulEmote.CONTENT_URI}) {
+            rowCount += cr.delete(uri, AwfulProvider.UPDATED_TIMESTAMP + " < datetime('now','-7 days')", null);
+        }
         Log.i("AwfulTrimDB", "Trimming DB older than 7 days, culled: " + rowCount);
     }
 
     public static ABaseTransformer getViewPagerTransformer() {
-        HashMap<String, ABaseTransformer> transformerMap = new HashMap<String, ABaseTransformer>();
+        HashMap<String, ABaseTransformer> transformerMap = new HashMap<>();
         transformerMap.put("Disabled", null);
         transformerMap.put("Accordion", new AccordionTransformer());
         transformerMap.put("BackgroundToForeground", new BackgroundToForegroundTransformer());
@@ -156,54 +150,10 @@ public class AwfulUtils {
         return transformerMap.get(AwfulPreferences.getInstance().transformer);
     }
 
-    public static String determineCSS(int forumId) {
-        AwfulPreferences prefs = AwfulPreferences.getInstance();
-        String userTheme = prefs.theme;
 
-        String[] baseThemes = prefs.getContext().getResources().getStringArray(R.array.schemas_values);
-        int[] specialForums = new int[]{Constants.FORUM_ID_YOSPOS, Constants.FORUM_ID_FYAD, Constants.FORUM_ID_FYAD_SUB, Constants.FORUM_ID_BYOB, Constants.FORUM_ID_COOL_CREW};
-
-        if (!(prefs.forceForumThemes && contains(specialForums, forumId)) && !Arrays.asList(baseThemes).contains(userTheme)) {
-            if (AwfulUtils.isMarshmallow()) {
-                File css = new File(Environment.getExternalStorageDirectory() + "/awful/" + userTheme);
-                int permissionCheck = ContextCompat.checkSelfPermission(prefs.getContext(), Manifest.permission.READ_EXTERNAL_STORAGE);
-                if (permissionCheck != PackageManager.PERMISSION_GRANTED || !(css.exists() && css.isFile() && css.canRead())) {
-                    //We don't have permission to get the custom css, but also no time to wait for the user to press a button, so you're shit outta luck
-                    if (userTheme.contains(".dark")) {
-                        userTheme = "dark.css";
-                    } else {
-                        userTheme = "default.css";
-                    }
-                    Toast.makeText(prefs.getContext(), R.string.no_file_permission_theme, Toast.LENGTH_LONG).show();
-                    return "file:///android_asset/css/" + userTheme;
-                }
-            }
-            return "file:///" + Environment.getExternalStorageDirectory() + "/awful/" + userTheme;
-        } else if (prefs.forceForumThemes) {
-            switch (forumId) {
-                case (Constants.FORUM_ID_FYAD):
-                case (Constants.FORUM_ID_FYAD_SUB):
-                    return "file:///android_asset/css/fyad.css";
-                case (Constants.FORUM_ID_BYOB):
-                case (Constants.FORUM_ID_COOL_CREW):
-                    return "file:///android_asset/css/byob.css";
-                case (Constants.FORUM_ID_YOSPOS):
-                    if (prefs.amberDefaultPos) {
-                        return "file:///android_asset/css/amberpos.css";
-                    } else {
-                        return "file:///android_asset/css/yospos.css";
-                    }
-                default:
-                    return "file:///android_asset/css/" + userTheme;
-            }
-        } else {
-            return "file:///android_asset/css/" + userTheme;
-        }
-    }
-
-    public static boolean contains(int[] intArray, int value){
-        for(int cur:intArray){
-            if(cur == value){
+    public static boolean contains(int[] intArray, int value) {
+        for (int cur : intArray) {
+            if (cur == value) {
                 return true;
             }
         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/widget/AwfulProgressBar.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/widget/AwfulProgressBar.java
@@ -32,8 +32,6 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
-import android.graphics.PorterDuff.Mode;
-import android.graphics.PorterDuffXfermode;
 import android.util.AttributeSet;
 import android.view.View;
 
@@ -64,7 +62,7 @@ public class AwfulProgressBar extends View implements AwfulPreferences.AwfulPref
 	
 	private void setPaint(Context context){
 		mProgressColor = new Paint();
-		mProgressColor.setColor(ColorProvider.getProgressbarColor());
+		mProgressColor.setColor(ColorProvider.PROGRESS_BAR.getColor());
 		mClearColor = new Paint();
 		mClearColor.setColor(Color.TRANSPARENT);
 	}

--- a/Awful.apk/src/main/res/layout-sw600dp/private_message_activity.xml
+++ b/Awful.apk/src/main/res/layout-sw600dp/private_message_activity.xml
@@ -56,7 +56,7 @@
                     android:layout_height="48dp"
                     android:layout_centerInParent="true"
                     app:srcCompat="@drawable/frog_silhouette"
-                    android:tint="?attr/listDividerColor"
+                    android:tint="?android:listDivider"
                     tools:ignore="ContentDescription"/>
 
                 <TextView

--- a/Awful.apk/src/main/res/layout/forum_display.xml
+++ b/Awful.apk/src/main/res/layout/forum_display.xml
@@ -25,8 +25,7 @@
             android:id="@+id/forum_list"
             android:layout_width="fill_parent"
             android:layout_height="match_parent"
-            android:cacheColorHint="@color/background"
-            android:divider="?attr/listDividerColor"
+            android:cacheColorHint="@android:color/white"
             android:dividerHeight="1dp"
             tools:listitem="@layout/thread_item" />
     </com.ferg.awfulapp.widget.SwipyRefreshLayout>

--- a/Awful.apk/src/main/res/layout/forum_index_fragment.xml
+++ b/Awful.apk/src/main/res/layout/forum_index_fragment.xml
@@ -31,7 +31,7 @@
                 android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
                 app:srcCompat="@drawable/frog_silhouette"
-                android:tint="?attr/listDividerColor"
+                android:tint="?attr/secondaryPostFontColor"
                 tools:ignore="ContentDescription"/>
 
             <ProgressBar
@@ -57,8 +57,7 @@
             android:id="@+id/forum_index_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:cacheColorHint="@color/background"
-            android:divider="?attr/listDividerColor"
+            android:cacheColorHint="@android:color/white"
             android:dividerHeight="1dp"
             android:drawSelectorOnTop="false"
             android:groupIndicator="@android:color/transparent"

--- a/Awful.apk/src/main/res/layout/forum_index_item.xml
+++ b/Awful.apk/src/main/res/layout/forum_index_item.xml
@@ -41,7 +41,7 @@
             android:layout_height="20dp"
             android:layout_gravity="center"
             android:contentDescription="@string/show_and_hide_subforums"
-            android:tint="?colorAccentThemeFix"
+            android:tint="?primaryPostFontColor"
             android:visibility="visible"
             app:srcCompat="@drawable/ic_expand_more"
             tools:ignore="MissingPrefix"/>
@@ -101,7 +101,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:layout_below="@id/section_title"
-        android:tint="?attr/listDividerColor"
+        android:tint="?android:listDivider"
         app:srcCompat="@drawable/list_divider"
         tools:ignore="ContentDescription,MissingPrefix"/>
 

--- a/Awful.apk/src/main/res/layout/forum_index_subforum_item.xml
+++ b/Awful.apk/src/main/res/layout/forum_index_subforum_item.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:tint="?attr/listDividerColor"
+        android:tint="?android:listDivider"
         app:srcCompat="@drawable/list_divider"
         tools:ignore="ContentDescription,MissingPrefix"/>
 

--- a/Awful.apk/src/main/res/layout/nav_drawer.xml
+++ b/Awful.apk/src/main/res/layout/nav_drawer.xml
@@ -18,7 +18,7 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_gravity="start"
-        android:background="?attr/background"
+        android:background="?attr/navbarMainBackground"
         app:headerLayout="@layout/nav_drawer_header"
         app:menu="@menu/nav_drawer" />
 </android.support.v4.widget.DrawerLayout>

--- a/Awful.apk/src/main/res/layout/nav_drawer_header.xml
+++ b/Awful.apk/src/main/res/layout/nav_drawer_header.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="88dp"
-    android:background="?attr/navbarBackground"
+    android:background="?attr/navbarHeaderBackground"
     android:orientation="vertical">
 
 

--- a/Awful.apk/src/main/res/layout/search_forums_dialog.xml
+++ b/Awful.apk/src/main/res/layout/search_forums_dialog.xml
@@ -15,7 +15,7 @@
         android:layout_gravity="center_horizontal"
         android:background="?attr/colorPrimary"
         android:padding="8dp"
-        android:textColor="@color/actionbar_font_color"
+        android:textColor="?attr/actionBarFontColor"
         android:gravity="center_horizontal" />
 
     <ProgressBar

--- a/Awful.apk/src/main/res/layout/select_action_dialog.xml
+++ b/Awful.apk/src/main/res/layout/select_action_dialog.xml
@@ -21,7 +21,7 @@
         android:id="@+id/actionTitle"
         android:layout_gravity="center_horizontal"
         android:background="?attr/colorPrimary"
-        android:textColor="@color/actionbar_font_color"
+        android:textColor="?attr/actionBarFontColor"
         android:gravity="left"
         android:maxLines="2"
         android:scrollbars = "vertical"

--- a/Awful.apk/src/main/res/layout/thread_item.xml
+++ b/Awful.apk/src/main/res/layout/thread_item.xml
@@ -11,7 +11,7 @@
     android:paddingRight="4dp"
     android:paddingLeft="16dp"
     android:paddingTop="@dimen/material_list_item_vertical_padding"
-    tools:background="@color/background"
+    tools:background="@android:color/white"
     tools:ignore="RtlHardcoded,RtlSymmetry">
 
     <!-- TODO: add better content descriptions in code, e.g. rating number -->

--- a/Awful.apk/src/main/res/values/colors.xml
+++ b/Awful.apk/src/main/res/values/colors.xml
@@ -4,64 +4,36 @@
     <color name="forums_blue_darker">#00537E</color>
     <color name="forums_blue_evendarker">#00314b</color>
     <color name="forums_blue_darkest">#002032</color>
-    <color name="forums_gray">#f4f4f4</color>
     <color name="holo_blue_light">#ff33b5e5</color>
-    
-    <color name="default_post_font">#555555</color>    
-    <color name="forum_title">#484848</color>
+
+    <color name="default_post_font">#555555</color>
     <color name="secondary_post_font">#989898</color>
-    <color name="background">#ffffff</color>
     <color name="alt_background">#dfdfdf</color>
-    <color name="background_read">#ddeeff</color>
-    <color name="font_read">#777777</color>
-    <color name="alt_background_read">#c0e0ff</color>
-    
-    <color name="link_quote">#00c0f4</color>
-    
-    <color name="actionbar_color">#000000</color>
-    <color name="actionbar_font_color">#ffffff</color>
-    
-    <color name="unread_posts">#00659a</color>
-    <color name="unread_posts_dim">#88aabb</color>
-    <color name="unread_posts_counter">#ffffff</color>
-    
-        
-        
+
     <color name="dark_default_post_font">#e7e7e7</color>
     <color name="dark_secondary_post_font">#777777</color>
     <color name="dark_background">#212121</color>
     <color name="dark_alt_background">#333333</color>
     <color name="dark_header_background">#444444</color>
-    <color name="dark_header_font">#ffffff</color>
-    <color name="dark_header_divider">#f4f4f4</color>
-    <color name="dark_op_post">#003366</color>
-    <color name="dark_link_quote">#5463ff</color>
-    <color name="dark_blue">#ff33b5e5</color>
 
-    <color name="oled_background">#000000</color>
-    
     <color name="yospos_default_post_font">#57FF57</color>
-    <color name="yospos_secondary_post_font">#57FF57</color>
-    <color name="yospos_background">#000000</color>
-    <color name="yospos_alt_background">#111111</color>
+    <color name="yospos_secondary_post_font">#008200</color>
+    <color name="yospos_alt_background">#002800</color>
 
     <color name="amberpos_default_post_font">#eacf4c</color>
-    <color name="amberpos_secondary_post_font">#6C6F22</color>
-    <color name="amberpos_background">#000000</color>
-    <color name="amberpos_alt_background">#111111</color>
+    <color name="amberpos_secondary_post_font">#726300</color>
+    <color name="amberpos_alt_background">#2c0f00</color>
 
     <color name="fyad_default_post_font">#006666</color>
     <color name="fyad_secondary_post_font">#999999</color>
     <color name="fyad_background">#FFCCFF</color>
     <color name="fyad_alt_background">#FFCCCC</color>
+    <color name="fyad_hot_pink">#FF80FF</color>
 
     <color name="byob_default_post_font">#006666</color>
     <color name="byob_secondary_post_font">#CCFFFF</color>
     <color name="byob_background">#9999FF</color>
     <color name="byob_alt_background">#CCFFFF</color>
-    
-    <color name="profile_column">#e7eff5</color>
-    <color name="selected_item">#33eeeeee</color>
 
     <color name="bookmark_default">#356693</color>
     <color name="bookmark_orange">#e28d00</color>
@@ -75,6 +47,53 @@
 
     <color name="default_srl_background_color">#FFFAFAFA</color>
 
-    <color name="sidebarOverlay">#99CCCCCC</color>
-    <color name="sidebarOverlay_dark">#99CCCCCC</color>
+
+    <!-- Bookmark colours for stars/unread counters -->
+    <integer-array name="bookmarkColors">
+        <item>@color/bookmark_default</item>
+        <item>@color/bookmark_orange</item>
+        <item>@color/bookmark_red</item>
+        <item>@color/bookmark_yellow</item>
+    </integer-array>
+
+    <integer-array name="bookmarkDimColors">
+        <item>@color/bookmark_default_dim</item>
+        <item>@color/bookmark_orange_dim</item>
+        <item>@color/bookmark_red_dim</item>
+        <item>@color/bookmark_yellow_dim</item>
+    </integer-array>
+
+
+    <!-- Arrays for the spinny progress wheel colours -->
+
+    <integer-array name="defaultSrlProgressColors">
+        <item>@android:color/holo_green_light</item>
+        <item>@android:color/holo_orange_light</item>
+        <item>@android:color/holo_red_light</item>
+        <item>@android:color/holo_blue_bright</item>
+    </integer-array>
+
+    <integer-array name="darkSrlProgressColors">
+        <item>@color/forums_blue_darker</item>
+        <item>@color/forums_blue_evendarker</item>
+    </integer-array>
+
+    <integer-array name="oledSrlProgressColors">
+        <item>@color/dark_default_post_font</item>
+    </integer-array>
+
+    <integer-array name="yosposSrlProgressColors">
+        <item>@android:color/black</item>
+    </integer-array>
+
+    <integer-array name="fyadSrlProgressColors">
+        <item>@color/fyad_default_post_font</item>
+        <item>@color/fyad_secondary_post_font</item>
+    </integer-array>
+
+    <integer-array name="byobSrlProgressColors">
+        <item>@color/byob_secondary_post_font</item>
+        <item>@color/byob_default_post_font</item>
+    </integer-array>
+
 </resources>

--- a/Awful.apk/src/main/res/values/setting_constants.xml
+++ b/Awful.apk/src/main/res/values/setting_constants.xml
@@ -6,16 +6,11 @@
         <item>portrait</item>
         <item>landscape</item>
     </string-array>
-    <string-array name="schemas_values">
+    <!-- Themes are defined in ThemeProvider, this is here as a placeholder to init the list preference -->
+    <string-array name="themes_values">
         <item>default.css</item>
-        <item>dark.css</item>
-        <item>oled.css</item>
-        <item>yospos.css</item>
-        <item>amberpos.css</item>
-        <item>fyad.css</item>
-        <item>byob.css</item>
-        <item>classic.css</item>
     </string-array>
+
     <string-array name="layouts_values">
         <item>default</item>
     </string-array>

--- a/Awful.apk/src/main/res/values/styles.xml
+++ b/Awful.apk/src/main/res/values/styles.xml
@@ -102,7 +102,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:gravity">left</item>
-        <item name="android:textColor">@color/default_post_font</item>
+        <item name="android:textColor">?primaryPostFontColor</item>
     </style>
 
     <style name="ForumListItem.Subforum">
@@ -114,12 +114,12 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:gravity">left</item>
-        <item name="android:textColor">@color/default_post_font</item>
+        <item name="android:textColor">?primaryPostFontColor</item>
         <item name="android:textSize">16sp</item>
     </style>
 
     <style name="ForumListTitle.Subtitle">
-        <item name="android:textColor">@color/secondary_post_font</item>
+        <item name="android:textColor">?secondaryPostFontColor</item>
         <item name="android:textSize">14sp</item>
     </style>
 

--- a/Awful.apk/src/main/res/values/themes.xml
+++ b/Awful.apk/src/main/res/values/themes.xml
@@ -5,6 +5,16 @@
         <item name="android:windowBackground">@drawable/launch_screen</item>
     </style>
 
+    <!--
+    base themes
+
+    Some of these use references to other attributes in the theme, they're intended
+    to cascade to child themes and refer to *their* attributes, so they don't need
+    to be redefined
+    e.g. the Navigation Drawer background uses the theme's alt background, whatever that is,
+    and dark themes set icon colours to the theme's accent colour
+    -->
+
     <style name="Theme.AwfulTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Set AppCompat’s actionBarStyle -->
         <item name="android:windowBackground">@null</item>
@@ -13,27 +23,51 @@
         <item name="colorPrimary">@color/forums_blue</item>
         <item name="colorPrimaryDark">@color/forums_blue_darker</item>
         <item name="colorAccent">@color/holo_blue_light</item>
-        <item name="colorAccentThemeFix">@color/default_post_font</item>
-        <item name="background">@color/background</item>
-        <item name="listDividerColor">@color/alt_background</item>
-        <item name="navbarBackground">@color/forums_blue_darker</item>
-        <item name="navbarUsernameColor">@color/background</item>
+
+        <!-- Main/alternative background and text colours -->
+        <item name="background">@android:color/white</item>
+        <item name="altBackground">?background</item>
+        <item name="primaryPostFontColor">@color/default_post_font</item>
+        <item name="secondaryPostFontColor">@color/secondary_post_font</item>
+
+        <!-- Unread post counters -->
+        <item name="unreadColor">@color/bookmark_default</item>
+        <item name="unreadColorDim">@color/bookmark_default_dim</item>
+        <item name="unreadFontColor">@android:color/white</item>
+
+        <!-- Navigation drawer -->
+        <item name="navbarMainBackground">?altBackground</item>
+        <item name="navbarHeaderBackground">@color/forums_blue_darker</item>
+        <item name="navbarUsernameColor">@android:color/white</item>
+
+        <!-- FAB -->
+        <item name="justPostButtonFontColor">@android:color/white</item>
         <item name="justPostButtonColor">@color/forums_blue</item>
-        <item name="justPostButtonFontColor">@color/background</item>
         <item name="justPostButtonColorPressed">@color/forums_blue_darker</item>
-        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
-        <item name="android:actionOverflowButtonStyle">@style/Base.Widget.AppCompat.ActionButton.Overflow</item>
-        <item name="awfulPopUpTheme">@style/ThemeOverlay.AppCompat.Light</item>
-        <item name="windowActionModeOverlay">true</item>
+
         <!-- icons -->
-        <item name="iconColor">@color/background</item>
+        <item name="iconColor">@android:color/white</item>
         <item name="iconColorDark">@color/secondary_post_font</item>
 
         <!-- bottom sheet -->
         <item name="bottomSheetBackgroundColor">?background</item>
         <item name="bottomSheetItemTextColor">?android:textColorPrimary</item>
 
+        <!-- other stuff -->
+        <item name="actionBarColor">@android:color/black</item>
+        <item name="actionBarFontColor">@android:color/white</item>
+        <item name="progressBarColor">@color/holo_blue_light</item>
+        <item name="srlBackgroundColor">@color/default_srl_background_color</item>
+        <item name="srlProgressColors">@array/defaultSrlProgressColors</item>
+        <item name="android:listDivider">@color/alt_background</item>
+
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+        <item name="android:actionOverflowButtonStyle">@style/Base.Widget.AppCompat.ActionButton.Overflow</item>
+        <item name="awfulPopUpTheme">@style/ThemeOverlay.AppCompat.Light</item>
+        <item name="windowActionModeOverlay">true</item>
+
     </style>
+
 
     <style name="Theme.AwfulTheme.Dark" parent="Theme.AppCompat.NoActionBar">
         <!-- Set AppCompat’s actionBarStyle -->
@@ -42,85 +76,135 @@
         <!-- Set AppCompat’s color theming attrs -->
         <item name="colorPrimary">@color/forums_blue_evendarker</item>
         <item name="colorPrimaryDark">@color/forums_blue_darkest</item>
-        <item name="colorAccent">@color/dark_default_post_font</item>
-        <item name="colorAccentThemeFix">@color/secondary_post_font</item>
+        <item name="colorAccent">?primaryPostFontColor</item>
+
+        <!-- Main/alternative background and text colours -->
         <item name="background">@color/dark_background</item>
-        <item name="listDividerColor">@color/dark_header_background</item>
-        <item name="navbarBackground">@color/dark_alt_background</item>
-        <item name="navbarUsernameColor">@color/secondary_post_font</item>
-        <item name="justPostButtonColor">@color/forums_blue_evendarker</item>
-        <item name="justPostButtonFontColor">@color/dark_default_post_font</item>
+        <item name="altBackground">?background</item>
+        <item name="primaryPostFontColor">@color/dark_default_post_font</item>
+        <item name="secondaryPostFontColor">@color/dark_secondary_post_font</item>
+
+        <!-- Unread post counters -->
+        <item name="unreadColor">@color/bookmark_default</item>
+        <item name="unreadColorDim">@color/bookmark_default_dim</item>
+        <item name="unreadFontColor">@android:color/white</item>
+
+        <!-- Navigation drawer -->
+        <item name="navbarMainBackground">?altBackground</item>
+        <item name="navbarHeaderBackground">@color/dark_alt_background</item>
+        <item name="navbarUsernameColor">?primaryPostFontColor</item>
+
+        <!-- FAB -->
+        <item name="justPostButtonFontColor">?primaryPostFontColor</item>
+        <item name="justPostButtonColor">?colorPrimary</item>
         <item name="justPostButtonColorPressed">@color/forums_blue_darker</item>
-        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
-        <item name="awfulPopUpTheme">@style/ThemeOverlay.AppCompat</item>
-        <item name="windowActionModeOverlay">true</item>
+
         <!-- icons -->
-        <item name="iconColor">@color/dark_default_post_font</item>
-        <item name="iconColorDark">@color/dark_default_post_font</item>
+        <item name="iconColor">?colorAccent</item>
+        <item name="iconColorDark">?colorAccent</item>
 
         <!-- bottom sheet -->
         <item name="bottomSheetBackgroundColor">?background</item>
         <item name="bottomSheetItemTextColor">?android:textColorPrimary</item>
+
+        <!-- other stuff -->
+        <item name="actionBarColor">@android:color/black</item>
+        <item name="actionBarFontColor">?primaryPostFontColor</item>
+        <item name="progressBarColor">@color/holo_blue_light</item>
+        <item name="srlBackgroundColor">@color/dark_alt_background</item>
+        <item name="srlProgressColors">@array/darkSrlProgressColors</item>
+        <item name="android:listDivider">@color/dark_header_background</item>
+
+        <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
+        <item name="awfulPopUpTheme">@style/ThemeOverlay.AppCompat</item>
+        <item name="windowActionModeOverlay">true</item>
+
     </style>
 
+    <!-- OLED-type themes -->
 
     <style name="Theme.AwfulTheme.OLED" parent="Theme.AwfulTheme.Dark">
-        <item name="colorPrimary">@color/oled_background</item>
-        <item name="colorPrimaryDark">@color/oled_background</item>
-        <item name="colorAccent">@color/dark_default_post_font</item>
-        <item name="colorAccentThemeFix">@color/dark_default_post_font</item>
-        <item name="background">@color/oled_background</item>
-        <item name="listDividerColor">@color/dark_header_background</item>
-        <item name="navbarBackground">@color/dark_background</item>
-        <item name="navbarUsernameColor">@color/dark_default_post_font</item>
+        <item name="background">@android:color/black</item>
+
+        <item name="colorPrimary">?background</item>
+        <item name="colorPrimaryDark">?background</item>
+
+        <item name="navbarHeaderBackground">@color/dark_background</item>
+        <item name="srlBackgroundColor">?attr/navbarHeaderBackground</item>
+        <item name="srlProgressColors">@array/oledSrlProgressColors</item>
         <item name="justPostButtonColor">@color/forums_blue_evendarker</item>
-        <item name="justPostButtonFontColor">@color/dark_default_post_font</item>
         <item name="justPostButtonColorPressed">@color/forums_blue_darkest</item>
     </style>
 
+
     <style name="Theme.AwfulTheme.YOSPOS" parent="Theme.AwfulTheme.OLED">
-        <item name="colorAccent">@color/yospos_default_post_font</item>
-        <item name="colorAccentThemeFix">?colorAccent</item>
-        <item name="justPostButtonColor">@color/yospos_default_post_font</item>
-        <item name="justPostButtonFontColor">@color/oled_background</item>
-        <item name="justPostButtonColorPressed">@color/yospos_secondary_post_font</item>
-        <item name="iconColor">@color/yospos_default_post_font</item>
-        <item name="iconColorDark">@color/yospos_default_post_font</item>
-        <item name="android:textColorSecondary">@color/yospos_default_post_font</item>
-        <item name="android:textColorPrimary">@color/yospos_default_post_font</item>
-        <item name="colorControlNormal">@color/yospos_default_post_font</item>
-        <item name="navbarUsernameColor">@color/yospos_default_post_font</item>
+        <item name="primaryPostFontColor">@color/yospos_default_post_font</item>
+        <item name="secondaryPostFontColor">@color/yospos_secondary_post_font</item>
+        <item name="altBackground">@color/yospos_alt_background</item>
+
+        <item name="colorControlNormal">?colorAccent</item>
+
+        <item name="unreadColor">?primaryPostFontColor</item>
+        <item name="unreadColorDim">?secondaryPostFontColor</item>
+        <item name="unreadFontColor">?background</item>
+
+        <item name="actionBarColor">?background</item>
+        <item name="progressBarColor">?primaryPostFontColor</item>
+        <item name="srlBackgroundColor">?primaryPostFontColor</item>
+        <item name="srlProgressColors">@array/yosposSrlProgressColors</item>
+
+        <item name="justPostButtonColor">?colorAccent</item>
+        <item name="justPostButtonFontColor">?background</item>
+        <item name="justPostButtonColorPressed">?secondaryPostFontColor</item>
+
+        <item name="navbarHeaderBackground">?background</item>
+        <item name="android:listDivider">?secondaryPostFontColor</item>
+        <item name="android:textColorSecondary">?primaryPostFontColor</item>
+        <item name="android:textColorPrimary">?primaryPostFontColor</item>
     </style>
 
-    <style name="Theme.AwfulTheme.AMBERPOS" parent="Theme.AwfulTheme.OLED">
-        <item name="colorAccent">@color/amberpos_default_post_font</item>
-        <item name="colorAccentThemeFix">?colorAccent</item>
-        <item name="justPostButtonColor">@color/amberpos_default_post_font</item>
-        <item name="justPostButtonFontColor">@color/oled_background</item>
-        <item name="justPostButtonColorPressed">@color/amberpos_secondary_post_font</item>
-        <item name="iconColor">@color/amberpos_default_post_font</item>
-        <item name="iconColorDark">@color/amberpos_default_post_font</item>
-        <item name="android:textColorSecondary">@color/amberpos_default_post_font</item>
-        <item name="android:textColorPrimary">@color/amberpos_default_post_font</item>
-        <item name="colorControlNormal">@color/amberpos_default_post_font</item>
-        <item name="navbarUsernameColor">@color/amberpos_default_post_font</item>
+
+    <style name="Theme.AwfulTheme.AMBERPOS" parent="Theme.AwfulTheme.YOSPOS">
+        <item name="primaryPostFontColor">@color/amberpos_default_post_font</item>
+        <item name="secondaryPostFontColor">@color/amberpos_secondary_post_font</item>
+        <item name="altBackground">@color/amberpos_alt_background</item>
     </style>
 
-    <style name="Theme.AwfulTheme.BYOB" parent="Theme.AwfulTheme">
+    <!-- Wow pastels -->
+
+    <!-- Base references for the BYOB and FYAD themes-->
+    <style name="Theme.AwfulTheme.Wacky" parent="Theme.AwfulTheme">
+        <item name="unreadColor">?primaryPostFontColor</item>
+        <item name="unreadColorDim">?secondaryPostFontColor</item>
+        <item name="progressBarColor">?background</item>
+        <item name="srlBackgroundColor">?background</item>
+
+        <item name="justPostButtonColor">?background</item>
+        <item name="justPostButtonColorPressed">?altBackground</item>
+        <item name="android:listDivider">?colorAccent</item>
+    </style>
+
+    <style name="Theme.AwfulTheme.BYOB" parent="Theme.AwfulTheme.Wacky">
+        <item name="primaryPostFontColor">@color/byob_default_post_font</item>
+        <item name="secondaryPostFontColor">@color/byob_secondary_post_font</item>
+        <item name="background">@color/byob_background</item>
+        <item name="altBackground">@color/byob_alt_background</item>
+
         <item name="colorAccent">@color/byob_secondary_post_font</item>
-        <item name="colorAccentThemeFix">?colorAccent</item>
-        <item name="justPostButtonColor">@color/byob_background</item>
-        <item name="justPostButtonColorPressed">@color/byob_alt_background</item>
-        <item name="background">@color/byob_alt_background</item>
+        <item name="srlProgressColors">@array/byobSrlProgressColors</item>
     </style>
 
-    <style name="Theme.AwfulTheme.FYAD" parent="Theme.AwfulTheme">
-        <item name="colorAccent">@color/fyad_alt_background</item>
-        <item name="colorAccentThemeFix">@color/forums_blue</item>
-        <item name="justPostButtonColor">@color/fyad_background</item>
-        <item name="justPostButtonColorPressed">@color/fyad_alt_background</item>
-        <item name="background">@color/fyad_alt_background</item>
+
+    <style name="Theme.AwfulTheme.FYAD" parent="Theme.AwfulTheme.Wacky">
+        <item name="primaryPostFontColor">@color/fyad_default_post_font</item>
+        <item name="secondaryPostFontColor">@color/fyad_secondary_post_font</item>
+        <item name="background">@color/fyad_background</item>
+        <item name="altBackground">@color/fyad_alt_background</item>
+
+        <item name="colorAccent">@color/fyad_hot_pink</item>
+        <item name="srlProgressColors">@array/fyadSrlProgressColors</item>
     </style>
+
 
     <style name="DrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
         <item name="spinBars">true</item>

--- a/Awful.apk/src/main/res/values/values.xml
+++ b/Awful.apk/src/main/res/values/values.xml
@@ -1,21 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="navbarBackground" format="color" />
+    <!-- The main text colour for a theme -->
+    <attr name="primaryPostFontColor" format="color"/>
+    <!-- The secondary text colour for a theme -->
+    <attr name="secondaryPostFontColor" format="color"/>
+    <!-- The secondary background colour for a theme -->
+    <attr name="altBackground" format="color"/>
+    <!-- The Navigation Drawer's main background colour -->
+    <attr name="navbarMainBackground" format="color" />
+    <!-- The Navigation Drawer's header background colour -->
+    <attr name="navbarHeaderBackground" format="color" />
+    <!-- The username text colour in the Navigation Drawer's header -->
     <attr name="navbarUsernameColor" format="color" />
+    <!-- Main colour for the Floating Action Button -->
     <attr name="justPostButtonColor" format="color" />
-    <attr name="justPostButtonFontColor" format="color" />
+    <!-- Colour for the Floating Action Button in the 'pressed' state -->
     <attr name="justPostButtonColorPressed" format="color" />
-    <attr name="listDividerColor" format="color" />
-    <!-- this is a hack because some themes (FYAD) have accent colours that are anything but -->
-    <attr name="colorAccentThemeFix" format="color" />
-
+    <!-- The colour of the icon in the Floating Action Button -->
+    <attr name="justPostButtonFontColor" format="color" />
+    <!-- Reference for the app:popupTheme set on Toolbars -->
     <attr name="awfulPopUpTheme" format="reference" />
 
-    <!-- icons -->
+    <!-- The colour tint used for light icons (e.g. for contrast with dark backgrounds) -->
     <attr name="iconColor" format="color" />
+    <!-- The colour tint used for dark icons (e.g. for contrast with light backgrounds) -->
     <attr name="iconColorDark" format="color" />
 
-    <!-- bottom sheet -->
+    <!-- The background colour of bottom sheets -->
     <attr name="bottomSheetBackgroundColor" format="color" />
+    <!-- The text colour used for text labels in bottom sheets -->
     <attr name="bottomSheetItemTextColor" format="color" />
+
+    <!-- Background colour for an unread counter icon -->
+    <attr name="unreadColor" format="color"/>
+    <!-- Dimmed background colour for an unread counter icon, e.g. for zero unread items -->
+    <attr name="unreadColorDim" format="color"/>
+    <!-- Text colour for unread counter numbers -->
+    <attr name="unreadFontColor" format="color"/>
+    <!-- Background colour for the action bar -->
+    <attr name="actionBarColor" format="color"/>
+    <!-- Text colour for the action bar -->
+    <attr name="actionBarFontColor" format="color"/>
+    <!-- Colour for the basic progress bar -->
+    <attr name="progressBarColor" format="color"/>
+    <!-- Background colour for the spinning loading icon -->
+    <attr name="srlBackgroundColor" format="color"/>
+    <!-- Foreground colour for the spinning loading icon. This should point to an array of colour references -->
+    <attr name="srlProgressColors" format="reference" />
 </resources>

--- a/Awful.apk/src/main/res/xml/themesettings.xml
+++ b/Awful.apk/src/main/res/xml/themesettings.xml
@@ -4,7 +4,7 @@
             android:key="@string/pref_key_theme"
             android:title="@string/theme"
             android:entries="@array/theme"
-            android:entryValues="@array/schemas_values"
+            android:entryValues="@array/themes_values"
             android:defaultValue="default.css"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
@@ -24,7 +24,7 @@
             android:key="@string/pref_key_preferred_font"
             android:title="@string/select_font"
             android:entries="@array/theme"
-            android:entryValues="@array/schemas_values"
+            android:entryValues="@array/themes_values"
             android:defaultValue="default"
             />
 </PreferenceScreen>


### PR DESCRIPTION
Created new ThemeProvider enum class to define themes, and provide utility methods for accessing
related resources, defaults etc.
Reworked ColorProvider as an enum class with simplified methods, mapping constants to themed and
default colour attributes instead of a method for each with a switch for each theme.

Themes have been reworked to try and set some basic attributes and define other attributes'
relationships to them, so you can set some standard colours and certain elements will use them
unless the theme overrides it. It's probably still not very consistent and maybe it needs reworking,
but I think it's easier to understand now, once you get that some attributes are defined in a parent.
I cut out a bunch of redundant attributes too

I've also moved the SRL progress spinner colours into arrays, referenced directly by themes,
so they can be customised purely in XML. Bookmark colours too
Also tweaked some themes for more contrast, including some half-bright colours for YOSPOS. I dunno
know if that's canon or an outrage or what

This also fixes some issues where user css files weren't being checked pre-Marshmallow