### PR TITLE
Reply rework

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostReplyActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostReplyActivity.java
@@ -1,18 +1,18 @@
 /********************************************************************************
  * Copyright (c) 2011, Scott Ferguson
  * All rights reserved.
- * 
+ * <p>
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the software nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- * 
+ * * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * * Neither the name of the software nor the
+ * names of its contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ * <p>
  * THIS SOFTWARE IS PROVIDED BY SCOTT FERGUSON ''AS IS'' AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -28,23 +28,31 @@
 package com.ferg.awfulapp;
 
 import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
 
 
 public class PostReplyActivity extends AwfulActivity {
 
-    private Toolbar mToolbar;
+    @BindView(R.id.toolbar)
+    Toolbar mToolbar;
+    PostReplyFragment replyFragment;
 
     @Override
-    public void onCreate(Bundle savedInstanceState)
-    {
+    public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.post_reply_activity);
+        ButterKnife.bind(this);
 
-        mToolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(mToolbar);
         setActionBar();
+
+        FragmentManager fm = getSupportFragmentManager();
+        replyFragment = (PostReplyFragment) fm.findFragmentById(R.id.reply_fragment);
     }
 
     @Override
@@ -56,11 +64,18 @@ public class PostReplyActivity extends AwfulActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                finish();
+                onLeaveActivity();
                 break;
         }
-
         return super.onOptionsItemSelected(item);
     }
-	
+
+    @Override
+    public void onBackPressed() {
+        onLeaveActivity();
+    }
+
+    private void onLeaveActivity() {
+        replyFragment.onNavigateBack();
+    }
 }

--- a/Awful.apk/src/main/res/menu/post_reply.xml
+++ b/Awful.apk/src/main/res/menu/post_reply.xml
@@ -9,23 +9,6 @@
         android:orderInCategory="99999"
         app:showAsAction="always"/>
     <item
-        android:id="@+id/save_draft"
-        android:title="@string/menu_save_draft"
-        app:showAsAction="never|withText">
-    </item>
-    <item
-        android:id="@+id/discard"
-        android:icon="@drawable/ic_error_dark"
-        android:title="@string/menu_discard"
-        app:showAsAction="never|withText">
-    </item>
-    <item
-        android:id="@+id/preview"
-        android:icon="@drawable/ic_preview"
-        android:title="@string/menu_preview"
-        app:showAsAction="never|withText">
-    </item>
-    <item
         android:id="@+id/signature"
         android:checkable="true"
         android:title="@string/signature"

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -106,9 +106,9 @@
     <string name="filter_emote_hint">Filter emotes…</string>
     <string name="bbcode">BBCode</string>
     <string name="submit">Submit</string>
-    <string name="menu_preview">Preview post</string>
-    <string name="menu_save_draft">Save draft</string>
-    <string name="menu_discard">Discard</string>
+    <string name="preview">Preview</string>
+    <string name="save">Save</string>
+    <string name="discard">Discard</string>
     <string name="signature">Show Signature</string>
     <string name="disableEmots">Disable Smilies in This Post</string>
     <string name="add_attachment">Add file attachment</string>


### PR DESCRIPTION
Some tweaks and fixes for the Reply view:

- save/discard is a forced choice when the user cancels a reply
- automatically saves in onPause (avoids losing replies when the app is in the background etc)
- preview is now an option on the Confirm Submit dialog
- reorganised methods to try and make it easier to read, added documentation
- simplified/encapsulated some state
- some code fixes to try and avoid problems (e.g. activity-dependent code into onActivityCreated)