### PR TITLE
AwfulThread rework

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -403,7 +403,8 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
 
     private AdapterView.OnItemClickListener onThreadSelected = new AdapterView.OnItemClickListener() {
         public void onItemClick(AdapterView<?> aParent, View aView, int aPosition, long aId) {
-        	Cursor row = mCursorAdapter.getRow(aId);
+            // TODO: 04/06/2017 why is all this in a threadlist click listener? We know it's a thread! It's not a forum!
+            Cursor row = mCursorAdapter.getRow(aId);
             if(row != null && row.getColumnIndex(AwfulThread.BOOKMARKED)>-1) {
                     Log.i(TAG, "Thread ID: " + Long.toString(aId));
                     int unreadPage = AwfulPagedItem.getLastReadPage(row.getInt(row.getColumnIndex(AwfulThread.UNREADCOUNT)),

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
@@ -38,8 +38,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 
-import com.ferg.awfulapp.constants.Constants;
-import com.ferg.awfulapp.thread.AwfulThread;
+import com.ferg.awfulapp.thread.ThreadDisplay;
 import com.ferg.awfulapp.webview.AwfulWebView;
 import com.ferg.awfulapp.webview.WebViewJsInterface;
 
@@ -79,7 +78,7 @@ public class PreviewFragment extends AwfulDialogFragment {
     }
 
     private String getBlankPage() {
-        return AwfulThread.getContainerHtml(mPrefs, 0);
+        return ThreadDisplay.getContainerHtml(mPrefs, 0);
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -107,6 +107,7 @@ import com.ferg.awfulapp.thread.AwfulPost;
 import com.ferg.awfulapp.thread.AwfulThread;
 import com.ferg.awfulapp.thread.AwfulURL;
 import com.ferg.awfulapp.thread.AwfulURL.TYPE;
+import com.ferg.awfulapp.thread.ThreadDisplay;
 import com.ferg.awfulapp.util.AwfulError;
 import com.ferg.awfulapp.util.AwfulUtils;
 import com.ferg.awfulapp.webview.AwfulWebView;
@@ -120,9 +121,6 @@ import com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayoutD
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -1079,7 +1077,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 
         try {
             if (DEBUG) Log.d(TAG, String.format("populateThreadView: displaying %d posts", aPosts.size()));
-            String html = AwfulThread.getHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPage(), mLastPage, mParentForumId, threadClosed);
+            String html = ThreadDisplay.getHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPage(), mLastPage);
             refreshSessionCookie();
             bodyHtml = html;
 			mThreadView.refreshPageContents(true);
@@ -1373,7 +1371,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 	 * @return	The basic page HTML, with no post content
      */
 	private String getBlankPage(){
-		return AwfulThread.getContainerHtml(mPrefs, getParentForumId());
+		return ThreadDisplay.getContainerHtml(mPrefs, getParentForumId());
 	}
 
     private int getLastPage() {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
@@ -22,7 +22,7 @@ import com.ferg.awfulapp.provider.AwfulTheme;
 import com.ferg.awfulapp.task.AnnouncementsRequest;
 import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.thread.AwfulPost;
-import com.ferg.awfulapp.thread.AwfulThread;
+import com.ferg.awfulapp.thread.ThreadDisplay;
 import com.ferg.awfulapp.webview.AwfulWebView;
 import com.ferg.awfulapp.webview.WebViewJsInterface;
 
@@ -38,7 +38,7 @@ import butterknife.ButterKnife;
  * <p>
  * This is basically a butchered thread view since that's kind of what the announcements page is.
  * Most of that happens in the request (not setting certain fields), here we just throw in some
- * meaningless constants in the {@link AwfulThread#getHtml(List, AwfulPreferences, int, int, int, boolean)}
+ * meaningless constants in the {@link #getHtml(List}
  * call, and hope it doesn't break. Seems to work! Fix later!
  * <p>
  * Also this also assumes the announcements page won't ever have more than one page.
@@ -117,7 +117,7 @@ public class AnnouncementsFragment extends AwfulFragment {
                 return true;
             }
         });
-        webView.setContent(AwfulThread.getContainerHtml(mPrefs, -1));
+        webView.setContent(ThreadDisplay.getContainerHtml(mPrefs, -1));
     }
 
 
@@ -141,7 +141,7 @@ public class AnnouncementsFragment extends AwfulFragment {
                         AnnouncementsManager.getInstance().markAllRead();
                         // these constants don't mean anything in the context of the announcement page
                         // we just want it to a) display ok, and b) not let the user click anything bad
-                        bodyHtml = AwfulThread.getHtml(result, AwfulPreferences.getInstance(), 1, 1, 0, true);
+                        bodyHtml = ThreadDisplay.getHtml(result, AwfulPreferences.getInstance(), 1, 1);
                         if (webView != null) {
                             webView.refreshPageContents(true);
                         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/service/AwfulCursorAdapter.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/service/AwfulCursorAdapter.java
@@ -73,7 +73,7 @@ public class AwfulCursorAdapter extends CursorAdapter {
 	@Override
 	public void bindView(View current, Context context, Cursor data) {
 		if(data.getColumnIndex(AwfulThread.BOOKMARKED) >= 0){//unique to threads
-			AwfulThread.getView(current, mPrefs, data, mFragment);
+			AwfulThread.setDataOnThreadListItem(current, mPrefs, data, mFragment);
 		}else if(data.getColumnIndex(AwfulForum.PARENT_ID) >= 0){//unique to forums
 			assert(false);
 //		}else if(data.getColumnIndex(AwfulPost.PREVIOUSLY_READ) >= 0){
@@ -91,7 +91,7 @@ public class AwfulCursorAdapter extends CursorAdapter {
 		View row;
 		if(data.getColumnIndex(AwfulThread.BOOKMARKED) >= 0){//unique to threads
 			row = inf.inflate(R.layout.thread_item, parent, false);
-			AwfulThread.getView(row, mPrefs, data, mFragment);
+			AwfulThread.setDataOnThreadListItem(row, mPrefs, data, mFragment);
 		}else if(data.getColumnIndex(AwfulMessage.UNREAD) >= 0){
 			row = inf.inflate(R.layout.thread_item, parent, false);
 			AwfulMessage.getView(row, mPrefs, data, false);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/service/ThreadCursorAdapter.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/service/ThreadCursorAdapter.java
@@ -57,14 +57,14 @@ public class ThreadCursorAdapter extends CursorAdapter {
 
 	@Override
 	public void bindView(View current, Context context, Cursor data) {
-        AwfulThread.getView(current, mPrefs, data, mFragment);
+        AwfulThread.setDataOnThreadListItem(current, mPrefs, data, mFragment);
 		mParent.setPreferredFont(current);
 	}
 
 	@Override
 	public View newView(Context context, Cursor data, ViewGroup parent) {
 		View row = inf.inflate(R.layout.thread_item, parent, false);
-        AwfulThread.getView(row, mPrefs, data, mFragment);
+        AwfulThread.setDataOnThreadListItem(row, mPrefs, data, mFragment);
 		mParent.setPreferredFont(row);
 		return row;
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
@@ -44,7 +44,7 @@ public class PostRequest extends AwfulRequest<Integer> {
 
     @Override
     protected Integer handleResponse(Document doc) throws AwfulError {
-        AwfulThread.getThreadPosts(getContentResolver(), doc, threadId, page, getPreferences().postPerPage, getPreferences(), userId);
+        AwfulThread.parseThreadPage(getContentResolver(), doc, threadId, page, getPreferences().postPerPage, getPreferences(), userId);
         return page;
     }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
@@ -100,7 +100,7 @@ public class AwfulForum extends AwfulPagedItem {
 	 */
 	public static void parseThreads(Document page, int forumId, int pageNumber, ContentResolver contentInterface) {
 		// get the threads on a (normal) forum page, index them and store
-		ArrayList<ContentValues> threads = AwfulThread.parseForumThreads(page, forumPageToIndex(pageNumber), forumId);
+		ArrayList<ContentValues> threads = AwfulThread.parseForumThreads(page, forumId, forumPageToIndex(pageNumber));
 		deletePageOfThreads(forumId, pageNumber, contentInterface);
 		insertThreads(threads, contentInterface);
 
@@ -119,7 +119,7 @@ public class AwfulForum extends AwfulPagedItem {
 	 */
 	public static void parseUCPThreads(@NonNull Document page, int pageNumber, @NonNull ContentResolver contentInterface) {
 		// get all the threads on the bookmarks page, with their INDEXes set appropriately, and store them
-		ArrayList<ContentValues> threads = AwfulThread.parseForumThreads(page, forumPageToIndex(pageNumber), Constants.USERCP_ID);
+		ArrayList<ContentValues> threads = AwfulThread.parseForumThreads(page, Constants.USERCP_ID, forumPageToIndex(pageNumber));
 		insertThreads(threads, contentInterface);
 
 		// for each thread on the page, create a bookmark (with the thread's ID) in the same position (same index)

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
@@ -45,6 +45,7 @@ import org.jsoup.select.Elements;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -100,7 +101,7 @@ public class AwfulForum extends AwfulPagedItem {
 	 */
 	public static void parseThreads(Document page, int forumId, int pageNumber, ContentResolver contentInterface) {
 		// get the threads on a (normal) forum page, index them and store
-		ArrayList<ContentValues> threads = AwfulThread.parseForumThreads(page, forumId, forumPageToIndex(pageNumber));
+		List<ContentValues> threads = AwfulThread.parseForumThreads(page, forumId, forumPageToIndex(pageNumber));
 		deletePageOfThreads(forumId, pageNumber, contentInterface);
 		insertThreads(threads, contentInterface);
 
@@ -119,12 +120,12 @@ public class AwfulForum extends AwfulPagedItem {
 	 */
 	public static void parseUCPThreads(@NonNull Document page, int pageNumber, @NonNull ContentResolver contentInterface) {
 		// get all the threads on the bookmarks page, with their INDEXes set appropriately, and store them
-		ArrayList<ContentValues> threads = AwfulThread.parseForumThreads(page, Constants.USERCP_ID, forumPageToIndex(pageNumber));
+		List<ContentValues> threads = AwfulThread.parseForumThreads(page, Constants.USERCP_ID, forumPageToIndex(pageNumber));
 		insertThreads(threads, contentInterface);
 
 		// for each thread on the page, create a bookmark (with the thread's ID) in the same position (same index)
 		String update_time = new Timestamp(System.currentTimeMillis()).toString();
-		ArrayList<ContentValues> bookmarks = new ArrayList<>();
+		List<ContentValues> bookmarks = new ArrayList<>();
 
 		int start_index = forumPageToIndex(pageNumber);
 		for (ContentValues thread : threads) {
@@ -145,12 +146,12 @@ public class AwfulForum extends AwfulPagedItem {
 	}
 
 
-	private static void insertThreads(@NonNull ArrayList<ContentValues> threads, @NonNull ContentResolver resolver) {
+	private static void insertThreads(@NonNull List<ContentValues> threads, @NonNull ContentResolver resolver) {
 		resolver.bulkInsert(AwfulThread.CONTENT_URI, threads.toArray(new ContentValues[threads.size()]));
 	}
 
 
-	private static void insertBookmarks(@NonNull ArrayList<ContentValues> bookmarks, @NonNull ContentResolver resolver) {
+	private static void insertBookmarks(@NonNull List<ContentValues> bookmarks, @NonNull ContentResolver resolver) {
 		resolver.bulkInsert(AwfulThread.CONTENT_URI_UCP, bookmarks.toArray(new ContentValues[bookmarks.size()]));
 
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulMessage.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulMessage.java
@@ -274,7 +274,7 @@ public class AwfulMessage extends AwfulPagedItem {
 			buffer.append("<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n");
 			buffer.append("<meta name='format-detection' content='telephone=no' />\n");
 			buffer.append("<meta name='format-detection' content='address=no' />\n");
-			for (String scriptName : AwfulThread.JS_FILES) {
+			for (String scriptName : ThreadDisplay.JS_FILES) {
 				buffer.append("<script src='file:///android_asset/")
 						.append(scriptName)
 						.append("' type='text/javascript'></script>\n");

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPost.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPost.java
@@ -40,7 +40,6 @@ import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.provider.DatabaseHelper;
-import com.ferg.awfulapp.provider.DatabaseHelper;
 import com.ferg.awfulapp.util.AwfulUtils;
 
 import org.apache.commons.lang3.StringUtils;
@@ -468,11 +467,24 @@ public class AwfulPost {
 	}
 
 
-    public static void syncPosts(ContentResolver content, Document aThread, int aThreadId, int unreadIndex, int opId, AwfulPreferences prefs, int startIndex){
+    /**
+     * Parse a thread page to grab its post data.
+     *
+     * @param content
+     * @param aThread
+     * @param aThreadId
+     * @param unreadIndex
+     * @param opId
+     * @param prefs
+     * @param startIndex
+     * @return the number of posts found on the page
+     */
+    public static int syncPosts(ContentResolver content, Document aThread, int aThreadId, int unreadIndex, int opId, AwfulPreferences prefs, int startIndex){
         ArrayList<ContentValues> result = AwfulPost.parsePosts(aThread, aThreadId, unreadIndex, opId, prefs, startIndex, false);
-
+        // TODO: 02/06/2017 see below, ignored posts are NOT stored!
         int resultCount = content.bulkInsert(CONTENT_URI, result.toArray(new ContentValues[result.size()]));
         Log.i(TAG, "Inserted "+resultCount+" posts into DB, threadId:"+aThreadId+" unreadIndex: "+unreadIndex);
+        return resultCount;
     }
 
     public static ArrayList<ContentValues> parsePosts(Document aThread, int aThreadId, int unreadIndex, int opId, AwfulPreferences prefs, int startIndex, boolean preview){
@@ -483,6 +495,7 @@ public class AwfulPost {
 
         Elements posts = aThread.getElementsByClass(preview ? "standard" : "post");
         for(Element postData : posts){
+            // TODO: 02/06/2017 this drops ignored posts completely - fine for a view, bad for actually getting all the posts on a page! Letting them store might break ignore??
             if (postData.hasClass("ignored") && prefs.hideIgnoredPosts) {
                 continue;
             }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -39,6 +39,8 @@ import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.os.Environment;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.util.Log;
@@ -76,9 +78,15 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static android.view.View.GONE;
+import static android.view.View.VISIBLE;
+import static butterknife.ButterKnife.findById;
+import static java.lang.Integer.parseInt;
 
 public class AwfulThread extends AwfulPagedItem  {
     private static final String TAG = "AwfulThread";
@@ -132,6 +140,117 @@ public class AwfulThread extends AwfulPagedItem  {
 	private static final Pattern urlId_regex = Pattern.compile("([^#]+)#(\\d+)$");
 
 
+    // TODO: 04/06/2017 explicit default values, nulls where parsed data doesn't set values (i.e. never added to the ContentValues)?
+    int id;
+    int index;
+    String title;
+
+    int forumId;
+//    String forumTitle;
+
+    String author;
+    int authorId;
+    String lastPoster;
+    int postCount;
+    int unreadCount;
+
+    int rating;
+    int bookmarkType;
+
+    boolean isLocked;
+    boolean isSticky;
+    boolean canOpenClose;
+    boolean hasBeenViewed;
+    boolean archived;
+
+    String tagUrl;
+    String tagCacheFile;
+    int tagExtra;
+    int category;
+
+
+    @Nullable
+    public static AwfulThread fromCursorRow(@NonNull Cursor row) {
+        if (row.isBeforeFirst() || row.isAfterLast()) {
+            Log.w(TAG, "fromCursor: passed empty row");
+            return null;
+        }
+        AwfulThread thread = new AwfulThread();
+
+        thread.id = row.getInt(row.getColumnIndex(ID));
+        thread.index = row.getInt(row.getColumnIndex(INDEX));
+        thread.title = row.getString(row.getColumnIndex(TITLE));
+
+        thread.forumId = row.getInt(row.getColumnIndex(FORUM_ID));
+        // TODO: 03/06/2017 this column name is taken from the thread projection, but is it ever used?
+//        thread.forumTitle = row.getString(row.getColumnIndex(FORUM_TITLE));
+
+        thread.author = row.getString(row.getColumnIndex(AUTHOR));
+        thread.authorId = row.getInt(row.getColumnIndex(AUTHOR_ID));
+        thread.lastPoster = row.getString(row.getColumnIndex(LASTPOSTER));
+        thread.postCount = row.getInt(row.getColumnIndex(POSTCOUNT));
+        thread.unreadCount = row.getInt(row.getColumnIndex(UNREADCOUNT));
+
+        thread.rating = row.getInt(row.getColumnIndex(RATING));
+        thread.bookmarkType = row.getInt(row.getColumnIndex(BOOKMARKED));
+
+        thread.isLocked = row.getInt(row.getColumnIndex(LOCKED)) > 0;
+        thread.archived = row.getInt(row.getColumnIndex(ARCHIVED)) > 0;
+        thread.isSticky = row.getInt(row.getColumnIndex(STICKY)) > 0;
+        thread.canOpenClose = row.getInt(row.getColumnIndex(CAN_OPEN_CLOSE)) > 0;
+        thread.hasBeenViewed = row.getInt(row.getColumnIndex(HAS_VIEWED_THREAD)) == 1;
+
+        thread.tagUrl = row.getString(row.getColumnIndex(TAG_URL));
+        thread.tagCacheFile = row.getString(row.getColumnIndex(TAG_CACHEFILE));
+        thread.tagExtra = row.getInt(row.getColumnIndex(TAG_EXTRA));
+        thread.category = row.getInt(row.getColumnIndex(CATEGORY));
+
+        return thread;
+    }
+
+
+    public ContentValues toContentValues() {
+        ContentValues cv = new ContentValues();
+        cv.put(ID, id);
+        cv.put(INDEX, index);
+        cv.put(FORUM_ID, forumId);
+        cv.put(TITLE, title);
+        cv.put(AUTHOR, author);
+        cv.put(AUTHOR_ID, authorId);
+
+
+        cv.put(CAN_OPEN_CLOSE, asSqlBoolean(canOpenClose));
+
+        cv.put(LASTPOSTER, lastPoster);
+        cv.put(LOCKED, asSqlBoolean(isLocked));
+        cv.put(STICKY, asSqlBoolean(isSticky));
+        cv.put(RATING, rating);
+        cv.put(TAG_URL, tagUrl);
+        cv.put(CATEGORY, category);
+        cv.put(TAG_CACHEFILE, tagCacheFile);
+
+        cv.put(TAG_EXTRA, tagExtra);
+        cv.put(POSTCOUNT, postCount);
+
+        cv.put(UNREADCOUNT, unreadCount);
+        cv.put(HAS_VIEWED_THREAD, asSqlBoolean(hasBeenViewed));
+        cv.put(BOOKMARKED, bookmarkType);
+        return cv;
+    }
+
+    private static int asSqlBoolean(boolean value) {
+        return value ? 1 : 0;
+    }
+
+    public boolean hasNewPosts() {
+        return unreadCount > 0;
+    }
+
+    public int getPageCount(int postsPerPage) {
+        return AwfulPagedItem.indexToPage(postCount, postsPerPage);
+    }
+
+
     /**
      * Parse a list of threads in a forum and generate their metadata.
      * <p>
@@ -142,9 +261,9 @@ public class AwfulThread extends AwfulPagedItem  {
      * @param startIndex the threads' positions in the forum will start from this index
      * @return the list of all the threads' metadata objects, ready for storage
      */
-    public static ArrayList<ContentValues> parseForumThreads(Document forumPage, int forumId, int startIndex) {
+    public static List<ContentValues> parseForumThreads(Document forumPage, int forumId, int startIndex) {
         String update_time = new Timestamp(System.currentTimeMillis()).toString();
-        ArrayList<ContentValues> result = new ArrayList<>();
+        List<ContentValues> result = new ArrayList<>();
         Log.v(TAG, "Update time: " + update_time);
         String username = AwfulPreferences.getInstance().username;
 
@@ -157,15 +276,10 @@ public class AwfulThread extends AwfulPagedItem  {
                 }
 
                 // start building thread data
-                ContentValues thread = new ContentValues();
-                thread.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);
-                thread.put(ID, Integer.parseInt(threadId.replaceAll("\\D", "")));
-
-                // don't update these values if we are loading bookmarks, or it will overwrite the cached forum results.
-                if (forumId != Constants.USERCP_ID) {
-                    thread.put(INDEX, startIndex);
-                    thread.put(FORUM_ID, forumId);
-                }
+                AwfulThread thread = new AwfulThread();
+                thread.id = parseInt(threadId.replaceAll("\\D", ""));
+                thread.index = startIndex;
+                thread.forumId = forumId;
                 startIndex++;
 
 
@@ -174,29 +288,29 @@ public class AwfulThread extends AwfulPagedItem  {
                 // title
                 Element title = threadElement.select(".thread_title").first();
                 if (title != null) {
-                    thread.put(TITLE, title.text());
+                    thread.title = title.text();
                 }
 
                 // thread author, and whether it's the user
                 boolean userIsAuthor = false;
                 Element author = threadElement.select(".author").first();
                 if (author != null) {
-                    thread.put(AUTHOR, author.text());
+                    thread.author = author.text();
                     String href = author.select("a[href*='userid']").first().attr("href");
-                    thread.put(AUTHOR_ID, Uri.parse(href).getQueryParameter("userid"));
+                    thread.authorId = parseInt(Uri.parse(href).getQueryParameter("userid"));
 
                     userIsAuthor = author.text().equals(username);
                 }
-                thread.put(CAN_OPEN_CLOSE, userIsAuthor ? 1 : 0);
+                thread.canOpenClose = userIsAuthor;
 
-                thread.put(LASTPOSTER, threadElement.select(".lastpost .author").first().text());
-                thread.put(LOCKED, threadElement.hasClass("closed") ? 1 : 0);
-                thread.put(STICKY, threadElement.select(".title_sticky").isEmpty() ? 0 : 1);
+                thread.lastPoster = threadElement.select(".lastpost .author").first().text();
+                thread.isLocked = threadElement.hasClass("closed");
+                thread.isSticky = threadElement.select(".title_sticky").isEmpty();
 
 
                 // optional thread rating
                 Element rating = threadElement.select(".rating img").first();
-                thread.put(RATING, rating != null ? AwfulRatings.getId(rating.attr("src")) : AwfulRatings.NO_RATING);
+                thread.rating = (rating != null) ? AwfulRatings.getId(rating.attr("src")) : AwfulRatings.NO_RATING;
 
 
                 // main thread tag
@@ -204,41 +318,40 @@ public class AwfulThread extends AwfulPagedItem  {
                 if (threadTag != null) {
                     Matcher threadTagMatcher = urlId_regex.matcher(threadTag.attr("src"));
                     if (threadTagMatcher.find()) {
-                        thread.put(TAG_URL, threadTagMatcher.group(1));
-                        thread.put(CATEGORY, threadTagMatcher.group(2));
+                        thread.tagUrl = threadTagMatcher.group(1);
+                        thread.category = parseInt(threadTagMatcher.group(2));
                         //thread tag stuff
                         Matcher fileNameMatcher = AwfulEmote.fileName_regex.matcher(threadTagMatcher.group(1));
                         if (fileNameMatcher.find()) {
-                            thread.put(TAG_CACHEFILE, fileNameMatcher.group(1));
+                            thread.tagCacheFile = fileNameMatcher.group(1);
                         }
                     } else {
-                        thread.put(CATEGORY, 0);
+                        thread.category = 0;
                     }
                 }
 
                 // secondary thread tag (e.g. Ask/Tell type)
                 Element extraTag = threadElement.select(".icon2 img").first();
-                thread.put(TAG_EXTRA, extraTag != null ? ExtraTags.getId(extraTag.attr("src")) : ExtraTags.NO_TAG);
+                thread.tagExtra = (extraTag != null) ? ExtraTags.getId(extraTag.attr("src")) : ExtraTags.NO_TAG;
 
 
                 // replies / postcount
                 Element postCount = threadElement.select(".replies").first();
                 if (postCount != null) {
                     // this represents the number of replies, but the actual postcount includes OP
-                    thread.put(POSTCOUNT, Integer.parseInt(postCount.text()) + 1);
+                    thread.postCount = Integer.parseInt(postCount.text()) + 1;
                 }
 
 
                 // unread count / viewed status
                 Element unreadCount = threadElement.select(".count").first();
                 if (unreadCount != null) {
-                    thread.put(UNREADCOUNT, Integer.parseInt(unreadCount.text()));
-                    thread.put(HAS_VIEWED_THREAD, 1);
+                    thread.unreadCount = parseInt(unreadCount.text());
+                    thread.hasBeenViewed = true;
                 } else {
-                    thread.put(UNREADCOUNT, 0);
+                    thread.unreadCount = 0;
                     // If there are X's then the user has viewed the thread
-                    boolean hasClearCountButton = !threadElement.select(".x").isEmpty();
-                    thread.put(HAS_VIEWED_THREAD, hasClearCountButton ? 1 : 0);
+                    thread.hasBeenViewed = !threadElement.select(".x").isEmpty();
                 }
 
                 // bookmarked status
@@ -254,10 +367,19 @@ public class AwfulThread extends AwfulPagedItem  {
                         bookmarkType = 3;
                     }
                 }
-                thread.put(BOOKMARKED, bookmarkType);
+                thread.bookmarkType = bookmarkType;
 
-                // finally add the parsed thread
-                result.add(thread);
+
+                // finally create and add the parsed thread
+                // TODO: 04/06/2017 handle this in the database classes
+                ContentValues cv = thread.toContentValues();
+                cv.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);
+                // don't update these values if we are loading bookmarks, or it will overwrite the cached forum results.
+                if (forumId == Constants.USERCP_ID) {
+                    cv.remove(INDEX);
+                    cv.remove(FORUM_ID);
+                }
+                result.add(cv);
             } catch (NullPointerException e) {
                 // If we can't parse a row, just skip it
                 e.printStackTrace();
@@ -294,46 +416,37 @@ public class AwfulThread extends AwfulPagedItem  {
         // first parse general thread metadata
 
         Cursor threadData = resolver.query(ContentUris.withAppendedId(CONTENT_URI, threadId), AwfulProvider.ThreadProjection, null, null, null);
-        int totalPosts = 0, unread = 0, opId = 0, bookmarkStatus = 0, hasViewedThread = 0;
+        AwfulThread thread = null;
         if (threadData != null && threadData.moveToFirst()) {
-            totalPosts = threadData.getInt(threadData.getColumnIndex(POSTCOUNT));
-            unread = threadData.getInt(threadData.getColumnIndex(UNREADCOUNT));
-            opId = threadData.getInt(threadData.getColumnIndex(AUTHOR_ID));
-            hasViewedThread = threadData.getInt(threadData.getColumnIndex(HAS_VIEWED_THREAD));
-            bookmarkStatus = threadData.getInt(threadData.getColumnIndex(BOOKMARKED));
-        }
-        if (threadData != null) {
+            thread = fromCursorRow(threadData);
             threadData.close();
         }
+        if (thread == null) {
+            thread = new AwfulThread();
+        }
 
-        ContentValues thread = new ContentValues();
-        thread.put(ID, threadId);
+        thread.id = threadId;
 
         Element title = page.getElementsByClass("bclast").first();
-        thread.put(TITLE, title != null ? title.text() : "UNKNOWN TITLE");
+        thread.title = (title == null) ? "UNKNOWN TITLE" : title.text();
 
         // look for a real reply button - if there isn't one, this thread is locked
         Element replyButton = page.select("[alt=Reply]:not([src*='forum-closed'])").first();
-        thread.put(LOCKED, (replyButton == null) ? 1 : 0);
+        thread.isLocked = (replyButton == null);
 
         Element openCloseButton = page.select("[alt='Close thread']").first();
-        thread.put(CAN_OPEN_CLOSE, (openCloseButton == null) ? 0 : 1);
+        thread.canOpenClose = (openCloseButton != null);
 
         Element bookmarkButton = page.select(".thread_bookmark").first();
         // we're assuming no bookmark button means archived - there's an explicit archived icon we could find too
-        boolean archived = (bookmarkButton == null);
-        thread.put(ARCHIVED, archived ? 1 : 0);
+        thread.archived = (bookmarkButton == null);
+        boolean bookmarked = (bookmarkButton != null) && bookmarkButton.attr("src").contains("unbookmark");
 
-        if (archived) {
-            thread.put(BOOKMARKED, 0);
-        } else {
-            boolean bookmarked = bookmarkButton.attr("src").contains("unbookmark");
-            if (bookmarked) {
-                // retain the old status, unless it was 0 (unbookmarked)
-                thread.put(BOOKMARKED, (bookmarkStatus < 1) ? 1 : bookmarkStatus);
-            } else {
-                thread.put(BOOKMARKED, 0);
-            }
+        if (!bookmarked) {
+            thread.bookmarkType = 0;
+        } else if (thread.bookmarkType == 0) {
+            // update bookmarked status when it was previously 'unbookmarked'
+            thread.bookmarkType = 1;
         }
 
         // ID of this thread's forum
@@ -342,46 +455,48 @@ public class AwfulThread extends AwfulPagedItem  {
         for (Element breadcrumb : page.select(".breadcrumbs [href]")) {
             matchForumId = forumId_regex.matcher(breadcrumb.attr("href"));
             if (matchForumId.find()) {//switched this to a regex
-                forumId = Integer.parseInt(matchForumId.group(1));//so this won't fail
+                forumId = parseInt(matchForumId.group(1));//so this won't fail
             }
         }
-        thread.put(FORUM_ID, forumId);
+        thread.forumId = forumId;
 
 
         // now calculate some read/unread numbers based on what we can see on the page
         int lastPageNumber = AwfulPagedItem.parseLastPage(page);
         int firstPostOnPageIndex = AwfulPagedItem.pageToIndex(pageNumber, postsPerPage, 0);
-        int firstUnreadIndex = (hasViewedThread == 0) ? 0 : totalPosts - unread;
+        int firstUnreadIndex = !thread.hasBeenViewed ? 0 : thread.postCount - thread.unreadCount;
 
         // hand off the page for post parsing, and get back the number of posts it found
         // TODO: 02/06/2017 sort out the ignored posts issue, the post parser doesn't put them in the DB (if you have 'always hide' on in the settings) and it messes up the numbers
-        int postsOnThisPage = AwfulPost.syncPosts(resolver, page, threadId, firstUnreadIndex, opId, prefs, firstPostOnPageIndex);
+        int postsOnThisPage = AwfulPost.syncPosts(resolver, page, threadId, firstUnreadIndex, thread.authorId, prefs, firstPostOnPageIndex);
         int postsOnPreviousPages = (pageNumber - 1) * postsPerPage;
         int postsRead = postsOnPreviousPages + postsOnThisPage;
 
-        // we might have more recent info here, see if we need to update totalPosts
+        // we might have more recent info here, see if we need to update lastPostCount
         // first up, if this is the last page then we've read all the posts
         if (pageNumber == lastPageNumber) {
-            totalPosts = postsRead;
+            thread.postCount = postsRead;
         } else {
             // we can calculate a minimum and maximum posts range by looking at the last page number
             int minTotal = ((lastPageNumber - 1) * postsPerPage) + 1;   // one post on the last page, any preceding pages are full
             int maxTotal = lastPageNumber * postsPerPage;               // all pages full
-            // if totalPosts is within this range, let's just assume it's more accurate than taking the minimum
+            // if lastPostCount is within this range, let's just assume it's more accurate than taking the minimum
             // if it's outside of that range it's obviously a stale value, use the min as our best guess
-            totalPosts = (minTotal <= totalPosts && totalPosts <= maxTotal) ? totalPosts : minTotal;
+            int lastPostCount = thread.postCount;
+            thread.postCount = (minTotal <= lastPostCount && lastPostCount <= maxTotal) ? lastPostCount : minTotal;
         }
+        thread.unreadCount = thread.postCount - postsRead;
 
-        int unreadPosts = totalPosts - postsRead;
-        Log.d(TAG, String.format("getThreadPosts: Thread ID %d, page %d of %d, %d posts on page%n%d posts read, %d unread of %d total.",
-                threadId, pageNumber, lastPageNumber, postsOnThisPage, postsRead, unreadPosts, totalPosts));
-
+        Log.d(TAG, String.format("getThreadPosts: Thread ID %d, page %d of %d, %d posts on page%n%d posts total: %d read/%d unread",
+                thread.id, pageNumber, lastPageNumber, postsOnThisPage, thread.postCount, postsRead, thread.unreadCount));
 
         // finally write new thread data to the database
-        thread.put(AwfulThread.POSTCOUNT, totalPosts);
-        thread.put(AwfulThread.UNREADCOUNT, unreadPosts);
-        if (resolver.update(ContentUris.withAppendedId(CONTENT_URI, threadId), thread, null, null) < 1) {
-            resolver.insert(CONTENT_URI, thread);
+        ContentValues cv = thread.toContentValues();
+        // TODO: 04/06/2017 this should be handled in the database-management classes
+        String update_time = new Timestamp(System.currentTimeMillis()).toString();
+        cv.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);
+        if (resolver.update(ContentUris.withAppendedId(CONTENT_URI, threadId), cv, null, null) < 1) {
+            resolver.insert(CONTENT_URI, cv);
         }
     }
 
@@ -416,6 +531,7 @@ public class AwfulThread extends AwfulPagedItem  {
         return buffer.toString();
     }
 
+
     public static String getHtml(List<AwfulPost> aPosts, AwfulPreferences aPrefs, int page, int lastPage, int forumId, boolean threadLocked) {
         StringBuilder buffer = new StringBuilder(1024);
         buffer.append("<div class='content'>\n");
@@ -447,6 +563,7 @@ public class AwfulThread extends AwfulPagedItem  {
 
         return buffer.toString();
     }
+
 
     public static String getPostsHtml(List<AwfulPost> aPosts, AwfulPreferences aPrefs, boolean threadLocked) {
         StringBuilder buffer = new StringBuilder();
@@ -516,31 +633,37 @@ public class AwfulThread extends AwfulPagedItem  {
         return buffer.toString();
     }
 
-	@SuppressWarnings("deprecation")
-	public static void getView(View current, AwfulPreferences prefs, Cursor data, AwfulFragment parent) {
-        Resources resources = current.getResources();
-        Context context = current.getContext();
 
+	@SuppressWarnings("deprecation")
+	public static void setDataOnThreadListItem(View item, AwfulPreferences prefs, Cursor data, AwfulFragment parent) {
+        AwfulThread thread = fromCursorRow(data);
+        if (thread == null) {
+            Log.w(TAG, "setDataOnThreadView: unable to get data for thread!");
+            return;
+        }
+
+        Resources resources = item.getResources();
+        Context context = item.getContext();
+        // get the forum ID for getting themed resources
         Integer forumId = null;
         if (ForumDisplayFragment.class.isInstance(parent)) {
             forumId = ((ForumDisplayFragment) parent).getForumId();
         }
 
-        TextView info   = (TextView) current.findViewById(R.id.thread_info);
-        TextView title  = (TextView) current.findViewById(R.id.title);
-        TextView unread = (TextView) current.findViewById(R.id.unread_count);
-        boolean stuck   = data.getInt(data.getColumnIndex(STICKY)) >0;
-        int unreadCount = data.getInt(data.getColumnIndex(UNREADCOUNT));
-        int bookmarked  = data.getInt(data.getColumnIndex(BOOKMARKED));
-        boolean hasViewedThread = data.getInt(data.getColumnIndex(HAS_VIEWED_THREAD)) == 1;
 
-        final ImageView threadTag = (ImageView) current.findViewById(R.id.thread_tag);
-        threadTag.setVisibility(View.GONE);
+        // thread title
+        TextView title  = findById(item, R.id.title);
+        title.setText(thread.title != null ? thread.title : "UNKNOWN");
+        title.setTextColor(ColorProvider.PRIMARY_TEXT.getColor(forumId));
+
+
+        // main thread tag
+        final ImageView threadTag = findById(item, R.id.thread_tag);
+        threadTag.setVisibility(GONE);
         if (prefs.threadInfo_Tag) {
-			String tagFile = data.getString(data.getColumnIndex(TAG_CACHEFILE));
-			if (!TextUtils.isEmpty(tagFile)) {
-                threadTag.setVisibility(View.VISIBLE);
-                String url = data.getString(data.getColumnIndex(TAG_URL));
+			if (!TextUtils.isEmpty(thread.tagCacheFile)) {
+                threadTag.setVisibility(VISIBLE);
+                String url = thread.tagUrl;
                 String localFileName = "@drawable/"+url.substring(url.lastIndexOf('/') + 1,url.lastIndexOf('.')).replace('-','_').toLowerCase();
 
                 int imageID = resources.getIdentifier(localFileName, null, context.getPackageName());
@@ -563,89 +686,75 @@ public class AwfulThread extends AwfulPagedItem  {
 		}
 
 
-        /*
-            Tag overlay (secondary tags etc)
-         */
-        int tagId = data.getInt(data.getColumnIndex(TAG_EXTRA));
-        ImageView forumTagOverlay = (ImageView) current.findViewById(R.id.thread_tag_overlay);
-        ImageView forumTagOverlayOpt = (ImageView) current.findViewById(R.id.thread_tag_overlay_optional);
-        forumTagOverlay.setVisibility(View.GONE);
-        forumTagOverlayOpt.setVisibility(View.GONE);
-        if (ExtraTags.getType(tagId) != ExtraTags.TYPE_NO_TAG) {
-            Drawable tagIcon = ExtraTags.getDrawable(tagId, resources);
+        // tag overlay (secondary tags etc)
+        ImageView forumTagOverlay = findById(item, R.id.thread_tag_overlay);
+        ImageView inlineForumTagOverlay = findById(item, R.id.thread_tag_overlay_optional);
+        forumTagOverlay.setVisibility(GONE);
+        inlineForumTagOverlay.setVisibility(GONE);
+        if (ExtraTags.getType(thread.tagExtra) != ExtraTags.TYPE_NO_TAG) {
+            Drawable tagIcon = ExtraTags.getDrawable(thread.tagExtra, resources);
             if (tagIcon != null) {
                 if(prefs.threadInfo_Tag) {
-                    forumTagOverlay.setVisibility(View.VISIBLE);
-                    forumTagOverlay.setImageDrawable(tagIcon);
+                    showImage(forumTagOverlay, tagIcon);
                 }else {
-                    forumTagOverlayOpt.setVisibility(View.VISIBLE);
-                    forumTagOverlayOpt.setImageDrawable(tagIcon);
+                    showImage(inlineForumTagOverlay, tagIcon);
                 }
             }
         }
 
-        info.setVisibility(View.VISIBLE);
-        StringBuilder tmp = new StringBuilder();
-        tmp.append(AwfulPagedItem.indexToPage(data.getInt(data.getColumnIndex(POSTCOUNT)), prefs.postPerPage)).append(" pgs");
-        if(hasViewedThread){
-            tmp.append(" | Last: ").append(NetworkUtils.unencodeHtml(data.getString(data.getColumnIndex(LASTPOSTER))));
-        }else{
-            tmp.append(" | OP: ").append(NetworkUtils.unencodeHtml(data.getString(data.getColumnIndex(AUTHOR))));
-        }
-        info.setText(tmp.toString().trim());
+
+        // page count / author / last poster info line
+        TextView info   = findById(item, R.id.thread_info);
+        info.setVisibility(VISIBLE);
+        String tmp = String.format(Locale.US, "%d pgs | %s: %s",
+                thread.getPageCount(prefs.postPerPage),
+                thread.hasBeenViewed ? "Last" : "OP",
+                NetworkUtils.unencodeHtml(thread.hasBeenViewed ? thread.lastPoster : thread.author));
+        info.setText(tmp.trim());
+        info.setTextColor(ColorProvider.ALT_TEXT.getColor(forumId));
 
 
-        /*
-            Ratings
-         */
-        ImageView threadRating = (ImageView)current.findViewById(R.id.thread_rating);
-        ImageView threadRatingOpt = (ImageView)current.findViewById(R.id.thread_rating_optional);
-        threadRating.setVisibility(View.GONE);
-        threadRatingOpt.setVisibility(View.GONE);
+        // ratings
+        ImageView threadRating = findById(item, R.id.thread_rating);
+        ImageView inlineThreadRating = findById(item, R.id.thread_rating_optional);
+        threadRating.setVisibility(GONE);
+        inlineThreadRating.setVisibility(GONE);
+        // if we're showing ratings...
         if (prefs.threadInfo_Rating) {
-            int rating = data.getInt(data.getColumnIndex(RATING));
-            Drawable ratingIcon = AwfulRatings.getDrawable(rating, resources);
-            if (ratingIcon != null) {
-                // replace thread tag with special rating tag in the Film Dump
-                if (AwfulRatings.getType(rating) == AwfulRatings.TYPE_FILM_DUMP) {
-                    threadTag.setVisibility(View.VISIBLE);
-                    threadTag.setImageDrawable(ratingIcon);
+            Drawable ratingIcon = AwfulRatings.getDrawable(thread.rating, resources);
+                // Film Dump replaces the actual thread tag, instead of using the separate rating view
+                if (AwfulRatings.getType(thread.rating) == AwfulRatings.TYPE_FILM_DUMP) {
+                    showImage(threadTag, ratingIcon);
                 } else {
-                    if(prefs.threadInfo_Tag){
-                        threadRating.setVisibility(View.VISIBLE);
-                        threadRating.setImageDrawable(ratingIcon);
-                    }else{
-                        threadRatingOpt.setVisibility(View.VISIBLE);
-                        threadRatingOpt.setImageDrawable(ratingIcon);
-                    }
+                    showImage(prefs.threadInfo_Tag ? threadRating : inlineThreadRating, ratingIcon);
                 }
-            }
         }
 
 
-        ImageView threadLocked = (ImageView)current.findViewById(R.id.thread_locked);
-        threadLocked.setVisibility(View.GONE);
-        ImageView threadSticky = (ImageView)current.findViewById(R.id.thread_sticky);
-        threadSticky.setVisibility(View.GONE);
-        if (stuck) {
-            threadSticky.setVisibility(View.VISIBLE);
-        } else if (data.getInt(data.getColumnIndex(LOCKED)) > 0){
-            //don't show lock if sticky, aka: every rules thread
-            threadLocked.setVisibility(View.VISIBLE);
-            current.setBackgroundColor(ColorProvider.BACKGROUND.getColor(forumId));
+        // locked and sticky status
+        ImageView threadLocked = findById(item, R.id.thread_locked);
+        ImageView threadSticky = findById(item, R.id.thread_sticky);
+        threadSticky.setVisibility(thread.isSticky ? VISIBLE : GONE);
+        threadLocked.setVisibility(thread.isLocked && !thread.isSticky ? VISIBLE : GONE);
+        if (thread.isLocked && !thread.isSticky) {
+            // TODO: 03/06/2017 what's this about?
+            item.setBackgroundColor(ColorProvider.BACKGROUND.getColor(forumId));
         }
 
-        unread.setVisibility(View.GONE);
-        if(hasViewedThread) {
-            unread.setVisibility(View.VISIBLE);
+
+        // unread counter
+        TextView unread = findById(item, R.id.unread_count);
+        unread.setVisibility(GONE);
+        if(thread.hasBeenViewed) {
+            unread.setVisibility(VISIBLE);
             unread.setTextColor(ColorProvider.UNREAD_TEXT.getColor(forumId));
-            unread.setText(Integer.toString(unreadCount));
+            unread.setText(Integer.toString(thread.unreadCount));
             GradientDrawable counter = (GradientDrawable) resources.getDrawable(R.drawable.unread_counter);
             if (counter != null) {
                 counter.mutate();
-                boolean dim = unreadCount < 1;
-                if (bookmarked > 0 && prefs.coloredBookmarks) {
-                    counter.setColor(ColorProvider.getBookmarkColor(bookmarked, dim));
+                boolean dim = !thread.hasNewPosts();
+                if (thread.bookmarkType > 0 && prefs.coloredBookmarks) {
+                    counter.setColor(ColorProvider.getBookmarkColor(thread.bookmarkType, dim));
                 } else {
                     ColorProvider colorAttr = dim ? ColorProvider.UNREAD_BACKGROUND_DIM : ColorProvider.UNREAD_BACKGROUND;
                     counter.setColor(colorAttr.getColor(forumId));
@@ -654,12 +763,12 @@ public class AwfulThread extends AwfulPagedItem  {
             }
         }
 
-        String titleText = data.getString(data.getColumnIndex(TITLE));
-        if(titleText != null){
-			title.setText(titleText);
-		}
-        title.setTextColor(ColorProvider.PRIMARY_TEXT.getColor(forumId));
-        info.setTextColor(ColorProvider.ALT_TEXT.getColor(forumId));
 	}
+
+	/** Utility method to set and show an imageview */
+    private static void showImage(ImageView imageView, Drawable drawable) {
+        imageView.setVisibility(VISIBLE);
+        imageView.setImageDrawable(drawable);
+    }
 
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -66,7 +66,6 @@ import com.samskivert.mustache.Template;
 
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 
 import java.io.File;
 import java.io.FileReader;
@@ -133,263 +132,259 @@ public class AwfulThread extends AwfulPagedItem  {
 	private static final Pattern urlId_regex = Pattern.compile("([^#]+)#(\\d+)$");
 
 
-	public static ArrayList<ContentValues> parseForumThreads(Document aResponse, int start_index, int forumId) {
-        ArrayList<ContentValues> result = new ArrayList<>();
-        Element threads = aResponse.getElementById("forum");
+    /**
+     * Parse a list of threads in a forum and generate their metadata.
+     * <p>
+     * This doesn't write to the database, you need to do this with the returned data.
+     *
+     * @param forumPage  the page to parse
+     * @param forumId    the ID of the forum this page is from
+     * @param startIndex the threads' positions in the forum will start from this index
+     * @return the list of all the threads' metadata objects, ready for storage
+     */
+    public static ArrayList<ContentValues> parseForumThreads(Document forumPage, int forumId, int startIndex) {
         String update_time = new Timestamp(System.currentTimeMillis()).toString();
+        ArrayList<ContentValues> result = new ArrayList<>();
         Log.v(TAG, "Update time: " + update_time);
-		for(Element node : threads.getElementsByClass("thread")){
+        String username = AwfulPreferences.getInstance().username;
+
+        for (Element threadElement : forumPage.select("#forum .thread")) {
             try {
-    			ContentValues thread = new ContentValues();
-                String threadId = node.id();
-                if(threadId == null || threadId.length() < 1){
-                	//skip the table header
-                	continue;
+                String threadId = threadElement.id();
+                if (TextUtils.isEmpty(threadId)) {
+                    //skip the table header
+                    continue;
                 }
+
+                // start building thread data
+                ContentValues thread = new ContentValues();
+                thread.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);
                 thread.put(ID, Integer.parseInt(threadId.replaceAll("\\D", "")));
-                if(forumId != Constants.USERCP_ID){//we don't update these values if we are loading bookmarks, or it will overwrite the cached forum results.
-                	thread.put(INDEX, start_index);
-                	thread.put(FORUM_ID, forumId);
-                }
-                start_index++;
-                Elements tarThread = node.getElementsByClass("thread_title");
-                Elements tarPostCount = node.getElementsByClass("replies");
-            	if (tarPostCount.size() > 0) {
-                    thread.put(POSTCOUNT, Integer.parseInt(tarPostCount.first().text().trim())+1);//this represents the number of replies, but the actual postcount includes OP
-                }
-                if (tarThread.size() > 0) {
-                    thread.put(TITLE, tarThread.first().text().trim());
-                }
 
-                if(node.hasClass("closed")){
-                	thread.put(LOCKED, 1);
-                }else{
-                	thread.put(LOCKED, 0);
+                // don't update these values if we are loading bookmarks, or it will overwrite the cached forum results.
+                if (forumId != Constants.USERCP_ID) {
+                    thread.put(INDEX, startIndex);
+                    thread.put(FORUM_ID, forumId);
                 }
+                startIndex++;
 
 
-                Elements killedBy = node.getElementsByClass("lastpost");
-                thread.put(LASTPOSTER, killedBy.first().getElementsByClass("author").first().text());
-                Elements tarSticky = node.getElementsByClass("title_sticky");
-                if (tarSticky.size() > 0) {
-                    thread.put(STICKY,1);
-                } else {
-                    thread.put(STICKY,0);
+                // parse out the various elements in the thread html:
+
+                // title
+                Element title = threadElement.select(".thread_title").first();
+                if (title != null) {
+                    thread.put(TITLE, title.text());
                 }
 
-                Element rating = node.getElementsByClass("rating").first();
-                if (rating != null && rating.children().size() > 0){
-                	Element img = rating.children().first();
-                	thread.put(RATING, AwfulRatings.getId(img.attr("src")));
-                } else {
-                	thread.put(RATING, AwfulRatings.NO_RATING);
-                }
+                // thread author, and whether it's the user
+                boolean userIsAuthor = false;
+                Element author = threadElement.select(".author").first();
+                if (author != null) {
+                    thread.put(AUTHOR, author.text());
+                    String href = author.select("a[href*='userid']").first().attr("href");
+                    thread.put(AUTHOR_ID, Uri.parse(href).getQueryParameter("userid"));
 
-                Elements tarIcon = node.getElementsByClass("icon");
-                if (tarIcon.size() > 0 && tarIcon.first().getAllElements().size() >0) {
-                    Matcher threadTagMatcher = urlId_regex.matcher(tarIcon.first().getElementsByTag("img").first().attr("src"));
-                    if(threadTagMatcher.find()){
-                    	//thread tag stuff
-        				Matcher fileNameMatcher = AwfulEmote.fileName_regex.matcher(threadTagMatcher.group(1));
-        				if(fileNameMatcher.find()){
-        					thread.put(TAG_CACHEFILE,fileNameMatcher.group(1));
-        				}
-                    	thread.put(TAG_URL, threadTagMatcher.group(1));
-                    	thread.put(CATEGORY, threadTagMatcher.group(2));
-                    }else{
-                    	thread.put(CATEGORY, 0);
+                    userIsAuthor = author.text().equals(username);
+                }
+                thread.put(CAN_OPEN_CLOSE, userIsAuthor ? 1 : 0);
+
+                thread.put(LASTPOSTER, threadElement.select(".lastpost .author").first().text());
+                thread.put(LOCKED, threadElement.hasClass("closed") ? 1 : 0);
+                thread.put(STICKY, threadElement.select(".title_sticky").isEmpty() ? 0 : 1);
+
+
+                // optional thread rating
+                Element rating = threadElement.select(".rating img").first();
+                thread.put(RATING, rating != null ? AwfulRatings.getId(rating.attr("src")) : AwfulRatings.NO_RATING);
+
+
+                // main thread tag
+                Element threadTag = threadElement.select(".icon img").first();
+                if (threadTag != null) {
+                    Matcher threadTagMatcher = urlId_regex.matcher(threadTag.attr("src"));
+                    if (threadTagMatcher.find()) {
+                        thread.put(TAG_URL, threadTagMatcher.group(1));
+                        thread.put(CATEGORY, threadTagMatcher.group(2));
+                        //thread tag stuff
+                        Matcher fileNameMatcher = AwfulEmote.fileName_regex.matcher(threadTagMatcher.group(1));
+                        if (fileNameMatcher.find()) {
+                            thread.put(TAG_CACHEFILE, fileNameMatcher.group(1));
+                        }
+                    } else {
+                        thread.put(CATEGORY, 0);
                     }
                 }
 
-                /*
-                    secondary tags
-                 */
-                Element extraTag = node.getElementsByClass("icon2").first();
-                if (extraTag != null && extraTag.children().size() > 0){
-                    Element img = extraTag.children().first();
-                    thread.put(TAG_EXTRA, ExtraTags.getId(img.attr("src")));
+                // secondary thread tag (e.g. Ask/Tell type)
+                Element extraTag = threadElement.select(".icon2 img").first();
+                thread.put(TAG_EXTRA, extraTag != null ? ExtraTags.getId(extraTag.attr("src")) : ExtraTags.NO_TAG);
+
+
+                // replies / postcount
+                Element postCount = threadElement.select(".replies").first();
+                if (postCount != null) {
+                    // this represents the number of replies, but the actual postcount includes OP
+                    thread.put(POSTCOUNT, Integer.parseInt(postCount.text()) + 1);
+                }
+
+
+                // unread count / viewed status
+                Element unreadCount = threadElement.select(".count").first();
+                if (unreadCount != null) {
+                    thread.put(UNREADCOUNT, Integer.parseInt(unreadCount.text()));
+                    thread.put(HAS_VIEWED_THREAD, 1);
                 } else {
-                    thread.put(TAG_EXTRA, ExtraTags.NO_TAG);
-                }
-
-                Elements tarUser = node.getElementsByClass("author");
-                if (tarUser.size() > 0) {
-                    // There's got to be a better way to do this
-                    thread.put(AUTHOR, tarUser.first().text().trim());
-                    // And probably a much better way to do this
-                    thread.put(AUTHOR_ID,tarUser.first().getElementsByAttribute("href").first().attr("href").substring(tarUser.first().getElementsByAttribute("href").first().attr("href").indexOf("userid=")+7));
-                }
-
-                if(thread.containsKey(AUTHOR)&& thread.getAsString(AUTHOR).equals(AwfulPreferences.getInstance().username)){
-                    thread.put(CAN_OPEN_CLOSE,1);
-                }else{
-                    thread.put(CAN_OPEN_CLOSE,0);
-                }
-
-                Elements tarCount = node.getElementsByClass("count");
-                if (tarCount.size() > 0 && tarCount.first().getAllElements().size() > 0) {
-                    thread.put(UNREADCOUNT, Integer.parseInt(tarCount.first().getAllElements().first().text().trim()));
-					thread.put(HAS_VIEWED_THREAD, 1);
-                } else {
-					thread.put(UNREADCOUNT, 0);
-                	Elements tarXCount = node.getElementsByClass("x");
+                    thread.put(UNREADCOUNT, 0);
                     // If there are X's then the user has viewed the thread
-					thread.put(HAS_VIEWED_THREAD, (tarXCount.isEmpty()?0:1));
+                    boolean hasClearCountButton = !threadElement.select(".x").isEmpty();
+                    thread.put(HAS_VIEWED_THREAD, hasClearCountButton ? 1 : 0);
                 }
-                Elements tarStar = node.getElementsByClass("star");
-                if(tarStar.size()>0) {
+
+                // bookmarked status
+                Element star = threadElement.select(".star").first();
+                int bookmarkType = 0;
+                if (star != null) {
                     // Bookmarks can only be detected now by the presence of a "bmX" class - no star image
-                    if(tarStar.first().hasClass("bm0")) {
-                        thread.put(BOOKMARKED, 1);
+                    if (star.hasClass("bm0")) {
+                        bookmarkType = 1;
+                    } else if (star.hasClass("bm1")) {
+                        bookmarkType = 2;
+                    } else if (star.hasClass("bm2")) {
+                        bookmarkType = 3;
                     }
-                    else if(tarStar.first().hasClass("bm1")) {
-                        thread.put(BOOKMARKED, 2);
-                    }
-                    else if(tarStar.first().hasClass("bm2")) {
-                        thread.put(BOOKMARKED, 3);
-                    }
-                    else {
-                        thread.put(BOOKMARKED, 0);
-                    }
-                } else {
-                    thread.put(BOOKMARKED, 0);
                 }
-        		thread.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);
+                thread.put(BOOKMARKED, bookmarkType);
+
+                // finally add the parsed thread
                 result.add(thread);
             } catch (NullPointerException e) {
                 // If we can't parse a row, just skip it
                 e.printStackTrace();
-                continue;
             }
         }
         return result;
-	}
-
-	public static ArrayList<ContentValues> parseSubforums(Document aResponse, int parentForumId){
-        ArrayList<ContentValues> result = new ArrayList<>();
-		Elements subforums = aResponse.getElementsByClass("subforum");
-        for(Element sf : subforums){
-        	Elements href = sf.getElementsByAttribute("href");
-        	if(href.size() <1){
-        		continue;
-        	}
-        	int id = Integer.parseInt(href.first().attr("href").replaceAll("\\D", ""));
-        	if(id > 0){
-        		ContentValues tmp = new ContentValues();
-        		tmp.put(AwfulForum.ID, id);
-        		tmp.put(AwfulForum.PARENT_ID, parentForumId);
-        		tmp.put(AwfulForum.TITLE, href.first().text());
-        		Elements subtext = sf.getElementsByTag("dd");
-        		if(subtext.size() >1){
-        			tmp.put(AwfulForum.SUBTEXT, subtext.first().text().replaceAll("\"", "").trim().substring(2));//ugh
-        		}
-        		result.add(tmp);
-        	}
-        }
-        return result;
     }
 
-    public static void getThreadPosts(ContentResolver contentResolv, Document response, int aThreadId, int aPage, int aPageSize, AwfulPreferences aPrefs, int aUserId) {
 
+    /**
+     * Parse a page from a thread, updating metadata and parsing the contained posts.
+     * <p>
+     * This will update the current read/unread counts, estimating the total number of posts
+     * if the last recorded total is too low (by the current number of pages) and this isn't the last page
+     * (meaning we only know how many full pages there are, not how many posts are on the last page).
+     * Defaults to a minimum estimate, i.e. a single post on the last page.
+     * <p>
+     * Also stores/updates the rest of the thread metadata - title, locked status etc., and passes
+     * the page to {@link AwfulPost} for parsing and syncing.
+     *
+     * @param resolver     a ContentResolver used to access the database
+     * @param page         the thread page's HTML document
+     * @param threadId     the ID of this thread
+     * @param pageNumber   which page of the thread this document represents
+     * @param postsPerPage used to calculate post counts
+     * @param prefs        a preferences instance
+     * @param filterUserId if this page is for a thread filtered by user, this should be set to the user's ID, otherwise 0
+     */
+    public static void parseThreadPage(ContentResolver resolver, Document page, int threadId, int pageNumber, int postsPerPage, AwfulPreferences prefs, int filterUserId) {
+        // TODO: 03/06/2017 see issue #503 on GitHub - filtering by user means the thread data gets overwritten by the pages from this new, shorter thread containing their posts
+        final int BLANK_USER_ID = 0;
+        final boolean filteringOnUserId = filterUserId > BLANK_USER_ID;
 
-		Cursor threadData = contentResolv.query(ContentUris.withAppendedId(CONTENT_URI, aThreadId), AwfulProvider.ThreadProjection, null, null, null);
-    	int totalReplies = 0, unread = 0, opId = 0, bookmarkStatus = 0, hasViewedThread = 0, postcount = 0;
-		if(threadData != null && threadData.moveToFirst()){
-			totalReplies    = threadData.getInt(threadData.getColumnIndex(POSTCOUNT));
-			unread          = threadData.getInt(threadData.getColumnIndex(UNREADCOUNT));
-            postcount       = threadData.getInt(threadData.getColumnIndex(POSTCOUNT));
-			opId            = threadData.getInt(threadData.getColumnIndex(AUTHOR_ID));
-			hasViewedThread = threadData.getInt(threadData.getColumnIndex(HAS_VIEWED_THREAD));
-			bookmarkStatus  = threadData.getInt(threadData.getColumnIndex(BOOKMARKED));
-		}
+        // first parse general thread metadata
 
-        ContentValues thread = new ContentValues();
-        thread.put(ID, aThreadId);
-    	Elements tarTitle = response.getElementsByClass("bclast");
-        if (tarTitle.size() > 0) {
-        	thread.put(TITLE, tarTitle.first().text().trim());
-        }else{
-        	Log.e(TAG,"TITLE NOT FOUND!");
+        Cursor threadData = resolver.query(ContentUris.withAppendedId(CONTENT_URI, threadId), AwfulProvider.ThreadProjection, null, null, null);
+        int totalPosts = 0, unread = 0, opId = 0, bookmarkStatus = 0, hasViewedThread = 0;
+        if (threadData != null && threadData.moveToFirst()) {
+            totalPosts = threadData.getInt(threadData.getColumnIndex(POSTCOUNT));
+            unread = threadData.getInt(threadData.getColumnIndex(UNREADCOUNT));
+            opId = threadData.getInt(threadData.getColumnIndex(AUTHOR_ID));
+            hasViewedThread = threadData.getInt(threadData.getColumnIndex(HAS_VIEWED_THREAD));
+            bookmarkStatus = threadData.getInt(threadData.getColumnIndex(BOOKMARKED));
         }
-
-        Elements replyAlts = response.getElementsByAttributeValue("alt", "Reply");
-        if (replyAlts.size() >0 && replyAlts.get(0).attr("src").contains("forum-closed")) {
-        	thread.put(LOCKED, 1);
-        }else{
-        	thread.put(LOCKED, 0);
-        }
-
-        Elements openClose = response.getElementsByAttributeValue("alt", "Close thread");
-        if(openClose.isEmpty()){
-            thread.put(CAN_OPEN_CLOSE, 0);
-        }else{
-            thread.put(CAN_OPEN_CLOSE, 1);
-        }
-
-        Elements bkButtons = response.getElementsByClass("thread_bookmark");
-        if (bkButtons.size() >0) {
-        	String bkSrc = bkButtons.get(0).attr("src");
-        	if(bkSrc != null && bkSrc.contains("unbookmark")){
-        		if(bookmarkStatus < 1){
-        			thread.put(BOOKMARKED, 1);
-        		}
-        	}else{
-        		thread.put(BOOKMARKED, 0);
-        	}
-            thread.put(ARCHIVED, 0);
-        }else{
-            thread.put(BOOKMARKED, 0);
-            thread.put(ARCHIVED, 1);
-        }
-    	int forumId = -1;
-    	for(Element breadcrumb : response.getElementsByClass("breadcrumbs")){
-	    	for(Element forumLink : breadcrumb.getElementsByAttribute("href")){
-	    		Matcher matchForumId = forumId_regex.matcher(forumLink.attr("href"));
-	    		if(matchForumId.find()){//switched this to a regex
-	    			forumId = Integer.parseInt(matchForumId.group(1));//so this won't fail
-	    		}
-	    	}
-    	}
-    	thread.put(FORUM_ID, forumId);
-    	int lastPage = AwfulPagedItem.parseLastPage(response);
-
         if (threadData != null) {
             threadData.close();
         }
-		int replycount;
-		if(aUserId > 0){
-			replycount = AwfulPagedItem.pageToIndex(lastPage, aPageSize, 0);
-		}else{
-			replycount = Math.max(totalReplies, AwfulPagedItem.pageToIndex(lastPage, aPageSize, 0));
-		}
 
-    	int newUnread = Math.max(0, replycount-AwfulPagedItem.pageToIndex(aPage, aPageSize, aPageSize-1));
-    	if(unread > 0){
-        	newUnread = Math.min(unread, newUnread);
-    	}
-    	if(aPage == lastPage){
-    		newUnread = 0;
-    	}
-        if(postcount < replycount || aUserId > 0){
-            thread.put(AwfulThread.POSTCOUNT, replycount);
-            Log.v(TAG, "Parsed lastPage:"+lastPage+" old total: "+totalReplies+" new total:"+replycount);
-        }
-        if(postcount < replycount || newUnread < unread){
-            thread.put(AwfulThread.UNREADCOUNT, newUnread);
-            Log.i(TAG, aThreadId+" - Old unread: "+unread+" new unread: "+newUnread);
+        ContentValues thread = new ContentValues();
+        thread.put(ID, threadId);
+
+        Element title = page.getElementsByClass("bclast").first();
+        thread.put(TITLE, title != null ? title.text() : "UNKNOWN TITLE");
+
+        // look for a real reply button - if there isn't one, this thread is locked
+        Element replyButton = page.select("[alt=Reply]:not([src*='forum-closed'])").first();
+        thread.put(LOCKED, (replyButton == null) ? 1 : 0);
+
+        Element openCloseButton = page.select("[alt='Close thread']").first();
+        thread.put(CAN_OPEN_CLOSE, (openCloseButton == null) ? 0 : 1);
+
+        Element bookmarkButton = page.select(".thread_bookmark").first();
+        // we're assuming no bookmark button means archived - there's an explicit archived icon we could find too
+        boolean archived = (bookmarkButton == null);
+        thread.put(ARCHIVED, archived ? 1 : 0);
+
+        if (archived) {
+            thread.put(BOOKMARKED, 0);
+        } else {
+            boolean bookmarked = bookmarkButton.attr("src").contains("unbookmark");
+            if (bookmarked) {
+                // retain the old status, unless it was 0 (unbookmarked)
+                thread.put(BOOKMARKED, (bookmarkStatus < 1) ? 1 : bookmarkStatus);
+            } else {
+                thread.put(BOOKMARKED, 0);
+            }
         }
 
-        if(contentResolv.update(ContentUris.withAppendedId(CONTENT_URI, aThreadId), thread, null, null) <1){
-            contentResolv.insert(CONTENT_URI, thread);
+        // ID of this thread's forum
+        int forumId = -1;
+        Matcher matchForumId;
+        for (Element breadcrumb : page.select(".breadcrumbs [href]")) {
+            matchForumId = forumId_regex.matcher(breadcrumb.attr("href"));
+            if (matchForumId.find()) {//switched this to a regex
+                forumId = Integer.parseInt(matchForumId.group(1));//so this won't fail
+            }
         }
-        AwfulPost.syncPosts(contentResolv,
-                response,
-                aThreadId,
-                ((unread == 0 && hasViewedThread == 0) ? 0 : totalReplies - unread),
-                opId,
-                aPrefs,
-                AwfulPagedItem.pageToIndex(aPage, aPageSize, 0));
+        thread.put(FORUM_ID, forumId);
+
+
+        // now calculate some read/unread numbers based on what we can see on the page
+        int lastPageNumber = AwfulPagedItem.parseLastPage(page);
+        int firstPostOnPageIndex = AwfulPagedItem.pageToIndex(pageNumber, postsPerPage, 0);
+        int firstUnreadIndex = (hasViewedThread == 0) ? 0 : totalPosts - unread;
+
+        // hand off the page for post parsing, and get back the number of posts it found
+        // TODO: 02/06/2017 sort out the ignored posts issue, the post parser doesn't put them in the DB (if you have 'always hide' on in the settings) and it messes up the numbers
+        int postsOnThisPage = AwfulPost.syncPosts(resolver, page, threadId, firstUnreadIndex, opId, prefs, firstPostOnPageIndex);
+        int postsOnPreviousPages = (pageNumber - 1) * postsPerPage;
+        int postsRead = postsOnPreviousPages + postsOnThisPage;
+
+        // we might have more recent info here, see if we need to update totalPosts
+        // first up, if this is the last page then we've read all the posts
+        if (pageNumber == lastPageNumber) {
+            totalPosts = postsRead;
+        } else {
+            // we can calculate a minimum and maximum posts range by looking at the last page number
+            int minTotal = ((lastPageNumber - 1) * postsPerPage) + 1;   // one post on the last page, any preceding pages are full
+            int maxTotal = lastPageNumber * postsPerPage;               // all pages full
+            // if totalPosts is within this range, let's just assume it's more accurate than taking the minimum
+            // if it's outside of that range it's obviously a stale value, use the min as our best guess
+            totalPosts = (minTotal <= totalPosts && totalPosts <= maxTotal) ? totalPosts : minTotal;
+        }
+
+        int unreadPosts = totalPosts - postsRead;
+        Log.d(TAG, String.format("getThreadPosts: Thread ID %d, page %d of %d, %d posts on page%n%d posts read, %d unread of %d total.",
+                threadId, pageNumber, lastPageNumber, postsOnThisPage, postsRead, unreadPosts, totalPosts));
+
+
+        // finally write new thread data to the database
+        thread.put(AwfulThread.POSTCOUNT, totalPosts);
+        thread.put(AwfulThread.UNREADCOUNT, unreadPosts);
+        if (resolver.update(ContentUris.withAppendedId(CONTENT_URI, threadId), thread, null, null) < 1) {
+            resolver.insert(CONTENT_URI, thread);
+        }
     }
+
 
     public static String getContainerHtml(AwfulPreferences aPrefs, int forumId){
         StringBuilder buffer = new StringBuilder("<!DOCTYPE html>\n<html>\n<head>\n");

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ThreadDisplay.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ThreadDisplay.java
@@ -1,0 +1,234 @@
+package com.ferg.awfulapp.thread;
+
+import android.Manifest;
+import android.content.pm.PackageManager;
+import android.os.Environment;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.util.ArrayMap;
+import android.widget.Toast;
+
+import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.provider.AwfulTheme;
+import com.ferg.awfulapp.util.AwfulUtils;
+import com.samskivert.mustache.Mustache;
+import com.samskivert.mustache.MustacheException;
+import com.samskivert.mustache.Template;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by baka kaba on 04/06/2017.
+ * <p>
+ * Contains methods used to construct an actual thread page.
+ * Extracted from {@link AwfulThread}
+ */
+public abstract class ThreadDisplay {
+
+    /**
+     * All the scripts from the javascript folder used in generating HTML
+     */
+    static final String[] JS_FILES = {
+            "zepto/zepto.min.js",
+            "zepto/selector.js",
+            "zepto/fx.js",
+            "zepto/fx_methods.js",
+            "zepto/touch.js",
+            "scrollend.js",
+            "inviewport.js",
+            "json2.js",
+            "twitterwidget.js",
+            "salr.js",
+            "thread.js"
+    };
+
+    /**
+     * Get the main HTML for the containing page.
+     * <p>
+     * This contains no post data, but sets up the basic template with the required JS scripts,
+     * CSS etc., and a container element to insert post data into.
+     *
+     * @param aPrefs  used to customise the template to the user's preferences
+     * @param forumId the ID of the forum this thread belongs to, used for themeing
+     * @return the template containing a container class
+     */
+    public static String getContainerHtml(AwfulPreferences aPrefs, int forumId) {
+        StringBuilder buffer = new StringBuilder("<!DOCTYPE html>\n<html>\n<head>\n");
+        buffer.append("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0 maximum-scale=1.0 minimum-scale=1.0, user-scalable=no\" />\n");
+        buffer.append("<meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" />\n");
+        buffer.append("<meta name='format-detection' content='telephone=no' />\n");
+        buffer.append("<meta name='format-detection' content='address=no' />\n");
+
+
+        // build the theme css tag, using the appropriate css path
+        // the dark-theme attribute can be used to e.g. embed a dark or light widget
+        AwfulTheme theme = AwfulTheme.forForum(forumId);
+        buffer.append(String.format("<link id='theme-css' rel='stylesheet' data-dark-theme='%b' href='%s'>\n", theme.isDark(), theme.getCssPath()));
+        buffer.append("<link rel='stylesheet' href='file:///android_asset/css/general.css' />");
+
+
+        if (!aPrefs.preferredFont.contains("default")) {
+            buffer.append("<style id='font-face' type='text/css'>@font-face { font-family: userselected; src: url('content://com.ferg.awfulapp.webprovider/").append(aPrefs.preferredFont).append("'); }</style>\n");
+        }
+        for (String scriptName : JS_FILES) {
+            buffer.append("<script src='file:///android_asset/javascript/")
+                    .append(scriptName)
+                    .append("' type='text/javascript'></script>\n");
+        }
+
+        buffer.append("</head><body><div id='container' class='container' ")
+                .append((!aPrefs.noFAB ? "style='padding-bottom:75px'" : ""))
+                .append("></div></body></html>");
+        return buffer.toString();
+    }
+
+
+    /**
+     * Generates post content HTML for a list of posts.
+     * <p>
+     * This method produces the content that should be inserted into the container template that
+     * {@link #getContainerHtml(AwfulPreferences, int)} produces.
+     *
+     * @param aPosts   the list of posts to generate HTML for
+     * @param aPrefs   used to customise the post content to the user's preferences
+     * @param page     the number of the page this represents
+     * @param lastPage the number of the last page in this thread
+     * @return the generated content, ready for insertion into the template
+     */
+    public static String getHtml(List<AwfulPost> aPosts, AwfulPreferences aPrefs, int page, int lastPage) {
+        StringBuilder buffer = new StringBuilder(1024);
+        buffer.append("<div class='content'>\n");
+
+        // if we're hiding read posts, work out how many are read and add the 'show old posts' link
+        if (aPrefs.hideOldPosts && aPosts.size() > 0 && !aPosts.get(aPosts.size() - 1).isPreviouslyRead()) {
+            int unreadCount = 0;
+            for (AwfulPost ap : aPosts) {
+                if (!ap.isPreviouslyRead()) {
+                    unreadCount++;
+                }
+            }
+            if (unreadCount < aPosts.size() && unreadCount > 0) {
+                buffer.append("    <article class='toggleread'>");
+                buffer.append("      <a>\n");
+                final int prevPosts = aPosts.size() - unreadCount;
+                buffer.append("        <h3>Show ")
+                        .append(prevPosts).append(" Previous Post").append(prevPosts > 1 ? "s" : "").append("</h3>\n");
+                buffer.append("      </a>\n");
+                buffer.append("    </article>");
+            }
+        }
+
+        // add the actual posts
+        buffer.append(getPostsHtml(aPosts, aPrefs));
+
+        if (page == lastPage) {
+            buffer.append("<div class='unread' ></div>\n");
+        }
+        buffer.append("</div>\n");
+
+        return buffer.toString();
+    }
+
+
+    /**
+     * Generates HTML for a list of posts using the appropriate Mustache layout.
+     * <p>
+     * This method generates HTML for the actual posts, taking user preferences into account.
+     *
+     * @return a HTML string representing all the posts
+     */
+    private static String getPostsHtml(List<AwfulPost> aPosts, AwfulPreferences aPrefs) {
+        StringBuilder buffer = new StringBuilder();
+        Template postTemplate;
+
+        try {
+            postTemplate = getPostTemplate(aPrefs);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
+        }
+
+        // should be fine to re-use this since we rewrite every mapping each time
+        Map<String, String> postData = new ArrayMap<>();
+        postData.put("notOnProbation", (aPrefs.isOnProbation()) ? null : "notOnProbation");
+
+        // run each post's data through the template, and combine into a final HTML string
+        for (AwfulPost post : aPosts) {
+            String username = post.getUsername();
+            String avatar = post.getAvatar();
+
+            postData.put("seen", post.isPreviouslyRead() ? "read" : "unread");
+            postData.put("isOP", (aPrefs.highlightOP && post.isOp()) ? "op" : null);
+            postData.put("isMarked", aPrefs.markedUsers.contains(username) ? "marked" : null);
+            postData.put("postID", post.getId());
+            postData.put("isSelf", (aPrefs.highlightSelf && username.equals(aPrefs.username)) ? "self" : null);
+            postData.put("avatarURL", (aPrefs.canLoadAvatars() && avatar != null && avatar.length() > 0) ? avatar : null);
+            postData.put("username", username);
+            postData.put("userID", post.getUserId());
+            postData.put("postDate", post.getDate());
+            postData.put("regDate", post.getRegDate());
+            postData.put("mod", post.isMod() ? "mod" : null);
+            postData.put("admin", post.isAdmin() ? "admin" : null);
+            postData.put("plat", post.isPlat() ? "plat" : null);
+            postData.put("avatarText", "" + post.getAvatarText());
+            postData.put("lastReadUrl", post.getLastReadUrl());
+            postData.put("editable", post.isEditable() ? "editable" : null);
+            postData.put("postcontent", post.getContent());
+
+            try {
+                buffer.append(postTemplate.execute(postData));
+            } catch (MustacheException e) {
+                e.printStackTrace();
+            }
+        }
+        return buffer.toString();
+    }
+
+    /**
+     * Get a Mustache template for posts, according to the user's preferences.
+     * <p>
+     * Falls back to the default template if a custom layout can't be accessed.
+     *
+     * @param aPrefs used to check if a custom layout is selected
+     * @throws IOException if the default template can't be read
+     */
+    private static Template getPostTemplate(AwfulPreferences aPrefs) throws IOException {
+        Template postTemplate;
+        Reader templateReader = null;
+
+        // user has a custom template selected (nobody uses this I bet)
+        if (!"default".equals(aPrefs.layout)) {
+            if (AwfulUtils.isMarshmallow()) {
+                int permissionCheck = ContextCompat.checkSelfPermission(aPrefs.getContext(), Manifest.permission.READ_EXTERNAL_STORAGE);
+
+                if (permissionCheck == PackageManager.PERMISSION_GRANTED) {
+                    File template = new File(Environment.getExternalStorageDirectory() + "/awful/" + aPrefs.layout);
+                    if (template.isFile() && template.canRead()) {
+                        templateReader = new FileReader(template);
+                    }
+                } else {
+                    Toast.makeText(aPrefs.getContext(), "Can't access custom layout because Awful lacks storage permissions. Reverting to default layout.", Toast.LENGTH_LONG).show();
+                }
+            } else {
+                File template = new File(Environment.getExternalStorageDirectory() + "/awful/" + aPrefs.layout);
+                if (template.isFile() && template.canRead()) {
+                    templateReader = new FileReader(template);
+                }
+
+            }
+        }
+
+        // use the default if necessary
+        if (templateReader == null) {
+            templateReader = new InputStreamReader(aPrefs.getResources().getAssets().open("mustache/post.mustache"));
+        }
+        postTemplate = Mustache.compiler().compile(templateReader);
+        return postTemplate;
+    }
+
+}


### PR DESCRIPTION
I've rewritten some code in AwfulThread to hopefully make the logic easier to follow - mostly using shorter selectors and being more explicit with naming and comments, and also fixing some quirks in post count calculation.

I've also made it into a data class, so an AwfulThread instance represents the metadata about a thread and methods can work with that thread object instead of manually unpacking database rows and rebuilding them to insert back into the DB. Hopefully we can pull all of the database query logic out of those other methods and classes and get some separation so it's easier to change things

I updated the thread list/page parsing methods to use these thread objects instead, and I've pulled out the code that generates HTML for the thread webview and put it in its own class - feels like a separate thing to me, splitting it out should make it easier to manage things