### PR TITLE
Add 'standarderror' check to AwfulError's parsing, handles rate limiting

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
@@ -8,7 +8,6 @@ import com.ferg.awfulapp.thread.AwfulThread;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 
 /**
  * Created by matt on 8/7/13.
@@ -45,13 +44,6 @@ public class PostRequest extends AwfulRequest<Integer> {
 
     @Override
     protected Integer handleResponse(Document doc) throws AwfulError {
-        if(doc.getElementsByTag("body").hasClass("standarderror")) {
-            Element standard = doc.getElementsByClass("standard").first();
-            if(standard != null && standard.hasText()){
-                throw new AwfulError(AwfulError.ERROR_ACCESS_DENIED, standard.text().replace("Special Message From Senor Lowtax", ""));
-            }
-        }
-
         AwfulThread.getThreadPosts(getContentResolver(), doc, threadId, page, getPreferences().postPerPage, getPreferences(), userId);
         return page;
     }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
@@ -130,6 +130,15 @@ public class AwfulError extends VolleyError{
                 error = new AwfulError(ERROR_FORUM_CLOSED);
             }
         }
+
+        // Some generic error - shows up for (at least) post rate limiting and whatever #PostRequest was seeing in responses
+        if(page.getElementsByTag("body").hasClass("standarderror")) {
+            Element standard = page.getElementsByClass("standard").first();
+            if(standard != null && standard.hasText()){
+                error = new AwfulError(AwfulError.ERROR_ACCESS_DENIED, standard.text().replace("Special Message From Senor Lowtax", ""));
+            }
+        }
+
         Element probation = page.getElementById("probation_warn");
         if(probation != null){
             error = new AwfulError(ERROR_PROBATION);


### PR DESCRIPTION
This 'standarderror' class appears in some error pages, PostRequest was
explicitly handling it in its #handleResponse method and throwing an
ACCESS DENIED AwfulError. The same class appears in the 'you're posting
too fast' error pages too, and possibly in some other situations?

So I've pulled that check out and put it in the normal AwfulError parsing
method, so it can run on everything and throw an error just like
everything else does.