### PR TITLE
Clean up WebView config and tweak JsInterface

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -55,7 +55,6 @@ import android.support.v4.app.LoaderManager;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.content.Loader;
-import android.support.v4.util.SimpleArrayMap;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.ShareActionProvider;
 import android.text.TextUtils;
@@ -119,6 +118,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Uses intent extras:
@@ -1097,7 +1097,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
 
 		@Override
-		protected void setCustomPreferences(SimpleArrayMap<String, String> preferences) {
+		protected void setCustomPreferences(Map<String, String> preferences) {
 			// TODO: 23/01/2017 add methods so you can't mess with the map directly
 			preferences.put("postjumpid", mPostJump);
 			preferences.put("scrollPosition", Integer.toString(savedScrollPosition));

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -70,35 +70,32 @@ public class AwfulWebView extends WebView {
     private void init() {
         AwfulPreferences prefs = AwfulPreferences.getInstance();
         WebSettings webSettings = getSettings();
-        webSettings.setRenderPriority(WebSettings.RenderPriority.LOW);
-        webSettings.setDefaultZoom(WebSettings.ZoomDensity.MEDIUM);
-        webSettings.setDefaultFontSize(prefs.postFontSizeDip);
-        webSettings.setDefaultFixedFontSize(prefs.postFixedFontSizeDip);
-        if (AwfulUtils.isLollipop()) {
-            webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
-        }
-
-        if (DEBUG && AwfulUtils.isKitKat()) {
-            WebView.setWebContentsDebuggingEnabled(true);
-        }
+        setWebChromeClient(new LoggingWebChromeClient());
 
         setBackgroundColor(Color.TRANSPARENT);
         setScrollBarStyle(WebView.SCROLLBARS_OUTSIDE_OVERLAY);
         webSettings.setJavaScriptEnabled(true);
-        setWebChromeClient(new LoggingWebChromeClient());
+        webSettings.setDefaultFontSize(prefs.postFontSizeDip);
+        webSettings.setDefaultFixedFontSize(prefs.postFixedFontSizeDip);
 
-        // TODO: fix deprecated warnings
-        // TODO: see if we can get the linter to recognise the AwfulUtils version checks as API guards
-
-        if (prefs.inlineYoutube || prefs.inlineWebm || prefs.inlineVines) {//YOUTUBE SUPPORT BLOWS
-            webSettings.setPluginState(WebSettings.PluginState.ON_DEMAND);
+        if (AwfulUtils.isLollipop()) {
+            //noinspection AndroidLintNewApi, AndroidLintInlinedApi
+            webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
         }
+
+        if (DEBUG && AwfulUtils.isKitKat()) {
+            //noinspection AndroidLintNewApi
+            WebView.setWebContentsDebuggingEnabled(true);
+        }
+
         if (AwfulUtils.isAtLeast(Build.VERSION_CODES.JELLY_BEAN_MR1) && (prefs.inlineWebm || prefs.inlineVines)) {
+            //noinspection AndroidLintNewApi
             webSettings.setMediaPlaybackRequiresUserGesture(false);
         }
+
         if (prefs.inlineTweets && AwfulUtils.isJellybean()) {
+            //noinspection AndroidLintNewApi
             webSettings.setAllowUniversalAccessFromFileURLs(true);
-            webSettings.setAllowFileAccessFromFileURLs(true);
             webSettings.setAllowFileAccess(true);
             webSettings.setAllowContentAccess(true);
         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
@@ -1,10 +1,13 @@
 package com.ferg.awfulapp.webview;
 
-import android.support.v4.util.SimpleArrayMap;
+import android.support.annotation.WorkerThread;
 import android.util.Log;
 import android.webkit.JavascriptInterface;
 
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by baka kaba on 23/01/2017.
@@ -14,12 +17,13 @@ import com.ferg.awfulapp.preferences.AwfulPreferences;
  * Subclass this to add handler methods specific to a particular context, e.g. when the WebView will
  * be used in a {@link com.ferg.awfulapp.ThreadDisplayFragment} and needs to react to other UI clicks.
  */
-
+// TODO: 12/02/2017 JS interface methods are called on a separate thread apparently - none of our implementations are thread-safe at all
+@WorkerThread
 public class WebViewJsInterface {
 
     private static final String TAG = "WebViewJsInterface";
 
-    private final SimpleArrayMap<String, String> preferences = new SimpleArrayMap<>();
+    private final Map<String, String> preferences = new ConcurrentHashMap<>();
 
     public WebViewJsInterface() {
         updatePreferences();
@@ -54,7 +58,7 @@ public class WebViewJsInterface {
      *
      * @param preferences the preference store to add to
      */
-    protected void setCustomPreferences(SimpleArrayMap<String, String> preferences) {
+    protected void setCustomPreferences(Map<String, String> preferences) {
     }
 
 


### PR DESCRIPTION
Removed some obsolete calls in AwfulWebView, cleaned up lint API complaints

JS interface methods need to be thread-safe, moved to a ConcurrentHashMap. Implementing classes
still need fixing though!
e.g. ThreadDisplayFragment's interface methods reference a lot of member variables, there's no
synchronisation on any of them. Probably need to clean the class up a bit first though