### PR TITLE
Implement Announcements

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -61,6 +61,12 @@
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|keyboardHidden|screenSize"
             />
+        <activity
+            android:name="com.ferg.awfulapp.announcements.AnnouncementsActivity"
+            android:label="@string/announcements"
+            android:windowSoftInputMode="adjustResize"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            />
         <activity 
             android:name="com.ferg.awfulapp.UserCPShortcutActivity"
             android:icon="@mipmap/ic_launcher"

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulApplication.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulApplication.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.crashlytics.android.Crashlytics;
+import com.ferg.awfulapp.announcements.AnnouncementsManager;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
@@ -37,6 +38,7 @@ public class AwfulApplication extends Application implements AwfulPreferences.Aw
         super.onCreate();
 		NetworkUtils.init(this);
 		AndroidThreeTen.init(this);
+		AnnouncementsManager.init(this);
         mPref = AwfulPreferences.getInstance(this, this);
         onPreferenceChange(mPref,null);
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsActivity.java
@@ -1,0 +1,43 @@
+package com.ferg.awfulapp.announcements;
+
+import android.os.Bundle;
+import android.view.MenuItem;
+
+import com.ferg.awfulapp.AwfulActivity;
+import com.ferg.awfulapp.R;
+
+import butterknife.ButterKnife;
+
+/**
+ * Created by baka kaba on 24/01/2017.
+ * <p>
+ * Basic activity that displays announcements.
+ * Doesn't need to exist to be honest, someone make a reusable container activity!
+ */
+
+public class AnnouncementsActivity extends AwfulActivity {
+
+    // TODO: 05/02/2017 this is a toolbar and a fragment, and the fragment is just a webview - refactor that layout into something reusable!
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.announcements_activity);
+        ButterKnife.bind(this);
+        setSupportActionBar(ButterKnife.findById(this, R.id.toolbar));
+        setActionBar();
+        setActionbarTitle(getString(R.string.announcements), null);
+    }
+
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                finish();
+                break;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
@@ -1,0 +1,193 @@
+package com.ferg.awfulapp.announcements;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import com.android.volley.VolleyError;
+import com.ferg.awfulapp.AwfulFragment;
+import com.ferg.awfulapp.R;
+import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.provider.AwfulTheme;
+import com.ferg.awfulapp.task.AnnouncementsRequest;
+import com.ferg.awfulapp.task.AwfulRequest;
+import com.ferg.awfulapp.thread.AwfulPost;
+import com.ferg.awfulapp.thread.AwfulThread;
+import com.ferg.awfulapp.webview.AwfulWebView;
+import com.ferg.awfulapp.webview.WebViewJsInterface;
+
+import java.util.List;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * Created by baka kaba on 05/02/2017.
+ * <p>
+ * Basic fragment that displays announcements.
+ * <p>
+ * This is basically a butchered thread view since that's kind of what the announcements page is.
+ * Most of that happens in the request (not setting certain fields), here we just throw in some
+ * meaningless constants in the {@link AwfulThread#getHtml(List, AwfulPreferences, int, int, int, boolean)}
+ * call, and hope it doesn't break. Seems to work! Fix later!
+ * <p>
+ * Also this also assumes the announcements page won't ever have more than one page.
+ * Whatever it's not even a thread
+ */
+
+public class AnnouncementsFragment extends AwfulFragment {
+
+    @BindView(R.id.announcements_webview)
+    AwfulWebView webView;
+
+    // TODO: 27/01/2017 stick a frog in the background or something while loading
+    private String bodyHtml = "";
+
+    @NonNull
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View view = inflateView(R.layout.announcements_fragment, container, inflater);
+        ButterKnife.bind(this, view);
+
+        initialiseWebView();
+        return view;
+    }
+
+    private void initialiseWebView() {
+        webView.setJavascriptHandler(new WebViewJsInterface() {
+            // TODO: 27/01/2017 work out which of these we can drop, or maybe make special announcements HTML instead of reusing the thread one
+            @JavascriptInterface
+            public String getBodyHtml() {
+                return bodyHtml;
+            }
+
+            @JavascriptInterface
+            public String getCSS() {
+                return AwfulTheme.forForum(null).getCssPath();
+            }
+
+            @JavascriptInterface
+            public String getIgnorePostHtml(String id) {
+                return null;
+            }
+
+            @JavascriptInterface
+            public String getPostJump() {
+                return "";
+            }
+
+            @JavascriptInterface
+            public void loadIgnoredPost(final String ignorePost) {
+            }
+
+            @JavascriptInterface
+            public void haltSwipe() {
+            }
+
+            @JavascriptInterface
+            public void resumeSwipe() {
+            }
+
+        });
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                if (webView != null && !bodyHtml.isEmpty()) {
+                    webView.refreshPageContents(true);
+                }
+            }
+
+            // this lets links open back in the main activity if we handle them (e.g. 'look at this thread'),
+            // and opens them in a browser or whatever if we don't (e.g. 'click here to buy a thing on the site')
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView aView, String url) {
+                Intent intent = new Intent(Intent.ACTION_VIEW);
+                intent.setData(Uri.parse(url));
+                startActivity(intent);
+                return true;
+            }
+        });
+        webView.setContent(AwfulThread.getContainerHtml(mPrefs, -1));
+    }
+
+
+    @Override
+    public void onActivityCreated(Bundle aSavedState) {
+        super.onActivityCreated(aSavedState);
+        showAnnouncements();
+    }
+
+    /**
+     * Fire off the network request to get and show the current announcements.
+     * Not caching these in the DB! Maybe later! Probably not!!
+     */
+    private void showAnnouncements() {
+        Context context = getContext().getApplicationContext();
+        setProgress(25);
+        queueRequest(
+                new AnnouncementsRequest(context).build(this, new AwfulRequest.AwfulResultCallback<List<AwfulPost>>() {
+                    @Override
+                    public void success(List<AwfulPost> result) {
+                        AnnouncementsManager.getInstance().markAllRead();
+                        // these constants don't mean anything in the context of the announcement page
+                        // we just want it to a) display ok, and b) not let the user click anything bad
+                        bodyHtml = AwfulThread.getHtml(result, AwfulPreferences.getInstance(), 1, 1, 0, true);
+                        if (webView != null) {
+                            webView.refreshPageContents(true);
+                        }
+                    }
+
+                    @Override
+                    public void failure(VolleyError error) {
+                        Log.w(TAG, "Announcement get failed!\n" + error.getMessage());
+                        setProgress(100);
+                    }
+                })
+        );
+    }
+
+
+    @Override
+    public String getTitle() {
+        return getString(R.string.announcements);
+    }
+
+
+    @Override
+    public void onPause() {
+        if (webView != null) {
+            webView.onPause();
+        }
+        super.onPause();
+    }
+
+    @Override
+    public void onResume() {
+        if (webView != null) {
+            webView.onResume();
+        }
+        super.onResume();
+    }
+
+    @Override
+    protected boolean doScroll(boolean down) {
+        if (webView == null) {
+            return false;
+        } else if (down) {
+            webView.pageDown(false);
+        } else {
+            webView.pageUp(false);
+        }
+        return true;
+    }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsManager.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsManager.java
@@ -1,0 +1,291 @@
+package com.ferg.awfulapp.announcements;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
+import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.UiThread;
+
+import com.ferg.awfulapp.preferences.AwfulPreferences;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+/**
+ * Created by baka kaba on 25/01/2017.
+ * <p>
+ * Central point for managing and viewing announcements.
+ * <p>
+ * This class parses thread pages (sent from {@link com.ferg.awfulapp.task.ThreadListRequest})
+ * looking for announcements, compares this list to the last set parsed (to determine if any are
+ * new), and stores these as the current announcements. Listeners can register for updates when
+ * a new announcement is parsed.
+ * <p>
+ * {@link #showAnnouncements(Activity)} displays the current announcements and records the last time
+ * the user viewed them. This is used with {@link #getUnreadCount()} to determine how many of the
+ * current announcements were found since the last view.
+ * <p>
+ * I don't really like this system, it feels kind of brittle - if announcements can update (I don't
+ * know if they can) without the title changing, the change won't be spotted. And if a title is
+ * changed it will look like a new announcement. I don't know if either of these are issues, but
+ * that's the drawback. I was going to use the timestamps (which also aren't ideal) but it turns out
+ * they randomly jump around timezones when the page is loaded, which is <i>real nice</i>
+ */
+
+public class AnnouncementsManager {
+
+    // SharedPreference constants for storing state
+    private static final String PREF_KEY_CURRENT_ANNOUNCEMENTS = "CURRENT_ANNOUNCEMENTS";
+    private static final String PREF_KEY_READ_ANNOUNCEMENTS = "READ_ANNOUNCEMENTS";
+
+    private static AnnouncementsManager manager = null;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+
+    @NonNull
+    private final Map<AnnouncementListener, Object> callbacks = Collections.synchronizedMap(new WeakHashMap<AnnouncementListener, Object>());
+
+    /**
+     * Used to synchronize access to current state, i.e. current and unread announcements, and the 'updated from site' flag
+     */
+    private final Object stateLock = new Object();
+    /**
+     * The current announcements marked as read - this is a subset of currentAnnouncements
+     */
+    @NonNull
+    private final Set<String> readAnnouncements = new HashSet<>();
+    private boolean hasUpdatedFromSite = false;
+    /**
+     * The last set of announcements parsed
+     */
+    @NonNull
+    private Set<String> currentAnnouncements = new HashSet<>();
+
+
+    private AnnouncementsManager() {
+    }
+
+    /**
+     * Initialise the AnnouncementsManager singleton, restoring state etc.
+     */
+    public static void init(@NonNull Context context) {
+        if (manager == null) {
+            manager = new AnnouncementsManager();
+            manager.restoreState(context);
+        }
+    }
+
+    /**
+     * Get the AnnouncementsManager singleton instance. You must call {@link #init(Context)} first!
+     */
+    public static AnnouncementsManager getInstance() {
+        if (manager == null) {
+            throw new RuntimeException("AnnouncementsManager needs to be initialised with init() before use!");
+        }
+        return manager;
+    }
+
+
+    /**
+     * Parse a <b>forum page (thread list)</b> to look for announcements.
+     * <p>
+     * <b>IMPORTANT: </b> this treats forum pages as the authority on announcements,
+     * i.e. if there are any announcements they <b>always</b> appear on forum pages, and if there
+     * aren't any present then there are no announcements.
+     * <p>
+     * If you pass in a different kind of page (e.g. the bookmarked thread list) they won't be present,
+     * so the current announcements will be cleared. If you then pass in a forum page, containing
+     * announcements, they'll all be treated as newly posted and trigger a notification.
+     * Forum pages only, thanks!
+     */
+    public void parseForumPage(@NonNull Document page) {
+        Set<String> parsedAnnouncements = new HashSet<>();
+        int newCount = 0;
+        int oldUnreadCount = 0;
+        int oldReadCount = 0;
+        boolean isFirstUpdate;
+        boolean announcementsHaveChanged = false;
+
+        // pull out all the announcement threads - timestamps jump forward and back in time at random so we'll have to ID by title
+        Elements announcementElements = page.select("#forum a.announcement");
+        synchronized (stateLock) {
+            for (Element announcement : announcementElements) {
+                // build a list of announcement titles, checking if they're known or new, and counting each type
+                String title = announcement.text();
+                parsedAnnouncements.add(title);
+                if (readAnnouncements.contains(title)) {
+                    oldReadCount++;
+                } else if (currentAnnouncements.contains(title)) {
+                    oldUnreadCount++;
+                } else {
+                    newCount++;
+                }
+            }
+
+            // store the announcements we parsed, forget any read announcements that no longer exist
+            // only doing this if something's changed, to avoid unnecessary work
+            if (currentAnnouncements != parsedAnnouncements) {
+                announcementsHaveChanged = true;
+                currentAnnouncements = parsedAnnouncements;
+                readAnnouncements.retainAll(currentAnnouncements);
+                saveState();
+            }
+
+            isFirstUpdate = !hasUpdatedFromSite;
+            hasUpdatedFromSite = true;
+        }
+
+        // notify about any changes
+        if (isFirstUpdate || announcementsHaveChanged) {
+            publishState(newCount, oldUnreadCount, oldReadCount, isFirstUpdate);
+        }
+    }
+
+
+    /**
+     * Publish an announcement state update to all listeners.
+     * <p>
+     * This provides each listener with the latest counts for each announcement type.
+     * See {@link AnnouncementListener#onAnnouncementsUpdated(int, int, int, boolean)}
+     * for details on isFirstUpdate
+     *
+     * @param newCount       the number of new, previously unseen messages found
+     * @param oldUnreadCount the number of old unread messages (i.e. excluding new)
+     * @param oldReadCount   the number of previously read messages
+     * @param isFirstUpdate  true if this is the first update from the site for this app session
+     */
+    private void publishState(int newCount, int oldUnreadCount, int oldReadCount, boolean isFirstUpdate) {
+        for (AnnouncementListener listener : callbacks.keySet()) {
+            handler.post(() -> listener.onAnnouncementsUpdated(newCount, oldUnreadCount, oldReadCount, isFirstUpdate));
+        }
+    }
+
+
+    /**
+     * Register a listener for new announcement updates.
+     * <p/>
+     * Only holds a weak reference, so keep your own reference if necessary.
+     */
+    public void registerListener(@NonNull AnnouncementListener listener) {
+        callbacks.put(listener, new Object());
+    }
+
+
+    /**
+     * The number of currently unread announcements.
+     * <p>
+     * This is the unread total, i.e. those found since the user last viewed the announcements page.
+     */
+    public int getUnreadCount() {
+        synchronized (stateLock) {
+            // readAnnouncements is always a subset of currentAnnouncements
+            return currentAnnouncements.size() - readAnnouncements.size();
+        }
+    }
+
+
+    /**
+     * Launch the Announcements activity.
+     *
+     * @param activity used to launch the new activity
+     */
+    public void showAnnouncements(@NonNull Activity activity) {
+        activity.startActivity(new Intent().setClass(activity.getApplicationContext(), AnnouncementsActivity.class));
+    }
+
+
+    /**
+     * Set all current announcements as read.
+     * <p>
+     * Call this when they've successfully been displayed. If a new announcement appears after this manager's
+     * latest update, and the user views it, this method won't be aware of the announcement and it will
+     * appear as a new, unread announcement on the next parse. Not ideal but it's the best we can really do
+     * right now, and it shouldn't come up much.
+     */
+    void markAllRead() {
+        int totalRead;
+        synchronized (stateLock) {
+            readAnnouncements.clear();
+            readAnnouncements.addAll(currentAnnouncements);
+            totalRead = readAnnouncements.size();
+            saveState();
+        }
+        publishState(0, 0, totalRead, false);
+    }
+
+
+    /**
+     * Persist the current announcement data, so it can be restored on app reload.
+     */
+    private void saveState() {
+        Context context = AwfulPreferences.getInstance().getContext();
+        SharedPreferences.Editor appState = PreferenceManager.getDefaultSharedPreferences(context).edit();
+        synchronized (stateLock) {
+            appState.putStringSet(PREF_KEY_CURRENT_ANNOUNCEMENTS, currentAnnouncements)
+                    .putStringSet(PREF_KEY_READ_ANNOUNCEMENTS, readAnnouncements);
+            appState.apply();
+        }
+    }
+
+
+    /**
+     * Restore saved announcement data, if it hasn't already been done.
+     * <p>
+     * This loads the persisted state written by {@link #saveState()}, and should be called as early
+     * as possible to retain the last-known state and update on top of that.
+     */
+    private void restoreState(@NonNull Context context) {
+        SharedPreferences appState = PreferenceManager.getDefaultSharedPreferences(context);
+        synchronized (stateLock) {
+            // can't just use the returned sets apparently!
+            currentAnnouncements.clear();
+            readAnnouncements.clear();
+            currentAnnouncements.addAll(appState.getStringSet(PREF_KEY_CURRENT_ANNOUNCEMENTS, Collections.emptySet()));
+            readAnnouncements.addAll(appState.getStringSet(PREF_KEY_READ_ANNOUNCEMENTS, Collections.emptySet()));
+        }
+    }
+
+
+    /**
+     * Wipes all stored announcement data
+     */
+    public void clearState() {
+        synchronized (stateLock) {
+            currentAnnouncements.clear();
+            readAnnouncements.clear();
+            saveState();
+        }
+    }
+
+
+    public interface AnnouncementListener {
+        /**
+         * Called when the known announcement state changes
+         * <p>
+         * 'New' means a previously unseen announcement link, or one that appears to have updated.
+         * On the next parse it will be treated as an 'old' announcement, so newCount
+         * should be treated as a notification that some new announcements have been found.
+         * <p>
+         * The isFirstUpdate flag is set to true for the first update from the site following an
+         * app restart. This lets listeners handle the initial state report differently from other
+         * updates (e.g. displaying an information popup when the app is first opened)
+         *
+         * @param newCount      the number of newly found announcements
+         * @param oldUnread     the number of old, unread announcements
+         * @param oldRead       the number of old, previously read announcements
+         * @param isFirstUpdate true if this is the initial update from the site
+         */
+        @UiThread
+        void onAnnouncementsUpdated(int newCount, int oldUnread, int oldRead, boolean isFirstUpdate);
+    }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AnnouncementsRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AnnouncementsRequest.java
@@ -1,0 +1,118 @@
+package com.ferg.awfulapp.task;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.thread.AwfulPost;
+import com.ferg.awfulapp.util.AwfulError;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.ferg.awfulapp.thread.AwfulPost.tryConvertToHttps;
+
+/**
+ * Created by baka kaba on 24/01/2017.
+ * <p>
+ * Request to load announcements and parse them as AwfulPosts.
+ *
+ * This performs no database caching!
+ *
+ * Announcements are like a weird variation on posts in a thread, as such they only have a few
+ * of the usual page elements, and only a few properties set in AwfulPost.
+ */
+
+public class AnnouncementsRequest extends AwfulRequest<List<AwfulPost>> {
+
+    public AnnouncementsRequest(Context context) {
+        super(context, null);
+    }
+
+    @NonNull
+    private static List<AwfulPost> parseAnnouncement(@NonNull Document aThread) {
+        List<AwfulPost> results = new ArrayList<>();
+        AwfulPreferences prefs = AwfulPreferences.getInstance();
+
+        // grab all the main announcement sections - these contain *most* of the data we need :/
+        Elements mainAnnouncements = aThread.select("#main_full  tr[valign='top']");
+        Log.d(TAG, "parseAnnouncement: found" + mainAnnouncements.size() + " announcements");
+        for (Element announcementSection : mainAnnouncements) {
+            AwfulPost announcement = new AwfulPost();
+
+            Element author = announcementSection.select(".author").first();
+            if (author != null) {
+                announcement.setUsername(author.text());
+            }
+
+            Element regDate = announcementSection.select(".registered").first();
+            if (regDate != null) {
+                announcement.setRegDate(regDate.text());
+            }
+
+            Element avatar = announcementSection.select(".title img").first();
+            if (avatar != null) {
+                tryConvertToHttps(avatar);
+                announcement.setAvatar(avatar.attr("src"));
+            }
+
+            // not sure if this ever appears for announcements but whatever, may as well
+            Element editedBy = announcementSection.select(".editedby").first();
+            if (editedBy != null) {
+                announcement.setEdited("<i>" + editedBy.text() + "</i>");
+            }
+
+            // announcements have their post date in a whole other section directly after the announcement section
+            Element postDateSection = announcementSection.nextElementSibling();
+            if (postDateSection != null) {
+                Element postDate = postDateSection.select(".postdate").first();
+                if (postDate != null) {
+                    announcement.setDate(postDate.text());
+                }
+            }
+
+
+            Element postBody = announcementSection.select(".postbody").first();
+            if (postBody != null) {
+                // process videos, images and links and store the resulting post HTML
+                AwfulPost.convertVideos(postBody, prefs.inlineYoutube);
+                for (Element image : postBody.getElementsByTag("img")) {
+                    AwfulPost.processPostImage(image, false, prefs);
+                }
+                for (Element link : postBody.getElementsByTag("a")) {
+                    tryConvertToHttps(link);
+                }
+                announcement.setContent(postBody.html());
+            }
+            // I guess this is important...?
+            announcement.setEditable(false);
+            results.add(announcement);
+            Log.i(TAG, Integer.toString(mainAnnouncements.size()) + " posts found, " + results.size() + " posts parsed.");
+        }
+        return results;
+    }
+
+
+    @Override
+    protected String generateUrl(Uri.Builder urlBuilder) {
+        return "https://forums.somethingawful.com/announcement.php?forumid=1";
+    }
+
+    @Override
+    protected List<AwfulPost> handleResponse(Document doc) throws AwfulError {
+        return parseAnnouncement(doc);
+    }
+
+    @Override
+    protected boolean handleError(AwfulError error, Document doc) {
+        Log.d(TAG, "handleError: " + error.getMessage() + "\n" + error.getSubMessage());
+        return error.isCritical();
+    }
+
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
@@ -3,6 +3,7 @@ package com.ferg.awfulapp.task;
 import android.content.Context;
 import android.net.Uri;
 
+import com.ferg.awfulapp.announcements.AnnouncementsManager;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.messages.PmManager;
 import com.ferg.awfulapp.thread.AwfulForum;
@@ -52,6 +53,7 @@ public class ThreadListRequest extends AwfulRequest<Void> {
                 PmManager.parseUcpPage(doc);
             }else{
                 AwfulForum.parseThreads(doc, forumId, page, getContentResolver());
+                AnnouncementsManager.getInstance().parseForumPage(doc);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -75,6 +75,7 @@ import java.io.Reader;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -418,7 +419,7 @@ public class AwfulThread extends AwfulPagedItem  {
         return buffer.toString();
     }
 
-    public static String getHtml(ArrayList<AwfulPost> aPosts, AwfulPreferences aPrefs, int page, int lastPage, int forumId, boolean threadLocked) {
+    public static String getHtml(List<AwfulPost> aPosts, AwfulPreferences aPrefs, int page, int lastPage, int forumId, boolean threadLocked) {
         StringBuilder buffer = new StringBuilder(1024);
         buffer.append("<div class='content'>\n");
 
@@ -450,7 +451,7 @@ public class AwfulThread extends AwfulPagedItem  {
         return buffer.toString();
     }
 
-    public static String getPostsHtml(ArrayList<AwfulPost> aPosts, AwfulPreferences aPrefs, boolean threadLocked) {
+    public static String getPostsHtml(List<AwfulPost> aPosts, AwfulPreferences aPrefs, boolean threadLocked) {
         StringBuilder buffer = new StringBuilder();
         Template postTemplate;
 

--- a/Awful.apk/src/main/res/layout/announcements_activity.xml
+++ b/Awful.apk/src/main/res/layout/announcements_activity.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:background="?attr/background"
+              android:orientation="vertical">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ToolBarStyle"
+        app:elevation="4dp"
+        app:popupTheme="?attr/awfulPopUpTheme"
+        />
+
+    <fragment
+        android:id="@+id/announcements_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:name="com.ferg.awfulapp.announcements.AnnouncementsFragment"
+        tools:layout="@layout/announcements_fragment"/>
+</LinearLayout>

--- a/Awful.apk/src/main/res/layout/announcements_fragment.xml
+++ b/Awful.apk/src/main/res/layout/announcements_fragment.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:background="?attr/background"
+              android:orientation="vertical">
+
+    <com.ferg.awfulapp.widget.AwfulProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="fill_parent"
+        android:layout_height="4dp"
+        android:visibility="gone"/>
+
+    <com.ferg.awfulapp.webview.AwfulWebView
+        android:id="@+id/announcements_webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</LinearLayout>

--- a/Awful.apk/src/main/res/menu/nav_drawer.xml
+++ b/Awful.apk/src/main/res/menu/nav_drawer.xml
@@ -25,6 +25,10 @@
             android:icon="@drawable/ic_mail_dark"
             android:title="@string/private_message" />
         <item
+            android:id="@+id/sidebar_announcements"
+            android:icon="@drawable/ic_error"
+            android:title="@string/announcements" />
+        <item
             android:id="@+id/sidebar_settings"
             android:icon="@drawable/ic_settings_dark"
             android:title="@string/settings" />

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -18,11 +18,22 @@
     <string name="toggle_folder">Toggle mail folder</string>
     <string name="select_message">Open a message or create a new one</string>
 
+    <plurals name="numberOfNewAnnouncements">
+        <item quantity="one">%d new announcement</item>
+        <item quantity="other">%d new announcements</item>
+    </plurals>
+
+    <plurals name="numberOfOldUnreadAnnouncements">
+        <item quantity="one">%d unread announcement</item>
+        <item quantity="other">%d unread announcements</item>
+    </plurals>
+
+
     <!-- Sidebar-->
     <string name="drawer_open">Open</string>
     <string name="drawer_close">Close</string>
-
     <string name="drawer_title">The SA Forums</string>
+    <string name="announcements">Announcements</string>
     <!-- sort THIS out -->
     <string name="usercp">Bookmarks</string>
     <string name="user_cp">Bookmarks</string>


### PR DESCRIPTION
Added some components to parse thread lists for announcements, keep a record of which
have been seen and viewed (for notifications and unread counts), and display
the current announcements in a fragment.

This is basically the same idea as the PM manager - thread lists are where announcements
are listed, so whenever a thread list is parsed, run it through the announcement manager
so it can pull out the necessary info. The manager informs listeners when something
important happens, e.g. first live update this session, or whenever the announcement list
changes. It also has methods to get the current unread count, display the current announcements,
and mark them all as read.

The announcements page currently reuses AwfulPosts and the thread HTML (even though
announcements are structurally different), and loads them directly from the site without
caching any in the DB. Hopefully this works well enough!

Also did some refactoring to make code reuse easier