### PR TITLE
Add Instagram and Twitch embedding, add separate JS file

### DIFF
--- a/Awful.apk/src/main/assets/javascript/embedding.js
+++ b/Awful.apk/src/main/assets/javascript/embedding.js
@@ -1,0 +1,40 @@
+//
+// Created by baka kaba on 16/08/2017.
+//
+// Functions to automatically embed page content, e.g. turn an Instagram URL into a widget
+//
+
+function processThreadEmbeds() {
+
+    // map preference keys to their corresponding embed functions
+    var embedFunctions = {
+        "inlineInstagram": embedInstagram
+    }
+
+    // check all embed preference keys - any set to true, run their embed function
+    for (embedType in embedFunctions) {
+        if (listener.getPreference(embedType) == "true") {
+            embedFunctions[embedType].call()
+        }
+    }
+
+    function embedInstagram() {
+        // get each Instagram link, and replace it with the HTML from the embed API call
+        var promises = []
+        $('.postcontent').find('a[href*="instagr.am/p"], a[href*="instagram.com/p"]')
+            .each(function() {
+                var link = $(this)
+                var url = link.attr('href')
+                api_call = "https://api.instagram.com/oembed?omitscript=true&url=" + url + "&callback=?"
+                promises.push($.getJSON(api_call, function(data) { link.replaceWith(data.html) }));
+            });
+        // do nothing if we have nothing to embed
+        if (promises.length == 0) return
+
+        // add the embed script, and run it after all the HTML widgets have been added
+        $('<script>').attr('src', 'https://platform.instagram.com/en_US/embeds.js').appendTo('head')
+        // potential race condition here if the promises complete before the script loads, so the function isn't available yet
+        $.when.apply($, promises).then(function() { instgrm.Embeds.process() });
+    }
+
+}

--- a/Awful.apk/src/main/assets/javascript/thread.js
+++ b/Awful.apk/src/main/assets/javascript/thread.js
@@ -121,6 +121,8 @@ function pageInit() {
         });
      }
 
+    processThreadEmbeds();
+
     $('.postcontent').find('div.bbcode_video object param[value^="http://vimeo.com"]').each(function(){
         var videoID = $(this).attr('value').match(/clip_id=(\d+)/)
         if (videoID === null) return

--- a/Awful.apk/src/main/assets/javascript/zepto/callbacks.js
+++ b/Awful.apk/src/main/assets/javascript/zepto/callbacks.js
@@ -1,0 +1,122 @@
+//     Zepto.js
+//     (c) 2010-2016 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+
+;(function($){
+  // Create a collection of callbacks to be fired in a sequence, with configurable behaviour
+  // Option flags:
+  //   - once: Callbacks fired at most one time.
+  //   - memory: Remember the most recent context and arguments
+  //   - stopOnFalse: Cease iterating over callback list
+  //   - unique: Permit adding at most one instance of the same callback
+  $.Callbacks = function(options) {
+    options = $.extend({}, options)
+
+    var memory, // Last fire value (for non-forgettable lists)
+        fired,  // Flag to know if list was already fired
+        firing, // Flag to know if list is currently firing
+        firingStart, // First callback to fire (used internally by add and fireWith)
+        firingLength, // End of the loop when firing
+        firingIndex, // Index of currently firing callback (modified by remove if needed)
+        list = [], // Actual callback list
+        stack = !options.once && [], // Stack of fire calls for repeatable lists
+        fire = function(data) {
+          memory = options.memory && data
+          fired = true
+          firingIndex = firingStart || 0
+          firingStart = 0
+          firingLength = list.length
+          firing = true
+          for ( ; list && firingIndex < firingLength ; ++firingIndex ) {
+            if (list[firingIndex].apply(data[0], data[1]) === false && options.stopOnFalse) {
+              memory = false
+              break
+            }
+          }
+          firing = false
+          if (list) {
+            if (stack) stack.length && fire(stack.shift())
+            else if (memory) list.length = 0
+            else Callbacks.disable()
+          }
+        },
+
+        Callbacks = {
+          add: function() {
+            if (list) {
+              var start = list.length,
+                  add = function(args) {
+                    $.each(args, function(_, arg){
+                      if (typeof arg === "function") {
+                        if (!options.unique || !Callbacks.has(arg)) list.push(arg)
+                      }
+                      else if (arg && arg.length && typeof arg !== 'string') add(arg)
+                    })
+                  }
+              add(arguments)
+              if (firing) firingLength = list.length
+              else if (memory) {
+                firingStart = start
+                fire(memory)
+              }
+            }
+            return this
+          },
+          remove: function() {
+            if (list) {
+              $.each(arguments, function(_, arg){
+                var index
+                while ((index = $.inArray(arg, list, index)) > -1) {
+                  list.splice(index, 1)
+                  // Handle firing indexes
+                  if (firing) {
+                    if (index <= firingLength) --firingLength
+                    if (index <= firingIndex) --firingIndex
+                  }
+                }
+              })
+            }
+            return this
+          },
+          has: function(fn) {
+            return !!(list && (fn ? $.inArray(fn, list) > -1 : list.length))
+          },
+          empty: function() {
+            firingLength = list.length = 0
+            return this
+          },
+          disable: function() {
+            list = stack = memory = undefined
+            return this
+          },
+          disabled: function() {
+            return !list
+          },
+          lock: function() {
+            stack = undefined
+            if (!memory) Callbacks.disable()
+            return this
+          },
+          locked: function() {
+            return !stack
+          },
+          fireWith: function(context, args) {
+            if (list && (!fired || stack)) {
+              args = args || []
+              args = [context, args.slice ? args.slice() : args]
+              if (firing) stack.push(args)
+              else fire(args)
+            }
+            return this
+          },
+          fire: function() {
+            return Callbacks.fireWith(this, arguments)
+          },
+          fired: function() {
+            return !!fired
+          }
+        }
+
+    return Callbacks
+  }
+})(Zepto)

--- a/Awful.apk/src/main/assets/javascript/zepto/deferred.js
+++ b/Awful.apk/src/main/assets/javascript/zepto/deferred.js
@@ -1,0 +1,118 @@
+//     Zepto.js
+//     (c) 2010-2016 Thomas Fuchs
+//     Zepto.js may be freely distributed under the MIT license.
+//
+//     Some code (c) 2005, 2013 jQuery Foundation, Inc. and other contributors
+
+;(function($){
+  var slice = Array.prototype.slice
+
+  function Deferred(func) {
+    var tuples = [
+          // action, add listener, listener list, final state
+          [ "resolve", "done", $.Callbacks({once:1, memory:1}), "resolved" ],
+          [ "reject", "fail", $.Callbacks({once:1, memory:1}), "rejected" ],
+          [ "notify", "progress", $.Callbacks({memory:1}) ]
+        ],
+        state = "pending",
+        promise = {
+          state: function() {
+            return state
+          },
+          always: function() {
+            deferred.done(arguments).fail(arguments)
+            return this
+          },
+          then: function(/* fnDone [, fnFailed [, fnProgress]] */) {
+            var fns = arguments
+            return Deferred(function(defer){
+              $.each(tuples, function(i, tuple){
+                var fn = $.isFunction(fns[i]) && fns[i]
+                deferred[tuple[1]](function(){
+                  var returned = fn && fn.apply(this, arguments)
+                  if (returned && $.isFunction(returned.promise)) {
+                    returned.promise()
+                      .done(defer.resolve)
+                      .fail(defer.reject)
+                      .progress(defer.notify)
+                  } else {
+                    var context = this === promise ? defer.promise() : this,
+                        values = fn ? [returned] : arguments
+                    defer[tuple[0] + "With"](context, values)
+                  }
+                })
+              })
+              fns = null
+            }).promise()
+          },
+
+          promise: function(obj) {
+            return obj != null ? $.extend( obj, promise ) : promise
+          }
+        },
+        deferred = {}
+
+    $.each(tuples, function(i, tuple){
+      var list = tuple[2],
+          stateString = tuple[3]
+
+      promise[tuple[1]] = list.add
+
+      if (stateString) {
+        list.add(function(){
+          state = stateString
+        }, tuples[i^1][2].disable, tuples[2][2].lock)
+      }
+
+      deferred[tuple[0]] = function(){
+        deferred[tuple[0] + "With"](this === deferred ? promise : this, arguments)
+        return this
+      }
+      deferred[tuple[0] + "With"] = list.fireWith
+    })
+
+    promise.promise(deferred)
+    if (func) func.call(deferred, deferred)
+    return deferred
+  }
+
+  $.when = function(sub) {
+    var resolveValues = slice.call(arguments),
+        len = resolveValues.length,
+        i = 0,
+        remain = len !== 1 || (sub && $.isFunction(sub.promise)) ? len : 0,
+        deferred = remain === 1 ? sub : Deferred(),
+        progressValues, progressContexts, resolveContexts,
+        updateFn = function(i, ctx, val){
+          return function(value){
+            ctx[i] = this
+            val[i] = arguments.length > 1 ? slice.call(arguments) : value
+            if (val === progressValues) {
+              deferred.notifyWith(ctx, val)
+            } else if (!(--remain)) {
+              deferred.resolveWith(ctx, val)
+            }
+          }
+        }
+
+    if (len > 1) {
+      progressValues = new Array(len)
+      progressContexts = new Array(len)
+      resolveContexts = new Array(len)
+      for ( ; i < len; ++i ) {
+        if (resolveValues[i] && $.isFunction(resolveValues[i].promise)) {
+          resolveValues[i].promise()
+            .done(updateFn(i, resolveContexts, resolveValues))
+            .fail(deferred.reject)
+            .progress(updateFn(i, progressContexts, progressValues))
+        } else {
+          --remain
+        }
+      }
+    }
+    if (!remain) deferred.resolveWith(resolveContexts, resolveValues)
+    return deferred.promise()
+  }
+
+  $.Deferred = Deferred
+})(Zepto)

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
@@ -98,6 +98,7 @@ public abstract class Keys {
             INLINE_YOUTUBE,
             INLINE_TWEETS,
             INLINE_INSTAGRAM,
+            INLINE_TWITCH,
             INLINE_VINES,
             INLINE_WEBM,
             AUTOSTART_WEBM,
@@ -172,6 +173,7 @@ public abstract class Keys {
     public static final int INLINE_YOUTUBE = R.string.pref_key_inline_youtube;
     public static final int INLINE_TWEETS = R.string.pref_key_inline_tweets;
     public static final int INLINE_INSTAGRAM = R.string.pref_key_inline_instagram;
+    public static final int INLINE_TWITCH = R.string.pref_key_inline_twitch;
     public static final int INLINE_VINES = R.string.pref_key_inline_vines;
     public static final int INLINE_WEBM = R.string.pref_key_inline_webm;
     public static final int AUTOSTART_WEBM = R.string.pref_key_autostart_webm;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
@@ -97,6 +97,7 @@ public abstract class Keys {
             HIGHLIGHT_OP,
             INLINE_YOUTUBE,
             INLINE_TWEETS,
+            INLINE_INSTAGRAM,
             INLINE_VINES,
             INLINE_WEBM,
             AUTOSTART_WEBM,
@@ -170,6 +171,7 @@ public abstract class Keys {
     public static final int HIGHLIGHT_OP = R.string.pref_key_highlight_op;
     public static final int INLINE_YOUTUBE = R.string.pref_key_inline_youtube;
     public static final int INLINE_TWEETS = R.string.pref_key_inline_tweets;
+    public static final int INLINE_INSTAGRAM = R.string.pref_key_inline_instagram;
     public static final int INLINE_VINES = R.string.pref_key_inline_vines;
     public static final int INLINE_WEBM = R.string.pref_key_inline_webm;
     public static final int AUTOSTART_WEBM = R.string.pref_key_autostart_webm;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ThreadDisplay.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ThreadDisplay.java
@@ -30,6 +30,7 @@ import java.util.Map;
  */
 public abstract class ThreadDisplay {
 
+    // TODO: 16/08/2017 generate this automatically from the folder contents
     /**
      * All the scripts from the javascript folder used in generating HTML
      */
@@ -39,11 +40,14 @@ public abstract class ThreadDisplay {
             "zepto/fx.js",
             "zepto/fx_methods.js",
             "zepto/touch.js",
+            "zepto/deferred.js",
+            "zepto/callbacks.js",
             "scrollend.js",
             "inviewport.js",
             "json2.js",
             "twitterwidget.js",
             "salr.js",
+            "embedding.js",
             "thread.js"
     };
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import android.webkit.JavascriptInterface;
 
 import com.ferg.awfulapp.preferences.AwfulPreferences;
+import com.ferg.awfulapp.preferences.Keys;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +42,7 @@ public class WebViewJsInterface {
         preferences.put("highlightUserQuote", Boolean.toString(aPrefs.highlightUserQuote));
         preferences.put("highlightUsername", Boolean.toString(aPrefs.highlightUsername));
         preferences.put("inlineTweets", Boolean.toString(aPrefs.inlineTweets));
+        preferences.put("inlineInstagram", Boolean.toString(aPrefs.getPreference(Keys.INLINE_INSTAGRAM, false)));
         preferences.put("inlineWebm", Boolean.toString(aPrefs.inlineWebm));
         preferences.put("autostartWebm", Boolean.toString(aPrefs.autostartWebm));
         preferences.put("inlineVines", Boolean.toString(aPrefs.inlineVines));

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
@@ -43,6 +43,7 @@ public class WebViewJsInterface {
         preferences.put("highlightUsername", Boolean.toString(aPrefs.highlightUsername));
         preferences.put("inlineTweets", Boolean.toString(aPrefs.inlineTweets));
         preferences.put("inlineInstagram", Boolean.toString(aPrefs.getPreference(Keys.INLINE_INSTAGRAM, false)));
+        preferences.put("inlineTwitch", Boolean.toString(aPrefs.getPreference(Keys.INLINE_TWITCH, false)));
         preferences.put("inlineWebm", Boolean.toString(aPrefs.inlineWebm));
         preferences.put("autostartWebm", Boolean.toString(aPrefs.autostartWebm));
         preferences.put("inlineVines", Boolean.toString(aPrefs.inlineVines));

--- a/Awful.apk/src/main/res/values/preference_keys.xml
+++ b/Awful.apk/src/main/res/values/preference_keys.xml
@@ -36,6 +36,7 @@
     <string name="pref_key_inline_youtube">inline_youtube</string>
     <string name="pref_key_inline_tweets">inline_tweets</string>
     <string name="pref_key_inline_instagram">inline_instagram</string>
+    <string name="pref_key_inline_twitch">inline_twitch</string>
     <string name="pref_key_inline_vines">inline_vines</string>
     <string name="pref_key_inline_webm">inline_webm</string>
     <string name="pref_key_autostart_webm">autostart_webm</string>

--- a/Awful.apk/src/main/res/values/preference_keys.xml
+++ b/Awful.apk/src/main/res/values/preference_keys.xml
@@ -35,6 +35,7 @@
     <string name="pref_key_highlight_op">op_highlight</string>
     <string name="pref_key_inline_youtube">inline_youtube</string>
     <string name="pref_key_inline_tweets">inline_tweets</string>
+    <string name="pref_key_inline_instagram">inline_instagram</string>
     <string name="pref_key_inline_vines">inline_vines</string>
     <string name="pref_key_inline_webm">inline_webm</string>
     <string name="pref_key_autostart_webm">autostart_webm</string>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -385,6 +385,7 @@
     <!-- Post Embedding page -->
     <string name="post_embedding_description">Embed elements in posts instead of just showing a link. These options may cause scroll lag or graphical glitches</string>
     <string name="inline_tweets">Tweets</string>
+    <string name="inline_instagram">Instagram</string>
     <string name="post_embedding_divider_videos">Videos</string>
     <string name="inline_youtube">YouTube</string>
     <string name="inline_vines">Vine</string>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -389,6 +389,8 @@
     <string name="post_embedding_divider_videos">Videos</string>
     <string name="inline_youtube">YouTube</string>
     <string name="inline_vines">Vine</string>
+    <string name="inline_twitch">Twitch</string>
+    <string name="inline_twitch_summary">Slow with several on a page</string>
     <string name="inline_webm">Other</string>
     <string name="inline_webm_summary">WebM/GIFV/MP4 etc.</string>
     <string name="autostart_webm">Autoplay embedded videos</string>

--- a/Awful.apk/src/main/res/xml/post_embedding_settings.xml
+++ b/Awful.apk/src/main/res/xml/post_embedding_settings.xml
@@ -12,6 +12,12 @@
         android:title="@string/inline_tweets"
         />
 
+    <com.ferg.awfulapp.preferences.CustomSwitchPreference
+        android:defaultValue="true"
+        android:key="@string/pref_key_inline_instagram"
+        android:title="@string/inline_instagram"
+        />
+
     <PreferenceCategory
         android:title="@string/post_embedding_divider_videos">
 

--- a/Awful.apk/src/main/res/xml/post_embedding_settings.xml
+++ b/Awful.apk/src/main/res/xml/post_embedding_settings.xml
@@ -35,6 +35,13 @@
 
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:defaultValue="false"
+            android:key="@string/pref_key_inline_twitch"
+            android:summary="@string/inline_twitch_summary"
+            android:title="@string/inline_twitch"
+            />
+
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
+            android:defaultValue="false"
             android:key="@string/pref_key_inline_webm"
             android:summary="@string/inline_webm_summary"
             android:title="@string/inline_webm"


### PR DESCRIPTION
I've added embedding functions for Instagram and Twitch URLs, and preferences
for both. Instagram defaults to on (for discovery), Twitch defaults to off because
it is *really heavy* and a page with multiple videos has to load some embedded
player for each link. Showing a preview pic that's play-on-click would be better,
but that requires an API key...

I added these functions to a separate script file where all the embedding code
can go, just to make it easier to extend without complicating the general thread
setup code. So now there's just a single call to the embed script, and that runs
everything according to the preferences that are passed in.

Also added some Zepto libraries to enable Promises - handy for things like the
Instagram oEmbed code, where you need to add HTML for each element
and then process the finished page when they're all done.