### PR TITLE
Implement share handler for plaintext URLs

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -50,6 +50,18 @@
 				<data android:pathPrefix="/showthread.php"/>
             </intent-filter>
         </activity>
+
+        <!--
+        This handles share intents, and is meant to run invisibly and separately in its own task (singleInstance)
+        -->
+        <activity android:name=".ShareHandlerActivity" android:launchMode="singleInstance" android:theme="@android:style/Theme.Translucent.NoTitleBar">
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity>
+
         <activity
                 android:name="com.ferg.awfulapp.AwfulLoginActivity"
                 android:windowSoftInputMode="adjustResize" android:theme="@style/Theme.AppCompat.Light" android:launchMode="singleTop"/>

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ShareHandlerActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ShareHandlerActivity.java
@@ -1,0 +1,60 @@
+package com.ferg.awfulapp;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.widget.Toast;
+
+import com.ferg.awfulapp.thread.AwfulURL;
+
+/**
+ * Created by baka kaba on 02/07/2017.
+ * <p>
+ * Handles share intents from other apps.
+ */
+public class ShareHandlerActivity extends Activity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // Get intent, action and MIME type
+        Intent intent = getIntent();
+        String action = intent.getAction();
+        String type = intent.getType();
+
+        // currently just
+        if (Intent.ACTION_SEND.equals(action) && type != null) {
+            if ("text/plain".equals(type)) {
+                handleSendText(intent);
+            }
+        } else {
+            // fallthrough - couldn't do anything with this share, let the user know
+            Toast.makeText(this, R.string.share_handler_no_url_found, Toast.LENGTH_SHORT).show();
+        }
+
+        // the activity runs in its own task - drop it once we're done with the intent
+        finish();
+    }
+
+
+    /**
+     * Handles a plain text {@link Intent#ACTION_SEND} intent.
+     */
+    private void handleSendText(Intent intent) {
+        String text = intent.getStringExtra(Intent.EXTRA_TEXT);
+
+        // Right now we only handle URLs, and ignore any other plain text content
+
+        // check if it's one of our URLs - AwfulURL parsing never fails, but falls back to EXTERNAL if it's not recognised
+        if (text != null && !AwfulURL.parse(text).isExternal()) {
+            Intent openAppIntent = new Intent(this, ForumsIndexActivity.class);
+            openAppIntent.setAction(Intent.ACTION_VIEW);
+            openAppIntent.setData(Uri.parse(text));
+            startActivity(openAppIntent);
+        } else {
+            Toast.makeText(this, R.string.share_handler_no_url_found, Toast.LENGTH_LONG).show();
+        }
+    }
+}

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <!-- Share handling -->
+    <string name="share_handler_no_url_found">This share isn\'t an Awful link!</string>
+
     <string name="awful_web_provider">AwfulWebProvider</string>
     <string name="cancel">Cancel</string>
     <string name="confirm">OK</string>


### PR DESCRIPTION
Added an activity to handle shares - currently just does URLs passed as
plain text, e.g. how Chrome shares the page you're reading