### PR TITLE
Add Crashlytics logging for issue #717, and Crashlytics init flag

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulApplication.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulApplication.java
@@ -34,6 +34,7 @@ public class AwfulApplication extends Application implements AwfulPreferences.Aw
 	 * Used for storing misc app data, separate from user preferences, so onPreferenceChange callbacks aren't triggered
 	 */
 	private static SharedPreferences appStatePrefs;
+    private static boolean crashlyticsEnabled = false;
 
 	private AwfulPreferences mPref;
 	private final HashMap<String, Typeface> fonts = new HashMap<>();
@@ -61,8 +62,10 @@ public class AwfulApplication extends Application implements AwfulPreferences.Aw
 			e.printStackTrace();
 		}
 		Log.i(TAG, String.format("App installed %d hours ago", hoursSinceInstall));
+
 		// enable Crashlytics on non-debug builds, or debug builds that have been installed for a while
-		if (!Constants.DEBUG || hoursSinceInstall > 4) {
+		crashlyticsEnabled = !Constants.DEBUG || hoursSinceInstall > 4;
+        if (crashlyticsEnabled) {
 			Fabric.with(this, new Crashlytics());
 			if(mPref.sendUsernameInReport){
 				Crashlytics.setUserName(mPref.username);
@@ -84,6 +87,14 @@ public class AwfulApplication extends Application implements AwfulPreferences.Aw
 		}
 
 		SyncManager.sync(this);
+    }
+
+
+    /**
+     * Returns true if the Crashlytics singleton has been initialised and can be used.
+     */
+    public static boolean crashlyticsEnabled() {
+        return crashlyticsEnabled;
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -43,6 +43,7 @@ import android.database.Cursor;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -50,6 +51,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.content.ContextCompat;
@@ -77,6 +79,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.android.volley.VolleyError;
+import com.crashlytics.android.Crashlytics;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
@@ -1191,6 +1194,30 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 			isGif = StringUtils.contains(lastSegment, ".gif")
 					&& !StringUtils.contains(lastSegment, ".gifv");
 		}
+
+		////////////////////////////////////////////////////////////////////////
+        // TODO: 28/04/2017 remove all this when Crashlytics #717 is fixed
+		if (AwfulApplication.crashlyticsEnabled()) {
+			Crashlytics.setString("Menu for URL:", url);
+			Crashlytics.setInt("Thread ID", getThreadId());
+			Crashlytics.setInt("Page", getPage());
+
+			FragmentActivity activity = getActivity();
+			Crashlytics.setBool("Activity exists", activity != null);
+			if (activity != null) {
+				String state = "Activity:";
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+					state += (activity.isDestroyed()) ? "IS_DESTROYED " : "";
+				}
+				state += (activity.isFinishing()) ? "IS_FINISHING" : "";
+				state += (activity.isChangingConfigurations()) ? "IS_CHANGING_CONFIGURATIONS" : "";
+				Crashlytics.setString("Activity state:", state);
+			}
+			Crashlytics.setBool("Thread display fragment resumed", isResumed());
+			Crashlytics.setBool("Thread display fragment attached", isAdded());
+			Crashlytics.setBool("Thread display fragment removing", isRemoving());
+		}
+        ////////////////////////////////////////////////////////////////////////
 
 		PostActionsFragment postActions = new PostActionsFragment();
 		postActions.setTitle(url);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
@@ -43,6 +43,7 @@ import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
+import com.ferg.awfulapp.AwfulApplication;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.thread.AwfulEmote;
 import com.ferg.awfulapp.thread.AwfulForum;
@@ -675,7 +676,7 @@ public class AwfulProvider extends ContentProvider {
                     aSelectionArgs, null, null, aSortOrder);
             result.setNotificationUri(getContext().getContentResolver(), aUri);
         } catch (Exception e) {
-			if (!Constants.DEBUG){
+			if (AwfulApplication.crashlyticsEnabled()){
 				Crashlytics.log(String.format("aUri:\n%s\nQuery tables string:\n%s", aUri, builder.getTables()));
 			}
             throw e;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
@@ -18,6 +18,7 @@ import com.android.volley.RetryPolicy;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.crashlytics.android.Crashlytics;
+import com.ferg.awfulapp.AwfulApplication;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
@@ -288,8 +289,8 @@ public abstract class AwfulRequest<T> {
                     return Response.error(ae);
                 }
             } catch (OutOfMemoryError e) {
-                if (!Constants.DEBUG) {
-                    Crashlytics.setString("URL", getUrl());
+                if (AwfulApplication.crashlyticsEnabled()) {
+                    Crashlytics.setString("Response URL", getUrl());
                     Crashlytics.setLong("Response data size", response.data.length);
                 }
                 throw e;


### PR DESCRIPTION
Not sure what's causing that, shouldn't be in a paused state when that method is called. It's possible
though since it's coming from the webview's link handler...

I've also added a flag to check if Crashlytics has been initialised - before it was just a 'not DEBUG' check
which is a bit brittle (also Crashlytics is enabled in debug after X hours anyway), and made things use it.