### PR TITLE
Extract WebView code to new AwfulWebView class and utilities

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -1,0 +1,71 @@
+package com.ferg.awfulapp.webview;
+
+import android.content.Context;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
+import android.util.AttributeSet;
+import android.webkit.WebView;
+
+/**
+ * Created by baka kaba on 21/01/2017.
+ */
+
+public class AwfulWebView extends WebView {
+
+    public static final String TAG = "AwfulWebView";
+
+    public AwfulWebView(Context context) {
+        super(context);
+    }
+
+    public AwfulWebView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public AwfulWebView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public AwfulWebView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+
+    @Override
+    public void onPause() {
+        pauseTimers();
+        super.onPause();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        resumeTimers();
+    }
+
+    /**
+     * Connects a handler to the JavaScript functions added to HTML for threads, posts, messages etc.
+     * <p>
+     * The base {@link WebViewJsInterface} handles some basic functions and preference injection.
+     * If you need to handle other specific stuff (e.g. thread option menus), subclass it and add
+     * the extra JavascriptInterface handler methods to that.
+     *
+     * @param handler an object containing JavaScriptInterface methods to handle JS function calls
+     */
+    public void setJavascriptHandler(@NonNull WebViewJsInterface handler) {
+        addJavascriptInterface(handler, "listener");
+    }
+
+    /**
+     * Calls the javascript function that updates the page HTML from its source.
+     *
+     * @param force if false the page will only update if it's currently blank.
+     */
+    public void refreshPageContents(boolean force) {
+        loadUrl(String.format("javascript:loadPageHtml(%s)", force ? "" : "true"));
+    }
+
+    // TODO: 28/01/2017 Add other common functions, e.g. initialising different 'blank' templates, so fragments don't have to explicitly call loadDataWithBaseUrl(blaaaaa) or whatever
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/LoggingWebChromeClient.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/LoggingWebChromeClient.java
@@ -1,0 +1,51 @@
+package com.ferg.awfulapp.webview;
+
+import android.os.Message;
+import android.support.annotation.CallSuper;
+import android.util.Log;
+import android.webkit.ConsoleMessage;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+
+import static com.ferg.awfulapp.constants.Constants.DEBUG;
+
+/**
+ * Created by baka kaba on 22/01/2017.
+ * <p>
+ * Just a basic WebChromeClient with debug logging.
+ * You can subclass this and override any methods to add specific functionality.
+ */
+
+public class LoggingWebChromeClient extends WebChromeClient {
+
+    private static final String TAG = "WebChromeClient";
+
+    @CallSuper
+    public boolean onConsoleMessage(ConsoleMessage message) {
+        if (DEBUG)
+            Log.d("Web Console", message.message() + " -- From line " + message.lineNumber() + " of " + message.sourceId());
+        return true;
+    }
+
+    @CallSuper
+    @Override
+    public void onCloseWindow(WebView window) {
+        super.onCloseWindow(window);
+        if (DEBUG) Log.d(TAG, "onCloseWindow");
+    }
+
+    @CallSuper
+    @Override
+    public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
+        if (DEBUG)
+            Log.d(TAG, "onCreateWindow" + (isDialog ? " isDialog" : "") + (isUserGesture ? " isUserGesture" : ""));
+        return super.onCreateWindow(view, isDialog, isUserGesture, resultMsg);
+    }
+
+    @CallSuper
+    @Override
+    public boolean onJsTimeout() {
+        if (DEBUG) Log.d(TAG, "onJsTimeout");
+        return super.onJsTimeout();
+    }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewConfig.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewConfig.java
@@ -1,0 +1,114 @@
+package com.ferg.awfulapp.webview;
+
+import android.graphics.Color;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.webkit.WebChromeClient;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+
+import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.util.AwfulUtils;
+
+import static com.ferg.awfulapp.constants.Constants.DEBUG;
+
+/**
+ * Created by baka kaba on 21/01/2017.
+ * <p>
+ * Centralised place for the different webview configurations the app uses.
+ * <p>
+ * This code was all moved from their respective fragments and put here instead.
+ * Call one of these methods to set up a WebView in the same way as before.
+ */
+
+public abstract class WebViewConfig {
+
+    // TODO: 28/01/2017 Everything now uses the 'thread' config, seems to work fine - if there are no issues, delete the old config methods, maybe move all this into AwfulWebView
+
+    /**
+     * Configure a WebView with the original settings from {@link com.ferg.awfulapp.ThreadDisplayFragment}
+     */
+    public static void configureForThread(@NonNull WebView webView) {
+        AwfulPreferences prefs = AwfulPreferences.getInstance();
+        WebSettings webSettings = webView.getSettings();
+        doBasicConfiguration(webSettings, prefs);
+
+        webView.setBackgroundColor(Color.TRANSPARENT);
+        webView.setScrollBarStyle(WebView.SCROLLBARS_OUTSIDE_OVERLAY);
+        webSettings.setJavaScriptEnabled(true);
+
+        // TODO: fix deprecated warnings
+        // TODO: see if we can get the linter to recognise the AwfulUtils version checks as API guards
+
+        if (prefs.inlineYoutube || prefs.inlineWebm || prefs.inlineVines) {//YOUTUBE SUPPORT BLOWS
+            webSettings.setPluginState(WebSettings.PluginState.ON_DEMAND);
+        }
+        if (AwfulUtils.isAtLeast(Build.VERSION_CODES.JELLY_BEAN_MR1) && (prefs.inlineWebm || prefs.inlineVines)) {
+            webSettings.setMediaPlaybackRequiresUserGesture(false);
+        }
+        if (prefs.inlineTweets && AwfulUtils.isJellybean()) {
+            webSettings.setAllowUniversalAccessFromFileURLs(true);
+            webSettings.setAllowFileAccessFromFileURLs(true);
+            webSettings.setAllowFileAccess(true);
+            webSettings.setAllowContentAccess(true);
+        }
+    }
+
+    /**
+     * Perform config common to all the config types.
+     *
+     * @param settings the WebSettings from the WebView being configured
+     */
+    private static void doBasicConfiguration(WebSettings settings, AwfulPreferences prefs) {
+        settings.setRenderPriority(WebSettings.RenderPriority.LOW);
+        settings.setDefaultZoom(WebSettings.ZoomDensity.MEDIUM);
+        settings.setDefaultFontSize(prefs.postFontSizeDip);
+        settings.setDefaultFixedFontSize(prefs.postFixedFontSizeDip);
+        if (AwfulUtils.isLollipop()) {
+            settings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+        }
+
+        if (DEBUG && AwfulUtils.isKitKat()) {
+            WebView.setWebContentsDebuggingEnabled(true);
+        }
+    }
+
+
+    /**
+     * Configure a WebView with the original settings from {@link com.ferg.awfulapp.MessageFragment}
+     */
+    @Deprecated
+    public static void configureForPm(@NonNull WebView webView) {
+        // TODO: 21/01/2017 this is missing a few things from the thread configs, try using those and see if it works ok
+        AwfulPreferences prefs = AwfulPreferences.getInstance();
+        WebSettings settings = webView.getSettings();
+        doBasicConfiguration(settings, prefs);
+    }
+
+    /**
+     * Configure a WebView with the original settings from {@link com.ferg.awfulapp.PreviewFragment}
+     */
+    @Deprecated
+    public static void configureForPostPreview(@NonNull WebView webView) {
+        AwfulPreferences prefs = AwfulPreferences.getInstance();
+        WebSettings settings = webView.getSettings();
+        doBasicConfiguration(settings, prefs);
+
+        webView.setBackgroundColor(Color.TRANSPARENT);
+        webView.setScrollBarStyle(WebView.SCROLLBARS_OUTSIDE_OVERLAY);
+        settings.setJavaScriptEnabled(true);
+        webView.setWebChromeClient(new WebChromeClient());
+
+        if (prefs.inlineYoutube || prefs.inlineWebm || prefs.inlineVines) {//YOUTUBE SUPPORT BLOWS
+            settings.setPluginState(WebSettings.PluginState.ON_DEMAND);
+        }
+        // TODO: 21/01/2017 inlineTweets check to match thread config?
+        if (AwfulUtils.isJellybean()) {
+            settings.setAllowUniversalAccessFromFileURLs(true);
+            settings.setAllowFileAccessFromFileURLs(true);
+            settings.setAllowFileAccess(true);
+            settings.setAllowContentAccess(true);
+        }
+    }
+
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
@@ -1,0 +1,73 @@
+package com.ferg.awfulapp.webview;
+
+import android.support.v4.util.SimpleArrayMap;
+import android.util.Log;
+import android.webkit.JavascriptInterface;
+
+import com.ferg.awfulapp.preferences.AwfulPreferences;
+
+/**
+ * Created by baka kaba on 23/01/2017.
+ * <p>
+ * Basic JavaScript handling for WebViews.
+ * <p>
+ * Subclass this to add handler methods specific to a particular context, e.g. when the WebView will
+ * be used in a {@link com.ferg.awfulapp.ThreadDisplayFragment} and needs to react to other UI clicks.
+ */
+
+public class WebViewJsInterface {
+
+    private static final String TAG = "WebViewJsInterface";
+
+    private final SimpleArrayMap<String, String> preferences = new SimpleArrayMap<>();
+
+    public WebViewJsInterface() {
+        updatePreferences();
+    }
+
+    /**
+     * Updates the JavaScript-accessible preference store from the current values in AwfulPreferences.
+     */
+    public final void updatePreferences() {
+        AwfulPreferences aPrefs = AwfulPreferences.getInstance();
+
+        preferences.clear();
+        preferences.put("username", aPrefs.username);
+        preferences.put("showSpoilers", Boolean.toString(aPrefs.showAllSpoilers));
+        preferences.put("highlightUserQuote", Boolean.toString(aPrefs.highlightUserQuote));
+        preferences.put("highlightUsername", Boolean.toString(aPrefs.highlightUsername));
+        preferences.put("inlineTweets", Boolean.toString(aPrefs.inlineTweets));
+        preferences.put("inlineWebm", Boolean.toString(aPrefs.inlineWebm));
+        preferences.put("autostartWebm", Boolean.toString(aPrefs.autostartWebm));
+        preferences.put("inlineVines", Boolean.toString(aPrefs.inlineVines));
+        preferences.put("disableGifs", Boolean.toString(aPrefs.disableGifs));
+        preferences.put("hideSignatures", Boolean.toString(aPrefs.hideSignatures));
+        preferences.put("disablePullNext", Boolean.toString(aPrefs.disablePullNext));
+
+        setCustomPreferences(preferences);
+    }
+
+    /**
+     * Add any additional JavaScript-accessible preference values to the store.
+     * <p>
+     * Override this to insert and update any additional preferences your webview's JS needs.
+     *
+     * @param preferences the preference store to add to
+     */
+    protected void setCustomPreferences(SimpleArrayMap<String, String> preferences) {
+    }
+
+
+    @JavascriptInterface
+    public String getPreference(String preference) {
+        return preferences.get(preference);
+    }
+
+
+    @JavascriptInterface
+    public void debugMessage(final String msg) {
+        Log.d(TAG, "Awful DEBUG: " + msg);
+    }
+
+    // TODO: 28/01/2017 work out if any other common interface methods can go in here
+}

--- a/Awful.apk/src/main/res/layout-v17/thread_display.xml
+++ b/Awful.apk/src/main/res/layout-v17/thread_display.xml
@@ -29,7 +29,7 @@
         android:layout_below="@+id/thread_userpost_notice"
         app:srl_direction="both">
 
-        <WebView
+        <com.ferg.awfulapp.webview.AwfulWebView
             android:id="@+id/thread"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"/>

--- a/Awful.apk/src/main/res/layout/post_preview.xml
+++ b/Awful.apk/src/main/res/layout/post_preview.xml
@@ -9,7 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <WebView
+        <com.ferg.awfulapp.webview.AwfulWebView
             android:id="@+id/post_pre_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/Awful.apk/src/main/res/layout/private_message_fragment.xml
+++ b/Awful.apk/src/main/res/layout/private_message_fragment.xml
@@ -60,7 +60,7 @@
                 tools:ignore="MissingPrefix"/>
         </RelativeLayout>
 
-        <WebView
+        <com.ferg.awfulapp.webview.AwfulWebView
             android:id="@+id/messagebody"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/Awful.apk/src/main/res/layout/thread_display.xml
+++ b/Awful.apk/src/main/res/layout/thread_display.xml
@@ -36,7 +36,7 @@
             android:layout_height="match_parent"
             app:srl_direction="both">
 
-            <WebView
+            <com.ferg.awfulapp.webview.AwfulWebView
                 android:id="@+id/thread"
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent" />


### PR DESCRIPTION
Pulled out most WebView configuration code into several components:
- an AwfulWebView class with some common methods and lifecycle handling
- a WebViewConfig class that does most of the setup that was previously
  in the containing fragments
- LoggingWebChromeClient, which is the basic client with logging calls,
  previously used in one class but now easy to subclass and drop in anywhere
- WebViewJsInterface, holding common JavascriptInterface-annotated methods

The idea is to get all that stuff out of the fragments holding the webviews,
get the code all in one place, and make the configuration and interaction calls
as minimal as possible.

There are still some changes to make (lots of TODOs),
partly removing some old config code and maybe pushing it all into AwfulWebView
as a generic init call, and partly getting some of the remaining WebView-poking
code out of the fragments (they shouldn't need to make direct load calls with
base URLs and html and charsets and stuff - need simple utility methods for that)