### PR TITLE
Fix dividers in preferences, pre-Lollipop forum list

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/SettingsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/SettingsFragment.java
@@ -2,18 +2,31 @@ package com.ferg.awfulapp.preferences.fragments;
 
 import android.app.Activity;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.ColorFilter;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v4.util.ArrayMap;
 import android.util.Log;
+import android.util.TypedValue;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
 
 import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.preferences.SettingsActivity;
+import com.ferg.awfulapp.provider.AwfulTheme;
 
 import java.util.Map;
 
@@ -125,6 +138,18 @@ public abstract class SettingsFragment extends PreferenceFragment {
         }
     }
 
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // for some reason, if you theme android:listDivider it won't show up in the preference list
+        // so doing this directly seems to be the only way to theme it? Can't just get() it either
+        ListView listview = (ListView) getActivity().findViewById(android.R.id.list);
+        Drawable divider = getResources().getDrawable(R.drawable.list_divider);
+        TypedValue colour = new TypedValue();
+        getActivity().getTheme().resolveAttribute(android.R.attr.listDivider, colour, true);
+        divider.setColorFilter(colour.data, PorterDuff.Mode.SRC_IN);
+        listview.setDivider(divider);
+    }
 
     /**
      * Set required defaults and selectively enable preferences.

--- a/Awful.apk/src/main/res/drawable/list_divider.xml
+++ b/Awful.apk/src/main/res/drawable/list_divider.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape = "line">
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <!-- TODO: this needs tinting by theme, can't use ?attr pre-lollipop! -->
-    <stroke
-        android:width="0.5dp"
-        android:color="@color/alt_background" />
+    <!--
+        You probably don't want to use this!
+        Pre-lollipop can't use ?attr references here, so you need to tint the drawable to theme it.
+        Tinting in XML has issues, so it's better to just use a 1dp-high ImageView and set its
+        background colour if you need a divider. This is only here so the Preferences divider can be set to something
+    -->
 
-    <size
-        android:height="1dp" />
+    <solid android:color="#99FF0000"/>
+    <size android:height="1dp"/>
 
 </shape>

--- a/Awful.apk/src/main/res/layout/forum_index_item.xml
+++ b/Awful.apk/src/main/res/layout/forum_index_item.xml
@@ -115,11 +115,10 @@
     <ImageView
         android:id="@+id/list_divider"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="1dp"
         android:layout_alignParentBottom="true"
         android:layout_below="@id/section_title"
-        android:tint="?android:listDivider"
-        app:srcCompat="@drawable/list_divider"
+        android:background="?android:attr/listDivider"
         tools:ignore="ContentDescription,MissingPrefix"/>
 
 </RelativeLayout>

--- a/Awful.apk/src/main/res/layout/forum_index_subforum_item.xml
+++ b/Awful.apk/src/main/res/layout/forum_index_subforum_item.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/item_container"
     android:layout_width="fill_parent"
@@ -11,10 +10,9 @@
     <ImageView
         android:id="@+id/list_divider"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="1dp"
+        android:background="?android:attr/listDivider"
         android:layout_alignParentBottom="true"
-        android:tint="?android:listDivider"
-        app:srcCompat="@drawable/list_divider"
         tools:ignore="ContentDescription,MissingPrefix"/>
 
     <RelativeLayout

--- a/Awful.apk/src/main/res/layout/post_reply_activity.xml
+++ b/Awful.apk/src/main/res/layout/post_reply_activity.xml
@@ -35,8 +35,8 @@
 
     <ImageView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:srcCompat="@drawable/list_divider"
+        android:layout_height="1dp"
+        android:background="?android:attr/listDivider"
         tools:ignore="ContentDescription"/>
 
     <fragment


### PR DESCRIPTION
Had to programmatically colour them since setting android:listDivider in themes
breaks dividers in the Preferences ListView, for some reason

There seems to be some issue with tinting the shape drawable we were using
(on pre-Lollipop devices, or my API 16 emulator anyway) so I've changed all the
dividers using it to just be 1dp-high ImageViews with the themed colour as the
background