### PR TITLE
Fix SSL connection failures on pre-Lollipop

### DIFF
--- a/Awful.apk/build.gradle
+++ b/Awful.apk/build.gradle
@@ -86,6 +86,9 @@ android {
 dependencies {
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:design:25.3.1'
+
+    // used to fix SSL issues on older devices - old version so it works on the API 18 emulator THANKS GOOGLE
+    compile 'com.google.android.gms:play-services-auth:9.2.1'
     //compile 'com.mcxiaoke.volley:library:1.0.19'
     compile 'com.github.samkirton:android-volley:9aba4f5f86'
     compile 'com.google.code.gson:gson:2.8.0'

--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.ferg.awfulapp"
-      android:versionCode="172"
-      android:versionName="3.3.1"
+      android:versionCode="173"
+      android:versionName="3.3.2"
       android:installLocation="auto">
     <supports-screens
         android:smallScreens="true"

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
@@ -99,6 +99,8 @@ public class NetworkUtils {
      * @param context   A context used to create a cache dir
      */
     public static void init(Context context) {
+        // update the security provider first, to ensure we fix SSL errors before setting anything else up
+        SecurityProvider.update(context);
         mNetworkQueue = Volley.newRequestQueue(context);
         // TODO: find out if this is even being used anywhere
         mImageCache = new LRUImageCache();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/SecurityProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/SecurityProvider.java
@@ -1,0 +1,54 @@
+package com.ferg.awfulapp.network;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
+import com.google.android.gms.common.GooglePlayServicesRepairableException;
+import com.google.android.gms.security.ProviderInstaller;
+
+/**
+ * Created by baka kaba on 29/10/2017.
+ * <p>
+ * A component to handle updating the device's Security Provider, which updates to fix vulnerabilities
+ * and routes security API calls through itself.
+ * <p>
+ * The update might fail because the user needs to install or update Google Play Services manually,
+ * or it could hit an unrecoverable error - which means the app might not work at all, especially
+ * if it's an old device that's still trying to use SSLv3. The last known state is held in {@link #status}
+ * <p>
+ * See: <a href="https://developer.android.com/training/articles/security-gms-provider.html">Updating Your Security Provider to Protect Against SSL Exploits</a>
+ */
+abstract class SecurityProvider {
+
+    private static String TAG = SecurityProvider.class.getSimpleName();
+    private static Status status = Status.UNCHECKED;
+    private static boolean userNotified = false;
+
+
+    /**
+     * Update the system's security provider to fix network vulnerabilities.
+     * <p>
+     * This fixes older devices trying to connect through SSLv3 (which gets rejected).
+     */
+    static void update(@NonNull Context context) {
+        try {
+            // this here blocks if there's an update, allegedly for ~350ms on older devices
+            // calling this first when initialising NetworkUtils (and letting it block) means we can update it before the network stuff is set up
+            ProviderInstaller.installIfNeeded(context);
+            status = Status.UP_TO_DATE;
+            Log.i(TAG, "Security Provider is up to date.");
+        } catch (GooglePlayServicesRepairableException e) {
+            status = Status.PLAY_SERVICES_UPDATE_REQUIRED;
+            Log.w(TAG, "Security Provider requires a Google Play Services update.", e);
+
+        } catch (GooglePlayServicesNotAvailableException e) {
+            status = Status.PLAY_SERVICES_ERROR;
+            Log.w(TAG, "Security Provider can't update!", e);
+        }
+
+    }
+
+    enum Status {UNCHECKED, UP_TO_DATE, PLAY_SERVICES_UPDATE_REQUIRED, PLAY_SERVICES_ERROR}
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.DefaultRetryPolicy;
@@ -154,6 +155,11 @@ public abstract class AwfulRequest<T> {
         new Response.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError error) {
+                // TODO: 29/10/2017 this is a temporary warning/advice for people on older devices who can't connect - remove it once there's something better for recommending security updates
+                if (error.getMessage().contains("SSLProtocolException")) {
+                    String message = "CAN'T CONNECT\nYour device is trying to use an outdated secure connection!\nUpdate \"Google Play Services\" in the Play Store, and try restarting the app";
+                    Toast.makeText(cont, message, Toast.LENGTH_LONG).show();
+                }
                 if(resultListener != null){
                     resultListener.failure(error);
                 }

--- a/Awful.apk/src/main/res/values/changelog.xml
+++ b/Awful.apk/src/main/res/values/changelog.xml
@@ -2,6 +2,10 @@
 <resources>
     <string-array name="changelog">
         <item>
+            3.3.2:\n
+            - Fix for HTTPS connection failures on older devices. If you still get SSL errors, try updating Google Play Services in the Play Store and restart the app!
+        </item>
+        <item>
             3.3.1:\n
             - Fixed post menu button not being visible on devices with poor font-choices.
         </item>


### PR DESCRIPTION
This uses the security provider from Google Play Services to basically patch
the networking calls and stop old devices from trying to connect with SSLv3,
which doesn't work anymore. It should also make things more secure in general?

I'm using an old version of the auth library so I can test it on an old emulator.
Might be worth updating later? You need Google Play Services installed in the SDK
too

I've crowbarred an SSL error check into the base request class, seems like the
easiest place to catch it. It just pops up a toast telling people to update
Google Play Services so the security provider can hopefully update. Feels bad
but it's a fix.

I'm working on a system for popping a useful info dialog but I'm not sure how to
tell when it's important ("you need to update because SSL is broke as heck")
or not ("you need to update for better security even though everything works").
And people *really don't like popups*