### PR TITLE
Show Size of Images in Action Menu

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
@@ -202,9 +202,9 @@ public class PostActionsFragment extends AwfulDialogFragment {
 	public void changeTitle(String title) {
 		View view = getView();
 		if (view != null) {
-			TextView actionTitle = (TextView) view.findViewById(R.id.actionTitle);
-			if (actionTitle != null) {
-				actionTitle.setText(title);
+			TextView fileSize = (TextView) view.findViewById(R.id.fileSize);
+			if (fileSize != null) {
+				fileSize.setText(title);
 			}
 		}
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
@@ -198,6 +198,16 @@ public class PostActionsFragment extends AwfulDialogFragment {
 	public void setTitle(String title) {
 		this.title = title;
 	}
+	
+	public void changeTitle(String title) {
+		View view = getView();
+		if (view != null) {
+			TextView actionTitle = (TextView) view.findViewById(R.id.actionTitle);
+			if (actionTitle != null) {
+				actionTitle.setText(title);
+			}
+		}
+	}
 
 	public void setPostId(String postId) {
 		this.postId = postId;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
@@ -205,6 +205,7 @@ public class PostActionsFragment extends AwfulDialogFragment {
 			TextView fileSize = (TextView) view.findViewById(R.id.fileSize);
 			if (fileSize != null) {
 				fileSize.setText(size);
+				fileSize.setVisibility(size == null ? View.GONE : View.VISIBLE);
 			}
 		}
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
@@ -199,12 +199,12 @@ public class PostActionsFragment extends AwfulDialogFragment {
 		this.title = title;
 	}
 	
-	public void changeTitle(String title) {
+	public void setSize(String size) {
 		View view = getView();
 		if (view != null) {
 			TextView fileSize = (TextView) view.findViewById(R.id.fileSize);
 			if (fileSize != null) {
-				fileSize.setText(title);
+				fileSize.setText(size);
 			}
 		}
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PostActionsFragment.java
@@ -205,7 +205,7 @@ public class PostActionsFragment extends AwfulDialogFragment {
 			TextView fileSize = (TextView) view.findViewById(R.id.fileSize);
 			if (fileSize != null) {
 				fileSize.setText(size);
-				fileSize.setVisibility(size == null ? View.GONE : View.VISIBLE);
+				fileSize.setVisibility(size == null ? View.INVISIBLE : View.VISIBLE);
 			}
 		}
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -1238,8 +1238,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 						URL location = new URL(parameters[0]);
 						URLConnection connection = location.openConnection();
 						int size = connection.getContentLength();
-						String pretty = Formatter.formatShortFileSize(getContext(), size);
-						return String.format("Image Size:\n%s\n\n%s", pretty, url);
+						return String.format("%s", Formatter.formatShortFileSize(getContext(), size));
 					}
 					catch (IOException exception) {
 						exception.printStackTrace();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -60,6 +60,7 @@ import android.support.v4.content.Loader;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.ShareActionProvider;
 import android.text.TextUtils;
+import android.text.format.Formatter;
 import android.util.Log;
 import android.view.InflateException;
 import android.view.LayoutInflater;
@@ -1227,6 +1228,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 		postActions.setUrl(url);
 		postActions.setActions(AwfulAction.getURLActions(url, isImage, isGif));
 		postActions.setStyle(DialogFragment.STYLE_NO_TITLE, 0);
+		postActions.setTitle(url);
 		
 		if (isImage || isGif) {
 			AsyncTask<String, Void, String> task = new AsyncTask<String, Void, String>() {
@@ -1236,7 +1238,8 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 						URL location = new URL(parameters[0]);
 						URLConnection connection = location.openConnection();
 						int size = connection.getContentLength();
-						return String.format("Size: %sB\n\n%s", size, url);
+						String pretty = Formatter.formatShortFileSize(getContext(), size);
+						return String.format("Image Size:\n%s\n\n%s", pretty, url);
 					}
 					catch (IOException exception) {
 						exception.printStackTrace();
@@ -1246,16 +1249,13 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
 				@Override
 				protected void onPostExecute(String result) {
-					postActions.setTitle(result);
-					postActions.show(fragmentManager, "Link Actions");
+					postActions.changeTitle(result);
 				}
 			};
 			task.execute(url);
 		}
-		else {
-			postActions.setTitle(url);
-			postActions.show(fragmentManager, "Link Actions");
-		}
+		
+		postActions.show(fragmentManager, "Link Actions");
 	}
 
 	protected void showImageInline(String url){

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -1238,7 +1238,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 						URL location = new URL(parameters[0]);
 						URLConnection connection = location.openConnection();
 						int size = connection.getContentLength();
-						return String.format("%s", Formatter.formatShortFileSize(getContext(), size));
+						return String.format("Size: %s", Formatter.formatShortFileSize(getContext(), size));
 					}
 					catch (IOException exception) {
 						exception.printStackTrace();
@@ -1248,7 +1248,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
 				@Override
 				protected void onPostExecute(String result) {
-					postActions.changeTitle(result);
+					postActions.setSize(result);
 				}
 			};
 			task.execute(url);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -118,6 +118,9 @@ import com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayoutD
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -1220,13 +1223,39 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
         ////////////////////////////////////////////////////////////////////////
 
 		PostActionsFragment postActions = new PostActionsFragment();
-		postActions.setTitle(url);
 		postActions.setParent(mSelf);
 		postActions.setUrl(url);
 		postActions.setActions(AwfulAction.getURLActions(url, isImage, isGif));
-
 		postActions.setStyle(DialogFragment.STYLE_NO_TITLE, 0);
-		postActions.show(fragmentManager, "Link Actions");
+		
+		if (isImage || isGif) {
+			AsyncTask<String, Void, String> task = new AsyncTask<String, Void, String>() {
+				@Override
+				protected String doInBackground(String... parameters) {
+					try {
+						URL location = new URL(parameters[0]);
+						URLConnection connection = location.openConnection();
+						int size = connection.getContentLength();
+						return String.format("Size: %sB\n\n%s", size, url);
+					}
+					catch (IOException exception) {
+						exception.printStackTrace();
+						return null;
+					}
+				}
+
+				@Override
+				protected void onPostExecute(String result) {
+					postActions.setTitle(result);
+					postActions.show(fragmentManager, "Link Actions");
+				}
+			};
+			task.execute(url);
+		}
+		else {
+			postActions.setTitle(url);
+			postActions.show(fragmentManager, "Link Actions");
+		}
 	}
 
 	protected void showImageInline(String url){

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -92,6 +92,7 @@ import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.task.BookmarkRequest;
 import com.ferg.awfulapp.task.CloseOpenRequest;
 import com.ferg.awfulapp.task.IgnoreRequest;
+import com.ferg.awfulapp.task.ImageSizeRequest;
 import com.ferg.awfulapp.task.MarkLastReadRequest;
 import com.ferg.awfulapp.task.PostRequest;
 import com.ferg.awfulapp.task.ProfileRequest;
@@ -1231,27 +1232,13 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 		postActions.setTitle(url);
 		
 		if (isImage || isGif) {
-			AsyncTask<String, Void, String> task = new AsyncTask<String, Void, String>() {
-				@Override
-				protected String doInBackground(String... parameters) {
-					try {
-						URL location = new URL(parameters[0]);
-						URLConnection connection = location.openConnection();
-						int size = connection.getContentLength();
-						return String.format("Size: %s", Formatter.formatShortFileSize(getContext(), size));
-					}
-					catch (IOException exception) {
-						exception.printStackTrace();
-						return null;
-					}
+			queueRequest(new ImageSizeRequest(url, result -> {
+				if (postActions == null) {
+					return;
 				}
-
-				@Override
-				protected void onPostExecute(String result) {
-					postActions.setSize(result);
-				}
-			};
-			task.execute(url);
+				String size = result == null ? "Unknown" : Formatter.formatShortFileSize(getContext(), result);
+				postActions.setSize(String.format("Size: %s", size));
+			}));
 		}
 		
 		postActions.show(fragmentManager, "Link Actions");

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ImageSizeRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ImageSizeRequest.java
@@ -1,0 +1,35 @@
+package com.ferg.awfulapp.task;
+
+import android.support.annotation.NonNull;
+
+import com.android.volley.NetworkResponse;
+import com.android.volley.Request;
+import com.android.volley.Response;
+import com.android.volley.toolbox.HttpHeaderParser;
+
+public class ImageSizeRequest extends Request<Integer> {
+    private final Response.Listener<Integer> listener;
+
+    public ImageSizeRequest(@NonNull String url, Response.Listener<Integer> listener) {
+        super(Method.HEAD, url, null);
+        this.listener = listener;
+    }
+
+    @Override
+    protected Response<Integer> parseNetworkResponse(NetworkResponse response) {
+        String length = response.headers.get("Content-Length");
+        if (length == null) {
+            return null;
+        }
+        try {
+            return Response.success(Integer.parseInt(length), HttpHeaderParser.parseCacheHeaders(response));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @Override
+    protected void deliverResponse(Integer response) {
+        listener.onResponse(response);
+    }
+}

--- a/Awful.apk/src/main/res/layout/select_action_dialog.xml
+++ b/Awful.apk/src/main/res/layout/select_action_dialog.xml
@@ -42,7 +42,9 @@
         android:paddingBottom="10dp"
         android:paddingLeft="24dp"
         android:paddingRight="24dp"
-        tools:text="64 KB"/>
+        android:visibility="gone"
+        tools:text="64 KB"
+        tools:visibility="visible"/>
 
     <android.support.v7.widget.RecyclerView
         android:layout_width="@dimen/dialog_size"

--- a/Awful.apk/src/main/res/layout/select_action_dialog.xml
+++ b/Awful.apk/src/main/res/layout/select_action_dialog.xml
@@ -30,7 +30,19 @@
         android:paddingLeft="24dp"
         android:paddingTop="24dp"
         android:paddingRight="24dp"
-        android:textSize="@dimen/abc_text_size_headline_material"/>
+        android:textSize="@dimen/abc_text_size_headline_material"
+        tools:text="http://i.imgur.com/example.png"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/fileSize"
+        android:background="?attr/colorPrimary"
+        android:textColor="?attr/actionBarFontColor"
+        android:paddingBottom="10dp"
+        android:paddingLeft="24dp"
+        android:paddingRight="24dp"
+        tools:text="64 KB"/>
 
     <android.support.v7.widget.RecyclerView
         android:layout_width="@dimen/dialog_size"

--- a/Awful.apk/src/main/res/layout/select_action_dialog.xml
+++ b/Awful.apk/src/main/res/layout/select_action_dialog.xml
@@ -12,7 +12,8 @@
     tools:context=".PostActionsFragment"
     android:orientation="vertical"
     android:paddingBottom="24dp"
-    android:elevation="24dp">
+    android:elevation="24dp"
+    android:animateLayoutChanges="true">
 
     <TextView
         android:layout_width="match_parent"
@@ -42,7 +43,7 @@
         android:paddingBottom="10dp"
         android:paddingLeft="24dp"
         android:paddingRight="24dp"
-        android:visibility="gone"
+        android:visibility="invisible"
         tools:text="64 KB"
         tools:visibility="visible"/>
 


### PR DESCRIPTION
Image size is now displayed at the top of the post action menu, within the title and before the image URL. 

In the future some form of indicator should be displayed to the user while image size is retrieved rather than apparent unresponsiveness while the network request is processed.

This PR is intended to resolve issue #458.