### PR TITLE
Fix https errors

### DIFF
--- a/Awful.apk/build.gradle
+++ b/Awful.apk/build.gradle
@@ -91,6 +91,9 @@ dependencies {
 
     compile 'com.android.support:appcompat-v7:26.1.0'
     compile 'com.android.support:design:26.1.0'
+    // used to fix SSL issues on older devices - old version so it works on the API 18 emulator THANKS GOOGLE
+    compile 'com.google.android.gms:play-services-auth:9.2.1'
+
     //compile 'com.mcxiaoke.volley:library:1.0.19'
     compile 'com.github.samkirton:android-volley:9aba4f5f86'
     compile 'com.google.code.gson:gson:2.8.0'

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
@@ -99,6 +99,8 @@ public class NetworkUtils {
      * @param context   A context used to create a cache dir
      */
     public static void init(Context context) {
+        // update the security provider first, to ensure we fix SSL errors before setting anything else up
+        SecurityProvider.INSTANCE.update(context);
         mNetworkQueue = Volley.newRequestQueue(context);
         // TODO: find out if this is even being used anywhere
         mImageCache = new LRUImageCache();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/SecurityProvider.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/SecurityProvider.kt
@@ -1,0 +1,54 @@
+package com.ferg.awfulapp.network
+
+import android.content.Context
+import android.util.Log
+import com.ferg.awfulapp.network.SecurityProvider.status
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
+import com.google.android.gms.common.GooglePlayServicesRepairableException
+import com.google.android.gms.security.ProviderInstaller
+
+/**
+ * Created by baka kaba on 29/10/2017.
+ *
+ * A component to handle updating the device's Security Provider, which updates to fix vulnerabilities
+ * and routes security API calls through itself.
+ *
+ * The update might fail because the user needs to install or update Google Play Services manually,
+ * or it could hit an unrecoverable error - which means the app might not work at all, especially
+ * if it's an old device that's still trying to use SSLv3. The last known state is held in [status]
+ *
+ * See: [Updating Your Security Provider to Protect Against SSL Exploits](https://developer.android.com/training/articles/security-gms-provider.html)
+ */
+object SecurityProvider {
+
+    private val TAG = this.javaClass.name!!
+    private var status = Status.UNCHECKED
+    private var userNotified = false
+
+
+    /**
+     * Update the system's security provider to fix network vulnerabilities.
+     *
+     * This fixes older devices trying to connect through SSLv3 (which gets rejected).
+     */
+    fun update(context: Context) {
+        try {
+            // this here blocks if there's an update, allegedly for ~350ms on older devices
+            // calling this first when initialising NetworkUtils (and letting it block) means we can update it before the network stuff is set up
+            ProviderInstaller.installIfNeeded(context)
+            status = Status.UP_TO_DATE
+            Log.i(TAG, "Security Provider is up to date.")
+        } catch (e: GooglePlayServicesRepairableException) {
+            status = Status.PLAY_SERVICES_UPDATE_REQUIRED
+            Log.w(TAG, "Security Provider requires a Google Play Services update.", e)
+
+        } catch (e: GooglePlayServicesNotAvailableException) {
+            status = Status.PLAY_SERVICES_ERROR
+            Log.w(TAG, "Security Provider can't update!", e)
+        }
+
+    }
+
+
+    enum class Status { UNCHECKED, UP_TO_DATE, PLAY_SERVICES_UPDATE_REQUIRED, PLAY_SERVICES_ERROR }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.DefaultRetryPolicy;
@@ -154,6 +155,11 @@ public abstract class AwfulRequest<T> {
         new Response.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError error) {
+                // TODO: 29/10/2017 this is a temporary warning/advice for people on older devices who can't connect - remove it once there's something better for recommending security updates
+                if (error.getMessage().contains("SSLProtocolException")) {
+                    String message = "CAN'T CONNECT\nYour device is trying to use an outdated secure connection!\nUpdate \"Google Play Services\" in the Play Store, and try restarting the app";
+                    Toast.makeText(cont, message, Toast.LENGTH_LONG).show();
+                }
                 if(resultListener != null){
                     resultListener.failure(error);
                 }


### PR DESCRIPTION
All right, I found a solution which is basically using [this Google library](https://developer.android.com/training/articles/security-gms-provider.html) to patch the secure networking provider. One thing it does is stops older devices from insisting on trying SSLv3, which I'm guessing Cloudflare just disabled

I tried some of the other stuff with SocketFactories and whatever, didn't work - still went for that SSLv3 even when you remove it from the enabled protocols. This seems to work ok? Tested on an API 18 (4.3) emulator, fixes the problem - not sure about earlier APIs, can't test those

One problem is avatars, emotes and some special icons like admin stars aren't working on the emulator. Fine on my phone though, hopefully it's just a problem for old devices so it's either no pics or no connection at all. It's just a quick fix anyway