### PR TITLE
Sort Stickied Threads to Top

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -1425,7 +1425,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
 
     private class PostLoaderManager implements LoaderManager.LoaderCallbacks<Cursor> {
-        private final static String sortOrder = AwfulPost.POST_INDEX + " ASC";
+		private final static String sortOrder = AwfulThread.STICKY + " " + AwfulPost.POST_INDEX + " ASC";
         private final static String selection = AwfulPost.THREAD_ID + "=? AND " + AwfulPost.POST_INDEX + ">=? AND " + AwfulPost.POST_INDEX + "<?";
         public Loader<Cursor> onCreateLoader(int aId, Bundle aArgs) {
             int index = AwfulPagedItem.pageToIndex(getPage(), mPrefs.postPerPage, 0);


### PR DESCRIPTION
This wound up being a simple fix. Stuck threads will now be sorted to the top of the list in the thread list view.

Resolves issue #266.