### PR TITLE
Fix AwfulProvider#query method not handling bad data (Crashlytics #719)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
@@ -26,7 +26,6 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 
 import com.android.volley.VolleyError;
-import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.preferences.SettingsActivity;
 import com.ferg.awfulapp.provider.AwfulProvider;
@@ -326,6 +325,7 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
 		}
 
 		public Loader<Cursor> onCreateLoader(int aId, Bundle aArgs) {
+			// TODO: 05/05/2017 if pmId is negative (i.e. an invalid number) the load will fail - try and avoid doing it?
 			Log.i(TAG,"Create PM Cursor:"+pmId);
             return new CursorLoader(getActivity(), 
             						ContentUris.withAppendedId(AwfulMessage.CONTENT_URI, pmId), 
@@ -336,10 +336,11 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
         }
 
         public void onLoadFinished(Loader<Cursor> aLoader, Cursor aData) {
-        	Log.v(TAG,"PM load finished, populating: "+aData.getCount());
         	//TODO retain info if entered into reply window
-        	if(aData.moveToFirst() && pmId >0){
-    			if(messageWebView != null){
+			// the Cursor will be null if pmId is negative
+			if(aData != null && aData.moveToFirst()){
+				Log.v(TAG,"PM load finished, populating: "+aData.getCount());
+				if(messageWebView != null){
 					messageWebView.setContent(null);
     			}
         		String title = aData.getString(aData.getColumnIndex(AwfulMessage.TITLE));
@@ -371,8 +372,7 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
         			mRecipient.setText(recipient);
         		}
         	}
-        	aData.close();
-        }
+		}
         
         @Override
         public void onLoaderReset(Loader<Cursor> aLoader) {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageListFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PrivateMessageListFragment.java
@@ -297,7 +297,9 @@ public class PrivateMessageListFragment extends AwfulFragment implements SwipeRe
         }
 
         public void onLoadFinished(Loader<Cursor> aLoader, Cursor aData) {
-        	Log.v(TAG,"PM load finished, populating: "+aData.getCount());
+            if (aData != null) {
+                Log.v(TAG,"PM load finished, populating: "+aData.getCount());
+            }
         	mCursorAdapter.swapCursor(aData);
         }
         


### PR DESCRIPTION
Sometimes when the ContentProvider is queried (through a CursorLoader
usually) bad data is passed, and the #query method has no fallback to
handle it. E.g. the PM system sometimes passes a PM ID of -1, the
UriMatcher doesn't catch it (probably because the number wildcard doesn't
match the -) and it never matches a Uri type. It still makes the query
without setting things like the tables parameter, and then it throws.

I've made the query method return null for bad data, and the querying
methods can be responsible for handling it (especially when they're
passing bad data in the first place)

The other methods (#update etc) don't have any proper validation either,
so bad data could end up being passed in and cause problems. The whole
thing needs reworking to be honest