### PR TITLE
Add titles and back arrow to Settings, visual tweaks and fixes

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/AccountSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/AccountSettings.java
@@ -3,6 +3,7 @@ package com.ferg.awfulapp.preferences.fragments;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.preference.Preference;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.widget.Toast;
 
@@ -23,6 +24,13 @@ public class AccountSettings extends SettingsFragment {
         prefClickListeners.put(new FeaturesListener(), new int[] {
                 R.string.pref_key_account_features_menu_item
         });
+    }
+
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.prefs_account);
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ForumIndexSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ForumIndexSettings.java
@@ -1,6 +1,7 @@
 package com.ferg.awfulapp.preferences.fragments;
 
 import android.preference.Preference;
+import android.support.annotation.NonNull;
 
 import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
@@ -35,6 +36,13 @@ public class ForumIndexSettings extends SettingsFragment
 
     private final ForumRepository forumRepo = ForumRepository.getInstance(null);
     private volatile boolean updateRunning = false;
+
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.forum_index_settings);
+    }
 
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ImageSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ImageSettings.java
@@ -1,5 +1,7 @@
 package com.ferg.awfulapp.preferences.fragments;
 
+import android.support.annotation.NonNull;
+
 import com.ferg.awfulapp.R;
 
 /**
@@ -14,4 +16,10 @@ public class ImageSettings extends SettingsFragment {
         };
     }
 
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.image_settings);
+    }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/MiscSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/MiscSettings.java
@@ -4,7 +4,7 @@ import android.app.Dialog;
 import android.os.Build;
 import android.preference.ListPreference;
 import android.preference.Preference;
-import android.preference.SwitchPreference;
+import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.Button;
 import android.widget.SeekBar;
@@ -32,6 +32,13 @@ public class MiscSettings extends SettingsFragment {
         prefClickListeners.put(new P2RDistanceListener(), new int[] {
                 R.string.pref_key_pull_to_refresh_distance
         });
+    }
+
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.prefs_misc);
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostEmbeddingSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostEmbeddingSettings.java
@@ -1,5 +1,7 @@
 package com.ferg.awfulapp.preferences.fragments;
 
+import android.support.annotation.NonNull;
+
 import com.ferg.awfulapp.R;
 
 /**
@@ -14,4 +16,9 @@ public class PostEmbeddingSettings extends SettingsFragment {
     }
 
 
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.embedding_settings_title);
+    }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostHighlightingSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostHighlightingSettings.java
@@ -1,5 +1,7 @@
 package com.ferg.awfulapp.preferences.fragments;
 
+import android.support.annotation.NonNull;
+
 import com.ferg.awfulapp.R;
 
 /**
@@ -9,5 +11,12 @@ public class PostHighlightingSettings extends SettingsFragment {
 
     {
         SETTINGS_XML_RES_ID = R.xml.post_highlighting_settings;
+    }
+
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.highlighting_settings_title);
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/PostSettings.java
@@ -4,6 +4,7 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.graphics.Typeface;
 import android.preference.Preference;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import android.util.TypedValue;
 import android.widget.Button;
@@ -38,6 +39,13 @@ public class PostSettings extends SettingsFragment {
         prefClickListeners.put(new PostsPerPageListener(), new int[] {
                 R.string.pref_key_post_per_page
         });
+    }
+
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.prefs_post_display);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/RootSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/RootSettings.java
@@ -55,6 +55,11 @@ public class RootSettings extends SettingsFragment {
         });
     }
 
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.settings_activity_title);
+    }
 
     /** Listener for the 'About...' option */
     private class AboutListener implements Preference.OnPreferenceClickListener {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/SettingsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/SettingsFragment.java
@@ -2,45 +2,37 @@ package com.ferg.awfulapp.preferences.fragments;
 
 import android.app.Activity;
 import android.content.res.Resources;
-import android.content.res.TypedArray;
-import android.graphics.ColorFilter;
 import android.graphics.PorterDuff;
-import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
-import android.support.v4.content.ContextCompat;
-import android.support.v4.graphics.drawable.DrawableCompat;
 import android.support.v4.util.ArrayMap;
 import android.util.Log;
 import android.util.TypedValue;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
 import android.widget.ListView;
 
 import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.preferences.SettingsActivity;
-import com.ferg.awfulapp.provider.AwfulTheme;
 
 import java.util.Map;
 
 /**
  * Created by baka kaba on 04/05/2015.
- *
+ * <p>
  * <p>Base fragment that adds preferences from a given XML resource,
  * sets defaults and enables options based on the user's device,
  * and sets preference summaries.</p>
- *
+ * <p>
  * <p>For some fragments the XML resource ID is all that's required.
  * Others may need to specify preferences etc., or override the
  * initialisation methods to perform more advanced shenanigans.</p>
- *
+ * <p>
  * <p>When adding a new fragment, please add its XML resId to
  * {@link SettingsActivity#PREFERENCE_XML_FILES} so it can be
  * automatically checked for defaults!</p>
@@ -76,17 +68,17 @@ public abstract class SettingsFragment extends PreferenceFragment {
 
     /**
      * <p>This must be set to the resource ID of a layout file containing the fragment's preferences</p>
-     *
+     * <p>
      * <p>Layout files should describe <b>a single level</b> in the preference hierarchy -
      * don't use the standard {@link android.preference.PreferenceScreen} behaviour to define
      * additional levels, as they will launch a separate activity.</p>
-     *
+     * <p>
      * <p>Instead, create a separate fragment to hold that content, and define a preference in
      * this layout which will open that fragment when clicked. Set this preference's
      * <i>android:fragment</i> value to this target fragment, and add the preference's key
      * to the SUBMENU_OPENING_KEYS array to enable its click behaviour.
      * See the {@link RootSettings} class for an example</p>
-     *
+     * <p>
      * <p>(This isn't ideal, it would be better if the click listener was added automatically wherever
      * a fragment value is set on a preference in the XML, so if anyone can handle that cleanly be my guest)</p>
      */
@@ -119,8 +111,6 @@ public abstract class SettingsFragment extends PreferenceFragment {
      */
     protected Map<Preference.OnPreferenceClickListener, int[]> prefClickListeners = new ArrayMap<>();
 
-    // TODO: 26/04/2017 Fragment titles for submenus as per https://material.io/guidelines/patterns/settings.html#settings-labels-secondary-text
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -143,7 +133,7 @@ public abstract class SettingsFragment extends PreferenceFragment {
         super.onActivityCreated(savedInstanceState);
         // for some reason, if you theme android:listDivider it won't show up in the preference list
         // so doing this directly seems to be the only way to theme it? Can't just get() it either
-        ListView listview = (ListView) getActivity().findViewById(android.R.id.list);
+        ListView listview = (ListView) getView().findViewById(android.R.id.list);
         Drawable divider = getResources().getDrawable(R.drawable.list_divider);
         TypedValue colour = new TypedValue();
         getActivity().getTheme().resolveAttribute(android.R.attr.listDivider, colour, true);
@@ -155,7 +145,17 @@ public abstract class SettingsFragment extends PreferenceFragment {
      * Set required defaults and selectively enable preferences.
      * Override this to perform any custom initialisation in the fragment
      */
-    protected void initialiseSettings() { }
+    protected void initialiseSettings() {
+    }
+
+
+    /**
+     * Get a title for this fragment - this should usually be the same as the label of the preference
+     * that opened it, e.g. clicking 'Images' should open a fragment whose title is 'Images'.
+     * See <a href="https://material.io/guidelines/patterns/settings.html#settings-grouping-settings">the Material Design specs</a>
+     */
+    @NonNull
+    public abstract String getTitle();
 
 
     /**
@@ -199,7 +199,8 @@ public abstract class SettingsFragment extends PreferenceFragment {
      * Override this if you want to perform any special handling
      * when a summary update call comes in.
      */
-    protected void onSetSummaries() { }
+    protected void onSetSummaries() {
+    }
 
 
     /**
@@ -254,14 +255,17 @@ public abstract class SettingsFragment extends PreferenceFragment {
     public interface OnSubmenuSelectedListener {
         /**
          * Respond to a click on a preference that opens a submenu
-         * @param container         The fragment containing the clicked preference
-         * @param submenuFragment   The name of the submenu fragment's class
+         *
+         * @param sourceFragment      The fragment containing the clicked preference
+         * @param submenuFragmentName The name of the submenu fragment's class
          */
-        void onSubmenuSelected(SettingsFragment container, String submenuFragment);
+        void onSubmenuSelected(@NonNull SettingsFragment sourceFragment, @NonNull String submenuFragmentName);
     }
 
 
-    /** Listener for clicks on options that open submenus */
+    /**
+     * Listener for clicks on options that open submenus
+     */
     private class SubmenuListener implements Preference.OnPreferenceClickListener {
 
         private final SettingsFragment mThis;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThemeSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThemeSettings.java
@@ -47,6 +47,13 @@ public class ThemeSettings extends SettingsFragment {
 
     private static final String TAG = "ThemeSettings";
 
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.theme_settings);
+    }
+
     @Override
     protected void initialiseSettings() {
         super.initialiseSettings();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThreadSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThreadSettings.java
@@ -1,5 +1,7 @@
 package com.ferg.awfulapp.preferences.fragments;
 
+import android.support.annotation.NonNull;
+
 import com.ferg.awfulapp.R;
 
 /**
@@ -9,5 +11,11 @@ public class ThreadSettings extends SettingsFragment {
 
     {
         SETTINGS_XML_RES_ID = R.xml.threadinfosettings;
+    }
+
+    @NonNull
+    @Override
+    public String getTitle() {
+        return getString(R.string.thread_settings);
     }
 }

--- a/Awful.apk/src/main/res/layout-land/settings.xml
+++ b/Awful.apk/src/main/res/layout-land/settings.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/layout_main"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?attr/background"
-    android:orientation="vertical">
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:id="@+id/layout_main"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:background="?attr/background"
+              android:orientation="vertical">
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/awful_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
+        android:elevation="4dp"
         android:minHeight="?attr/actionBarSize"
-        app:popupTheme="?attr/awfulPopUpTheme"
         android:theme="@style/ToolBarStyle"
         app:elevation="4dp"
-        android:elevation="4dp" />
+        app:popupTheme="?attr/awfulPopUpTheme"/>
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="fill_parent"
+        android:layout_height="match_parent"
         android:layout_gravity="center_horizontal"
         android:orientation="horizontal">
 
@@ -28,16 +28,20 @@
         <fragment
             android:id="@+id/root_fragment_container"
             android:name="com.ferg.awfulapp.preferences.fragments.RootSettings"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_gravity="left"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:layout_weight="0.5"/>
+
+        <ImageView
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:background="?android:attr/listDivider"
+            />
 
         <FrameLayout
             android:id="@+id/main_fragment_container"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_gravity="right"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:layout_weight="0.5"/>
     </LinearLayout>
 


### PR DESCRIPTION
The title bar now has a back arrow and shows the title of the current menu.
In dual-pane mode it uses the title of the current submenu if open, or the
main menu if not.

Added some basic fragment transitions to make navigation feel better (instead of
abrupt changes), and stuck a divider between the panes in the dual-pane layout.
Also fixed the list dividers in the second pane: the earlier fix grabbed 'the ListView'
in the activity, but in dual-pane mode there are two (one in each fragment) and
only the first one was being found and set. Now the fragments do #findViewById
on their own views.

Fixed an issue with back navigation popping off the last submenu fragment in
dual-pane mode instead of exiting like it should, and an issue where rotating
from dual- to single-pane made the main menu fragment disappear on higher APIs