### PR TITLE
Check for PMs and announcements on sync

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsManager.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsManager.java
@@ -1,14 +1,22 @@
 package com.ferg.awfulapp.announcements;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.UiThread;
+import android.util.Log;
+import android.widget.Toast;
 
+import com.android.volley.VolleyError;
 import com.ferg.awfulapp.AwfulApplication;
+import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.network.NetworkUtils;
+import com.ferg.awfulapp.task.AwfulRequest;
+import com.ferg.awfulapp.task.ThreadListRequest;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -262,6 +270,29 @@ public class AnnouncementsManager {
             readAnnouncements.clear();
             saveState();
         }
+    }
+
+
+    /**
+     * Check the site to update the current Announcement status
+     */
+    public static void updateAnnouncements(@NonNull Context context) {
+        // loading any forum will trigger an announcement parse - SH/SC is *probably* a stable ID, unlike say GBS
+        NetworkUtils.queueRequest(new ThreadListRequest(context, Constants.FORUM_ID_SHSC, 1).build(null, new AwfulRequest.AwfulResultCallback<Void>() {
+            @Override
+            public void success(Void result) {
+
+            }
+
+            @Override
+            public void failure(VolleyError error) {
+                String message = "Couldn't update announcements:\n" + error.getMessage();
+                if (Constants.DEBUG) {
+                    Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+                }
+                Log.w(AnnouncementsManager.class.getSimpleName(), message);
+            }
+        }));
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
@@ -197,6 +197,7 @@ public class Constants {
     public static final String REPLY_THREAD_ID = "reply_thread_id";
     
     public static final int AWFUL_THREAD_ID = 3571717;
+    public static final int FORUM_ID_SHSC = 22;
     public static final int FORUM_ID_YOSPOS = 219;
     public static final int FORUM_ID_FYAD = 26;
     public static final int FORUM_ID_FYAD_SUB = 154;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/messages/PmManager.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/messages/PmManager.java
@@ -1,8 +1,13 @@
 package com.ferg.awfulapp.messages;
 
+import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
+
+import com.ferg.awfulapp.constants.Constants;
+import com.ferg.awfulapp.network.NetworkUtils;
+import com.ferg.awfulapp.task.ThreadListRequest;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
@@ -66,6 +71,15 @@ public class PmManager {
      */
     public static void registerListener(@NonNull Listener listener) {
         callbacks.put(listener, new Object());
+    }
+
+
+    /**
+     * Check the site to update the current PM status
+     */
+    public static void updatePms(@NonNull Context context) {
+        // just need to load the user's bookmarks page to trigger a parse
+        NetworkUtils.queueRequest(new ThreadListRequest(context, Constants.USERCP_ID, 1).build());
     }
 
 


### PR DESCRIPTION
Added checks for those so they can notify the user on app start.
They're handled whenever the user loads a page with one of those notification links -
the bookmarks page for PMs, and an actual forum page (with the thread list) for announcements.

That's not great if the user doesn't visit one of those pages, so now those pages are loaded on sync
to trigger an update