### PR TITLE
Rework and optimise post parsing

### DIFF
--- a/Awful.apk/build.gradle
+++ b/Awful.apk/build.gradle
@@ -120,7 +120,8 @@ dependencies {
     //compile 'com.mcxiaoke.volley:library:1.0.19'
     compile 'com.github.samkirton:android-volley:9aba4f5f86'
     compile 'com.google.code.gson:gson:2.8.0'
-    compile 'org.jsoup:jsoup:1.10.3'
+
+    compile 'org.jsoup:jsoup:1.11.2'
     compile 'com.jakewharton.threetenabp:threetenabp:1.0.4'
     compile 'com.samskivert:jmustache:1.13'
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.java
@@ -275,6 +275,7 @@ public abstract class AwfulRequest<T> {
         @Override
         protected Response<T> parseNetworkResponse(NetworkResponse response) {
             try{
+                long startTime = System.currentTimeMillis();
                 if(Constants.DEBUG) Log.i(TAG, "Starting parse: " + getUrl());
                 updateProgress(25);
                 Document doc = Jsoup.parse(new ByteArrayInputStream(response.data), "CP1252", Constants.BASE_URL);
@@ -289,7 +290,10 @@ public abstract class AwfulRequest<T> {
                 try{
                     T result = handleResponse(doc);
                     updateProgress(100);
-                    if(Constants.DEBUG) Log.i(TAG, "Successful parse: " + getUrl());
+                    if(Constants.DEBUG) {
+                        long parseTime = System.currentTimeMillis() - startTime;
+                        Log.i(TAG, String.format("Successful parse: %s\nTook %dms", getUrl(), parseTime));
+                    }
                     return Response.success(result, HttpHeaderParser.parseCacheHeaders(response));
                 }catch(AwfulError ae){
                     updateProgress(100);
@@ -303,7 +307,7 @@ public abstract class AwfulRequest<T> {
                 throw e;
             }catch(Exception e){
                 updateProgress(100);
-                if(Constants.DEBUG) Log.i(TAG, "Failed parse: " + getUrl());
+                if(Constants.DEBUG) Log.w(TAG, "Failed parse: " + getUrl(), e);
                 return Response.error(new ParseError(e));
             }
         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -232,7 +232,8 @@ public class AwfulThread extends AwfulPagedItem  {
      * @return the list of all the threads' metadata objects, ready for storage
      */
     public static List<ContentValues> parseForumThreads(Document forumPage, int forumId, int startIndex) {
-        String update_time = new Timestamp(System.currentTimeMillis()).toString();
+        long startTime = System.currentTimeMillis();
+        String update_time = new Timestamp(startTime).toString();
         List<ContentValues> result = new ArrayList<>();
         Log.v(TAG, "Update time: " + update_time);
         String username = AwfulPreferences.getInstance().username;
@@ -355,6 +356,9 @@ public class AwfulThread extends AwfulPagedItem  {
                 e.printStackTrace();
             }
         }
+
+        float averageParseTime = (System.currentTimeMillis() - startTime) / (float) result.size();
+        Log.i(TAG, String.format("%d threads parsed\nAverage parse time: %.3fms", result.size(), averageParseTime));
         return result;
     }
 
@@ -379,6 +383,7 @@ public class AwfulThread extends AwfulPagedItem  {
      * @param filterUserId if this page is for a thread filtered by user, this should be set to the user's ID, otherwise 0
      */
     public static void parseThreadPage(ContentResolver resolver, Document page, int threadId, int pageNumber, int postsPerPage, AwfulPreferences prefs, int filterUserId) {
+        long startTime = System.currentTimeMillis();
         // TODO: 03/06/2017 see issue #503 on GitHub - filtering by user means the thread data gets overwritten by the pages from this new, shorter thread containing their posts
         final int BLANK_USER_ID = 0;
         final boolean filteringOnUserId = filterUserId > BLANK_USER_ID;
@@ -467,11 +472,13 @@ public class AwfulThread extends AwfulPagedItem  {
         // finally write new thread data to the database
         ContentValues cv = thread.toContentValues();
         // TODO: 04/06/2017 this should be handled in the database-management classes
-        String update_time = new Timestamp(System.currentTimeMillis()).toString();
+        String update_time = new Timestamp(startTime).toString();
         cv.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);
         if (resolver.update(ContentUris.withAppendedId(CONTENT_URI, threadId), cv, null, null) < 1) {
             resolver.insert(CONTENT_URI, cv);
         }
+
+        Log.i(TAG, String.format("Thread parse time: %dms", System.currentTimeMillis() - startTime));
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -1,0 +1,147 @@
+package com.ferg.awfulapp.thread
+
+import android.content.ContentValues
+import android.util.Log
+import com.ferg.awfulapp.network.NetworkUtils
+import com.ferg.awfulapp.preferences.AwfulPreferences
+import com.ferg.awfulapp.provider.DatabaseHelper
+import com.ferg.awfulapp.thread.AwfulPost.*
+import org.jsoup.nodes.Element
+import java.util.concurrent.Callable
+import java.util.regex.Pattern
+
+/**
+ * Created by baka kaba on 10/11/2017.
+ *
+ * A Callable that parses post data from an [Element] and returns it as a [ContentValues], as defined
+ * in [AwfulPost].
+ *
+ * This is meant to be used with a multithreaded executor, so you can parse posts in parallel and
+ * speed up page loads.
+ */
+
+private val USER_ID_REGEX = Pattern.compile("userid=(\\d+)")
+private val POST_ID_GARBAGE = "\\D".toRegex()
+private val POST_TIMESTAMP_GARBAGE = "[^\\w\\s:,]".toRegex()
+private const val TAG = "KotlinPostParseTask"
+
+/**
+ *
+ * @param[postData]         an Element containing a post structure
+ * @param[updateTime]       a parsing timestamp, which should be the same for each parsing task in a page load
+ * @param[index]            the index of this post in the thread
+ * @param[lastReadIndex]    the index of the last-read post, used to mark this post as seen or unseen
+ * @param[threadId]         the ID of this post's thread
+ * @param[opId]             the user ID of the person who created the thread
+ * @param[preview]          true if this post is from a post preview page, false for a normal thread view
+ * @returns the post data represented as a ContentValues (see [AwfulPost])
+ */
+class PostParseTaskKt constructor(
+        private val postData: Element,
+        private val updateTime: String,
+        private val index: Int,
+        private val lastReadIndex: Int,
+        private val threadId: Int,
+        private val opId: Int,
+        private val preview: Boolean,
+        private val prefs: AwfulPreferences
+) : Callable<ContentValues> {
+
+    @Throws(Exception::class)
+    override fun call(): ContentValues {
+        return ContentValues().apply {
+            //timestamp for DB trimming after a week
+            put(DatabaseHelper.UPDATED_TIMESTAMP, updateTime)
+            put(THREAD_ID, threadId)
+
+            if (!preview) {
+                //post id is formatted "post1234567", so we strip out the "post" prefix.
+                put(ID, Integer.parseInt(postData.id().replace(POST_ID_GARBAGE, "")))
+                //we calculate this beforehand, but now can pull this from the post (thanks cooch!)
+                //wait actually no, FYAD doesn't support this. ~FYAD Privilege~
+                try {
+                    put(POST_INDEX, Integer.parseInt(postData.attr("data-idx").replace(POST_ID_GARBAGE, "")))
+                } catch (nfe: NumberFormatException) {
+                    put(POST_INDEX, index)
+                }
+            }
+
+            // Check for "class=seenX", or just rely on unread index
+            val markedSeen = postData.selectFirst("[class^=seen]") != null
+            val postHasBeenRead = markedSeen || index <= lastReadIndex
+            put(PREVIOUSLY_READ, postHasBeenRead.sqlBool)
+
+            put(USERNAME, textForClass("author"))
+            put(REGDATE, textForClass("registered"))
+            put(IS_PLAT, postData.hasDescendantWithClass("platinum").sqlBool)
+            put(IS_MOD, postData.hasDescendantWithClass("role-mod").sqlBool)
+            put(IS_ADMIN, postData.hasDescendantWithClass("role-admin").sqlBool)
+
+            // grab the custom title, and also the avatar if there is one
+            postData.selectFirst(".title")!!
+                    .also { put(AVATAR_TEXT, it.text()) }
+                    .selectFirst("img")
+                    ?.let {
+                        tryConvertToHttps(it)
+                        put(AVATAR, it.attr("src"))
+                    }
+
+            // FYAD has its post contents inside the .complete_shit element, so we just grab that instead of the full .postbody
+            val postBody = postData.selectFirst(".postbody")
+            val fyadPostBody = postBody!!.selectFirst(".complete_shit")
+            (fyadPostBody ?: postBody).also {
+                convertVideos(it, prefs.inlineYoutube)
+                it.getElementsByTag("img").forEach { processPostImage(it, postHasBeenRead, prefs) }
+                it.getElementsByTag("a").forEach { tryConvertToHttps(it) }
+                put(CONTENT, it.html())
+            }
+
+            // extract and clean up post timestamp
+            NetworkUtils.unencodeHtml(textForClass("postdate"))
+                    .replace(POST_TIMESTAMP_GARBAGE, "").trim()
+                    .let { put(DATE, it) }
+
+
+            // parse user ID - fall back to the profile link if necessary
+            var userId = postData.getElementsByClass("userinfo")
+                    .flatMap { it.classNames() }
+                    .map { it.substringAfter("userid-", "") }
+                    .firstOrNull { it.isNotEmpty() }
+                    ?.toInt()
+
+            if (userId == null) {
+                postData.selectFirst(".profilelinks [href*='userid=']")
+                        ?.let {
+                            val matcher = USER_ID_REGEX.matcher(it.attr("href"))
+                            if (matcher.find()) {
+                                userId = Integer.parseInt(matcher.group(1))
+                            }
+                        }
+            }
+
+            if (userId != null) {
+                put(USER_ID, userId)
+                put(IS_OP, (opId == userId).sqlBool)
+            } else {
+                // TODO: 10/11/2017 better error handling? This is sort of a deal-breaker
+                Log.w(TAG, "Failed to parse UID!")
+            }
+
+            postData.getElementsByClass("editedBy")
+                    .mapNotNull { it.children().first() }
+                    .firstOrNull()
+                    ?.let { put(EDITED, "<i>${ it.text() }</i>") }
+
+            put(EDITABLE, postData.getElementsByAttributeValue("alt", "Edit").isNotEmpty().sqlBool)
+        }
+    }
+
+    private val Boolean.sqlBool: Int
+        get() = if (this) 1 else 0
+
+    private fun textForClass(cssClass: String): String =
+            postData.selectFirst(".$cssClass")?.text() ?: "data missing"
+
+    private fun Element.hasDescendantWithClass(cssClass: String): Boolean =
+            this.selectFirst(".$cssClass") != null
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
@@ -19,9 +19,7 @@ import org.jsoup.nodes.Element;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.HashMap;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -143,25 +141,9 @@ public class AwfulError extends VolleyError {
         // not logged in
         if (null != page.getElementById("notregistered")) {
             Log.e(TAG, "!!!Page says not registered - You are now LOGGED OUT");
-            Log.w(TAG, "NetworkUtils Cookie Headers dump:");
-            Map<String, String> headerMap = new HashMap<>();
-            NetworkUtils.setCookieHeaders(headerMap);
-            for (Map.Entry header : headerMap.entrySet()) {
-                Log.w(TAG, "Header key: " + header.getKey() + " value: " + header.getValue());
-            }
-
-            Log.w(TAG, "HttpClient CookieStore dump:");
-            NetworkUtils.logCookies();
-
-            // TODO fix the actual problem, probably repeated network requests in a short space of time
-            if (!NetworkUtils.dodgeLogoutBullet()) {
                 NetworkUtils.clearLoginCookies(prefs.getContext());
                 prefs.getContext().startActivity(new Intent().setClass(prefs.getContext(), AwfulLoginActivity.class));
-                Log.e(TAG, "ERROR_LOGGED_OUT");
-            }
             return new AwfulError(ERROR_LOGGED_OUT);
-        } else {
-            NetworkUtils.resetDodges();
         }
 
         // closed forums
@@ -172,8 +154,8 @@ public class AwfulError extends VolleyError {
         }
 
         // Some generic error - shows up for (at least) post rate limiting and whatever #PostRequest was seeing in responses
-        if (page.getElementsByTag("body").hasClass("standarderror")) {
-            Element standard = page.getElementsByClass("standard").first();
+        if (page.selectFirst("body").hasClass("standarderror")) {
+            Element standard = page.selectFirst(".standard");
             if (standard != null && standard.hasText()) {
                 return new AwfulError(AwfulError.ERROR_ACCESS_DENIED, standard.text().replace("Special Message From Senor Lowtax", ""));
             }


### PR DESCRIPTION
I've redone the code for parsing posts from a thread page, to make page loads
faster and hopefully easier to maintain. Parsing is multithreaded now, it's more
specific about Element selection (to avoid expensive tree parsing) and uses some
jsoup improvements. Overall I'm seeing 3x faster parsing for the post elements,
which cuts page load times by almost a second on a full 40-post page.

Feels a bit snappier, and hopefully it'll get faster when jsoup updates to handle
Windows-1252 encoding in an optimised way. Ideally we can improve other parsing
tasks too (maybe using a shared executor for all parse tasks) and make loads as
quick as possible - they're pretty slow.

I tweaked AwfulError a little too for some speedup (since it's run on every
request response), but there's only so much I can do without being able to see
the content of error pages. I've also removed some code from NetworkUtils which
shouldn't be needed anymore (the anti-logout stuff that should have been fixed
by limiting the number of pending requests)