### PR TITLE
v3.3.3 - Bugfix for Crashlytics #828, NPE when checking network errors

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.ferg.awfulapp"
-      android:versionCode="175"
-      android:versionName="3.3.2"
+      android:versionCode="177"
+      android:versionName="3.3.3"
       android:installLocation="auto">
     <supports-screens
         android:smallScreens="true"

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/SecurityProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/SecurityProvider.java
@@ -16,7 +16,7 @@ import com.google.android.gms.security.ProviderInstaller;
  * <p>
  * The update might fail because the user needs to install or update Google Play Services manually,
  * or it could hit an unrecoverable error - which means the app might not work at all, especially
- * if it's an old device that's still trying to use SSLv3. The last known state is held in {@link #status}
+ * if it's an old device that's still trying to use SSLv3. Use {@link #getStatus()} to get the most recent status.
  * <p>
  * See: <a href="https://developer.android.com/training/articles/security-gms-provider.html">Updating Your Security Provider to Protect Against SSL Exploits</a>
  */
@@ -24,8 +24,6 @@ abstract class SecurityProvider {
 
     private static String TAG = SecurityProvider.class.getSimpleName();
     private static Status status = Status.UNCHECKED;
-    private static boolean userNotified = false;
-
 
     /**
      * Update the system's security provider to fix network vulnerabilities.
@@ -47,7 +45,11 @@ abstract class SecurityProvider {
             status = Status.PLAY_SERVICES_ERROR;
             Log.w(TAG, "Security Provider can't update!", e);
         }
+    }
 
+    @NonNull
+    public static Status getStatus() {
+        return status;
     }
 
     enum Status {UNCHECKED, UP_TO_DATE, PLAY_SERVICES_UPDATE_REQUIRED, PLAY_SERVICES_ERROR}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
@@ -20,11 +20,13 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.HttpHeaderParser;
 import com.crashlytics.android.Crashlytics;
 import com.ferg.awfulapp.AwfulApplication;
+import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.util.AwfulError;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
@@ -156,9 +158,8 @@ public abstract class AwfulRequest<T> {
             @Override
             public void onErrorResponse(VolleyError error) {
                 // TODO: 29/10/2017 this is a temporary warning/advice for people on older devices who can't connect - remove it once there's something better for recommending security updates
-                if (error.getMessage().contains("SSLProtocolException")) {
-                    String message = "CAN'T CONNECT\nYour device is trying to use an outdated secure connection!\nUpdate \"Google Play Services\" in the Play Store, and try restarting the app";
-                    Toast.makeText(cont, message, Toast.LENGTH_LONG).show();
+                if (error != null && StringUtils.contains(error.getMessage(), "SSLProtocolException")) {
+                    Toast.makeText(cont, R.string.ssl_connection_error_message, Toast.LENGTH_LONG).show();
                 }
                 if(resultListener != null){
                     resultListener.failure(error);

--- a/Awful.apk/src/main/res/values/changelog.xml
+++ b/Awful.apk/src/main/res/values/changelog.xml
@@ -2,8 +2,9 @@
 <resources>
     <string-array name="changelog">
         <item>
-            3.3.2:\n
-            - Fix for HTTPS connection failures on older devices. If you still get SSL errors, try updating Google Play Services in the Play Store and restart the app!
+            3.3.3:\n
+            - Fix for HTTPS connection failures on older devices. If you still get SSL errors, try updating Google Play Services in the Play Store and restart the app!\n\n
+            - other bug fixes
         </item>
         <item>
             3.3.1:\n

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="insert_video_url_field_hint">Video URL</string>
 
     <!-- other shit -->
+    <string name="ssl_connection_error_message">CAN\'T CONNECT Your device is trying to use an outdated secure connection! Update \"Google Play Services\" in the Play Store, and try restarting the app</string>
     <string name="alert_message_1">GIF Animations are now disabled by default. This significantly improves battery life on
     most devices. \n
     \n


### PR DESCRIPTION
The error message checker (looking for SSL errors) didn't do null checks, that's
bad because there isn't always a message. Fixing this before there's a disaster!

Also moved the warning message into string resources