### PR TITLE
Move parsing tasks to ForumParsing, add dedicated multithreading, fix post previews

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewEditRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewEditRequest.java
@@ -4,19 +4,17 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
 import android.util.Log;
-import android.widget.Toast;
 
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
-import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.thread.AwfulMessage;
 import com.ferg.awfulapp.thread.AwfulPost;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by matt on 8/8/13.
@@ -51,15 +49,14 @@ public class PreviewEditRequest extends AwfulRequest<String> {
 
     @Override
     protected String handleResponse(Document doc) throws AwfulError {
-        //System.out.println(doc.body().html());
-        ArrayList<ContentValues> parsed = new ArrayList<>();
-        try {
-            parsed = AwfulPost.parsePosts(doc, 0, 0, 0, AwfulPreferences.getInstance(), 0, true);
+        List<ContentValues> parsed;
+        parsed = AwfulPost.parsePosts(doc, 0, 0, 0, AwfulPreferences.getInstance(), 0, true);
+        if (parsed.isEmpty()) {
+            Log.w(TAG, "handleResponse: parsing preview failed");
+            return "";
+        } else {
+            return parsed.get(0).getAsString(AwfulPost.CONTENT);
         }
-        catch (Exception e){
-            Log.e(TAG,"a thing happened",e);
-        }
-        return parsed.get(0).getAsString(AwfulPost.CONTENT);
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewEditRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewEditRequest.java
@@ -3,18 +3,17 @@ package com.ferg.awfulapp.task;
 import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
-import android.util.Log;
 
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
-import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.thread.AwfulMessage;
 import com.ferg.awfulapp.thread.AwfulPost;
+import com.ferg.awfulapp.thread.PostPreviewParseTask;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
 
-import java.util.List;
+import timber.log.Timber;
 
 /**
  * Created by matt on 8/8/13.
@@ -24,7 +23,7 @@ public class PreviewEditRequest extends AwfulRequest<String> {
         super(context, null);
         addPostParam(Constants.PARAM_ACTION, "updatepost");
         addPostParam(Constants.PARAM_POST_ID, Integer.toString(reply.getAsInteger(AwfulPost.EDIT_POST_ID)));
-        Log.e(TAG,Constants.PARAM_POST_ID +": " + Integer.toString(reply.getAsInteger(AwfulPost.EDIT_POST_ID)));
+        Timber.e(Constants.PARAM_POST_ID + ": " + Integer.toString(reply.getAsInteger(AwfulPost.EDIT_POST_ID)));
         addPostParam(Constants.PARAM_MESSAGE, NetworkUtils.encodeHtml(reply.getAsString(AwfulMessage.REPLY_CONTENT)));
         addPostParam(Constants.PARAM_PARSEURL, Constants.YES);
         if(reply.containsKey(AwfulPost.FORM_BOOKMARK) && reply.getAsString(AwfulPost.FORM_BOOKMARK).equalsIgnoreCase("checked")){
@@ -49,19 +48,12 @@ public class PreviewEditRequest extends AwfulRequest<String> {
 
     @Override
     protected String handleResponse(Document doc) throws AwfulError {
-        List<ContentValues> parsed;
-        parsed = AwfulPost.parsePosts(doc, 0, 0, 0, AwfulPreferences.getInstance(), 0, true);
-        if (parsed.isEmpty()) {
-            Log.w(TAG, "handleResponse: parsing preview failed");
-            return "";
-        } else {
-            return parsed.get(0).getAsString(AwfulPost.CONTENT);
-        }
+        return new PostPreviewParseTask(doc).call();
     }
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        Log.e(TAG,error.getMessage(),error);
+        Timber.e(error);
         return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewPostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewPostRequest.java
@@ -3,19 +3,18 @@ package com.ferg.awfulapp.task;
 import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
-import android.util.Log;
 import android.widget.Toast;
 
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
-import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.thread.AwfulMessage;
 import com.ferg.awfulapp.thread.AwfulPost;
+import com.ferg.awfulapp.thread.PostPreviewParseTask;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
 
-import java.util.List;
+import timber.log.Timber;
 
 /**
  * Created by matt on 8/8/13.
@@ -58,19 +57,12 @@ public class PreviewPostRequest extends AwfulRequest<String> {
 
     @Override
     protected String handleResponse(Document doc) throws AwfulError {
-        List<ContentValues> parsed;
-        parsed = AwfulPost.parsePosts(doc, 0, 0, 0, AwfulPreferences.getInstance(), 0, true);
-        if (parsed.isEmpty()) {
-            Log.w(TAG, "handleResponse: parsing preview failed");
-            return "";
-        } else {
-            return parsed.get(0).getAsString(AwfulPost.CONTENT);
-        }
+        return new PostPreviewParseTask(doc).call();
     }
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        Log.e(TAG,error.getMessage(),error);
+        Timber.e(error);
         return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewPostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewPostRequest.java
@@ -15,12 +15,15 @@ import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by matt on 8/8/13.
  */
 public class PreviewPostRequest extends AwfulRequest<String> {
+
+    // TODO: 18/12/2017 this and PreviewEditRequest are almost identical, merge 'em
+
     public PreviewPostRequest(Context context, ContentValues reply) {
         super(context, null);
         addPostParam(Constants.PARAM_ACTION, "postreply");
@@ -55,15 +58,14 @@ public class PreviewPostRequest extends AwfulRequest<String> {
 
     @Override
     protected String handleResponse(Document doc) throws AwfulError {
-        //System.out.println(doc.body().html());
-        ArrayList<ContentValues> parsed = new ArrayList<>();
-        try {
-            parsed = AwfulPost.parsePosts(doc, 0, 0, 0, AwfulPreferences.getInstance(), 0, true);
+        List<ContentValues> parsed;
+        parsed = AwfulPost.parsePosts(doc, 0, 0, 0, AwfulPreferences.getInstance(), 0, true);
+        if (parsed.isEmpty()) {
+            Log.w(TAG, "handleResponse: parsing preview failed");
+            return "";
+        } else {
+            return parsed.get(0).getAsString(AwfulPost.CONTENT);
         }
-        catch (Exception e){
-            Log.e(TAG,"a thing happened",e);
-        }
-        return parsed.get(0).getAsString(AwfulPost.CONTENT);
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPost.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPost.java
@@ -500,7 +500,7 @@ public class AwfulPost {
             if (postData.hasClass("ignored") && prefs.hideIgnoredPosts) {
                 continue;
             }
-            parseTasks.add(new PostParseTaskKt(postData, updateTime, index, unreadIndex, aThreadId, opId, preview, prefs));
+            parseTasks.add(new PostParseTask(postData, updateTime, index, unreadIndex, aThreadId, opId, preview, prefs));
             index++;
         }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -39,7 +39,6 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -52,7 +51,6 @@ import com.ferg.awfulapp.R;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.network.NetworkUtils;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
-import com.ferg.awfulapp.provider.AwfulProvider;
 import com.ferg.awfulapp.provider.ColorProvider;
 import com.ferg.awfulapp.provider.DatabaseHelper;
 
@@ -63,16 +61,14 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import timber.log.Timber;
 
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static butterknife.ButterKnife.findById;
-import static java.lang.Integer.parseInt;
 
 public class AwfulThread extends AwfulPagedItem  {
-    private static final String TAG = "AwfulThread";
 
     public static final String PATH         = "/thread";
     public static final String UCP_PATH     = "/ucpthread";
@@ -101,9 +97,6 @@ public class AwfulThread extends AwfulPagedItem  {
     public static final String TAG_URL 		        = "tag_url";
     public static final String TAG_CACHEFILE 	    = "tag_cachefile";
     public static final String TAG_EXTRA            = "tag_extra";
-
-    private static final Pattern forumId_regex = Pattern.compile("forumid=(\\d+)");
-	private static final Pattern urlId_regex = Pattern.compile("([^#]+)#(\\d+)$");
 
 
     // TODO: 04/06/2017 explicit default values, nulls where parsed data doesn't set values (i.e. never added to the ContentValues)?
@@ -138,7 +131,7 @@ public class AwfulThread extends AwfulPagedItem  {
     @Nullable
     public static AwfulThread fromCursorRow(@NonNull Cursor row) {
         if (row.isBeforeFirst() || row.isAfterLast()) {
-            Log.w(TAG, "fromCursor: passed empty row");
+            Timber.w("fromCursor: passed empty row");
             return null;
         }
         AwfulThread thread = new AwfulThread();
@@ -234,7 +227,7 @@ public class AwfulThread extends AwfulPagedItem  {
     static List<ContentValues> parseForumThreads(Document forumPage, int forumId, int startIndex) {
         long startTime = System.currentTimeMillis();
         String update_time = new Timestamp(startTime).toString();
-        Log.v(TAG, "Update time: " + update_time);
+        Timber.v("Update time: %s", update_time);
         String username = AwfulPreferences.getInstance().username;
 
         List<ForumParseTask> parseTasks = new ArrayList<>();
@@ -249,7 +242,7 @@ public class AwfulThread extends AwfulPagedItem  {
         List<ContentValues> result = ForumParsingKt.parse(parseTasks);
 
         float averageParseTime = (System.currentTimeMillis() - startTime) / (float) result.size();
-        Log.i(TAG, String.format("%d threads parsed\nAverage parse time: %.3fms", result.size(), averageParseTime));
+        Timber.i("%d threads parsed\nAverage parse time: %.3fms", result.size(), averageParseTime);
         return result;
     }
 
@@ -277,91 +270,11 @@ public class AwfulThread extends AwfulPagedItem  {
         long startTime = System.currentTimeMillis();
         // TODO: 03/06/2017 see issue #503 on GitHub - filtering by user means the thread data gets overwritten by the pages from this new, shorter thread containing their posts
         final int BLANK_USER_ID = 0;
+        // TODO: 05/01/2018 this filtering on userID thing isn't actually doing anything...
         final boolean filteringOnUserId = filterUserId > BLANK_USER_ID;
 
-        // first parse general thread metadata
-
-        Cursor threadData = resolver.query(ContentUris.withAppendedId(CONTENT_URI, threadId), AwfulProvider.ThreadProjection, null, null, null);
-        AwfulThread thread = null;
-        if (threadData != null) {
-            if (threadData.moveToFirst()) {
-                thread = fromCursorRow(threadData);
-            }
-            threadData.close();
-        }
-        if (thread == null) {
-            thread = new AwfulThread();
-        }
-
-        thread.id = threadId;
-
-        Element title = page.getElementsByClass("bclast").first();
-        thread.title = (title == null) ? "UNKNOWN TITLE" : title.text();
-
-        // look for a real reply button - if there isn't one, this thread is locked
-        Element replyButton = page.select("[alt=Reply]:not([src*='forum-closed'])").first();
-        thread.isLocked = (replyButton == null);
-
-        Element openCloseButton = page.select("[alt='Close thread']").first();
-        thread.canOpenClose = (openCloseButton != null);
-
-        Element bookmarkButton = page.select(".thread_bookmark").first();
-        // we're assuming no bookmark button means archived - there's an explicit archived icon we could find too
-        thread.archived = (bookmarkButton == null);
-        boolean bookmarked = (bookmarkButton != null) && bookmarkButton.attr("src").contains("unbookmark");
-
-        if (!bookmarked) {
-            thread.bookmarkType = 0;
-        } else if (thread.bookmarkType == 0) {
-            // update bookmarked status when it was previously 'unbookmarked'
-            thread.bookmarkType = 1;
-        }
-
-        // ID of this thread's forum
-        int forumId = -1;
-        Matcher matchForumId;
-        for (Element breadcrumb : page.select(".breadcrumbs [href]")) {
-            matchForumId = forumId_regex.matcher(breadcrumb.attr("href"));
-            if (matchForumId.find()) {//switched this to a regex
-                forumId = parseInt(matchForumId.group(1));//so this won't fail
-            }
-        }
-        thread.forumId = forumId;
-
-
-        // now calculate some read/unread numbers based on what we can see on the page
-        int lastPageNumber = AwfulPagedItem.parseLastPage(page);
-        int firstPostOnPageIndex = AwfulPagedItem.pageToIndex(pageNumber, postsPerPage, 0);
-        int firstUnreadIndex = !thread.hasBeenViewed ? 0 : thread.postCount - thread.unreadCount;
-
-        // hand off the page for post parsing, and get back the number of posts it found
-        // TODO: 02/06/2017 sort out the ignored posts issue, the post parser doesn't put them in the DB (if you have 'always hide' on in the settings) and it messes up the numbers
-        int postsOnThisPage = AwfulPost.syncPosts(resolver, page, threadId, firstUnreadIndex, thread.authorId, prefs, firstPostOnPageIndex);
-        int postsOnPreviousPages = (pageNumber - 1) * postsPerPage;
-        // calculate the read total by counting posts on this + preceding pages - only update the read count if it has grown (e.g. going back to an old page will give a lower count)
-        int postsRead = Math.max(thread.getReadCount(), postsOnPreviousPages + postsOnThisPage);
-
-        // we might have more recent info here, see if we need to update lastPostCount
-        // first up, if this is the last page then we've read all the posts
-        if (pageNumber == lastPageNumber) {
-            thread.postCount = postsRead;
-        } else {
-            // we can calculate a minimum and maximum posts range by looking at the last page number
-            int minTotal = ((lastPageNumber - 1) * postsPerPage) + 1;   // one post on the last page, any preceding pages are full
-            int maxTotal = lastPageNumber * postsPerPage;               // all pages full
-            // if lastPostCount is within this range, let's just assume it's more accurate than taking the minimum
-            // if it's outside of that range it's obviously a stale value, use the min as our best guess
-            int lastPostCount = thread.postCount;
-            thread.postCount = (minTotal <= lastPostCount && lastPostCount <= maxTotal) ? lastPostCount : minTotal;
-        }
-        // TODO: 16/06/2017 would it be better to store postCount and postsRead in the DB, and calculate the unread count from that?
-        thread.unreadCount = thread.postCount - postsRead;
-
-        Log.d(TAG, String.format("getThreadPosts: Thread ID %d, page %d of %d, %d posts on page%n%d posts total: %d read/%d unread",
-                thread.id, pageNumber, lastPageNumber, postsOnThisPage, thread.postCount, postsRead, thread.unreadCount));
-
         // finally write new thread data to the database
-        ContentValues cv = thread.toContentValues();
+        ContentValues cv = new ThreadPageParseTask(resolver, page, threadId, pageNumber, postsPerPage, prefs).call();
         // TODO: 04/06/2017 this should be handled in the database-management classes
         String update_time = new Timestamp(startTime).toString();
         cv.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);
@@ -369,7 +282,7 @@ public class AwfulThread extends AwfulPagedItem  {
             resolver.insert(CONTENT_URI, cv);
         }
 
-        Log.i(TAG, String.format("Thread parse time: %dms", System.currentTimeMillis() - startTime));
+        Timber.i("Thread parse time: %dms", System.currentTimeMillis() - startTime);
     }
 
 
@@ -377,7 +290,7 @@ public class AwfulThread extends AwfulPagedItem  {
 	public static void setDataOnThreadListItem(View item, AwfulPreferences prefs, Cursor data, AwfulFragment parent) {
         AwfulThread thread = fromCursorRow(data);
         if (thread == null) {
-            Log.w(TAG, "setDataOnThreadView: unable to get data for thread!");
+            Timber.w("setDataOnThreadView: unable to get data for thread!");
             return;
         }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -1,27 +1,32 @@
 package com.ferg.awfulapp.thread
 
+import android.content.ContentResolver
+import android.content.ContentUris
 import android.content.ContentValues
 import android.net.Uri
-import android.util.Log
 import com.ferg.awfulapp.constants.Constants
 import com.ferg.awfulapp.network.NetworkUtils
 import com.ferg.awfulapp.preferences.AwfulPreferences
+import com.ferg.awfulapp.provider.AwfulProvider
 import com.ferg.awfulapp.provider.DatabaseHelper
 import com.ferg.awfulapp.thread.AwfulPost.*
-import com.ferg.awfulapp.thread.AwfulThread.FORUM_ID
-import com.ferg.awfulapp.thread.AwfulThread.INDEX
+import com.ferg.awfulapp.thread.AwfulThread.*
+import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import timber.log.Timber
 import java.util.concurrent.*
+import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
  * Created by baka kaba on 10/11/2017.
  *
- * A Callable that parses post data from an [Element] and returns it as a [ContentValues], as defined
- * in [AwfulPost].
+ * Handles parsing forums html to extract data for posts, threads etc.
  *
- * This is meant to be used with a multithreaded executor, so you can parse posts in parallel and
- * speed up page loads.
+ * Different types of parsing (posts on a thread page, threads on a forum page etc.) have their own
+ * tasks - you can either #call these yourself, or use one of the #parse functions to run the tasks
+ * on the dedicated parsing threads. Generally you should call [parse] which attempts to run tasks
+ * in parallel if possible, and handles errors and fallback to running on the calling thread.
  */
 
 private val parseTaskExecutor: ExecutorService by lazy { Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()) }
@@ -41,26 +46,27 @@ fun <T> parse(parseTasks: Collection<Callable<T>>): List<T> {
     try {
         return parseMultiThreaded(parseTasks)
     } catch (e: InterruptedException) {
-        Log.w(TAG, "parse: parallel parse failed - attempting on main thread", e)
+        Timber.w(e, "parse: parallel parse failed - attempting on main thread")
     } catch (e: ExecutionException) {
-        Log.w(TAG, "parse: parallel parse failed - attempting on main thread", e)
+        Timber.w(e, "parse: parallel parse failed - attempting on main thread")
     }
 
     return try {
         parseSingleThreaded(parseTasks)
     } catch (e: Exception) {
-        Log.w(TAG, "parse: single-thread parse failed", e)
+        Timber.w(e, "parse: single-thread parse failed")
         emptyList()
     }
 }
 
 
-private val USER_ID_REGEX = Pattern.compile("userid=(\\d+)")
-private val POST_ID_GARBAGE = "\\D".toRegex()
-private val POST_TIMESTAMP_GARBAGE = "[^\\w\\s:,]".toRegex()
-private const val TAG = "KotlinPostParseTask"
-
 /**
+ * A task that parses data from a post on a thread page, and returns it as a [ContentValues],
+ * as defined in [AwfulPost].
+ *
+ * The Element you need to pass in is the one that wraps a single post's content, and has either
+ * an _id_ attribute of "postXXXXXX", or a _data-idx_ attribute of "XXXXX". Currently (as of 5/1/18)
+ * this is a _table_.
  *
  * @param[postData]         an Element containing a post structure
  * @param[updateTime]       a parsing timestamp, which should be the same for each parsing task in a page load
@@ -71,7 +77,7 @@ private const val TAG = "KotlinPostParseTask"
  * @param[preview]          true if this post is from a post preview page, false for a normal thread view
  * @returns the post data represented as a ContentValues (see [AwfulPost])
  */
-class PostParseTaskKt constructor(
+class PostParseTask(
         private val postData: Element,
         private val updateTime: String,
         private val index: Int,
@@ -82,6 +88,12 @@ class PostParseTaskKt constructor(
         private val prefs: AwfulPreferences
 ) : Callable<ContentValues> {
 
+    companion object {
+        private val USER_ID_REGEX = Pattern.compile("userid=(\\d+)")
+        private val POST_ID_GARBAGE = "\\D".toRegex()
+        private val POST_TIMESTAMP_GARBAGE = "[^\\w\\s:,]".toRegex()
+    }
+
     @Throws(Exception::class)
     override fun call(): ContentValues {
         return ContentValues().apply {
@@ -91,7 +103,7 @@ class PostParseTaskKt constructor(
 
             if (!preview) {
                 //post id is formatted "post1234567", so we strip out the "post" prefix.
-                put(ID, postData.id().replace(POST_ID_GARBAGE, "").toInt())
+                put(AwfulPost.ID, postData.id().replace(POST_ID_GARBAGE, "").toInt())
                 //we calculate this beforehand, but now can pull this from the post (thanks cooch!)
                 //wait actually no, FYAD doesn't support this. ~FYAD Privilege~
                 put(POST_INDEX, postData.attr("data-idx").replace(POST_ID_GARBAGE, "").toIntOrNull() ?: index)
@@ -155,13 +167,13 @@ class PostParseTaskKt constructor(
                 put(IS_OP, (opId == userId).sqlBool)
             } else {
                 // TODO: 10/11/2017 better error handling? This is sort of a deal-breaker
-                Log.w(TAG, "Failed to parse UID!")
+                Timber.w("Failed to parse UID!")
             }
 
             postData.getElementsByClass("editedBy")
                     .mapNotNull { it.children().first() }
                     .firstOrNull()
-                    ?.let { put(EDITED, "<i>${ it.text() }</i>") }
+                    ?.let { put(EDITED, "<i>${it.text()}</i>") }
 
             put(EDITABLE, postData.getElementsByAttributeValue("alt", "Edit").isNotEmpty().sqlBool)
         }
@@ -178,22 +190,38 @@ class PostParseTaskKt constructor(
 }
 
 
-private val THREAD_URL_ID_REGEX = Pattern.compile("([^#]+)#(\\d+)$")
-
+/**
+ * A task that parses thread data from an item in a thread list, and returns it as a [ContentValues],
+ * as defined in [AwfulThread].
+ *
+ * The Element you need to pass in is the one that wraps a single thread entry in the list, and has
+ * an _id_ attribute of "threadXXXXXX". Currently (as of 5/1/18) this is a _tr_.
+ *
+ * @param threadElement an Element containing a a thread list entry
+ * @param forumId the ID of the forum this thread is in
+ * @param threadIndex the index of this thread in the thread list
+ * @param username the user's username
+ * @param parseTimestamp the timestamp for this data (generally you want the same for a set of tasks)
+ * @returns the post data represented as a ContentValues (see [AwfulThread])
+ */
 class ForumParseTask(
         private val threadElement: Element,
         private val forumId: Int,
-        private val startIndex: Int,
+        private val threadIndex: Int,
         private val username: String,
         private val parseTimestamp: String
 ) : Callable<ContentValues> {
+
+    companion object {
+        private val THREAD_URL_ID_REGEX = Pattern.compile("([^#]+)#(\\d+)$")
+    }
 
     override fun call(): ContentValues {
         // start building thread data
         val awfulThread = AwfulThread()
         with(awfulThread) {
             id = threadElement.id().replace("\\D".toRegex(), "").toInt()
-            index = startIndex
+            index = threadIndex
             forumId = this@ForumParseTask.forumId
 
             threadElement.selectFirst(".thread_title")?.let { title = it.text() }
@@ -212,8 +240,7 @@ class ForumParseTask(
 
             // optional thread rating
             rating = threadElement.selectFirst(".rating img")
-                    ?.let { AwfulRatings.getId(it.attr("src")) }
-                    ?: AwfulRatings.NO_RATING
+                    ?.let { AwfulRatings.getId(it.attr("src")) } ?: AwfulRatings.NO_RATING
 
             // main thread tag
             threadElement.selectFirst(".icon img")?.let {
@@ -234,8 +261,7 @@ class ForumParseTask(
 
             // secondary thread tag (e.g. Ask/Tell type)
             tagExtra = threadElement.selectFirst(".icon2 img")
-                    ?.let { ExtraTags.getId(it.attr("src")) }
-                    ?: ExtraTags.NO_TAG
+                    ?.let { ExtraTags.getId(it.attr("src")) } ?: ExtraTags.NO_TAG
 
 
             // replies / postcount
@@ -267,5 +293,95 @@ class ForumParseTask(
             }
         }
     }
-
 }
+
+
+/**
+ * A task that parses thread data from a thread page and returns it as a [ContentValues],
+ * as defined in [AwfulThread].
+ *
+ * @param resolver used to load current data for this thread
+ * @param page a Document representing a page from a thread
+ * @param threadId the ID of the thread this page is from
+ * @param pageNumber this page's number in the thread when it was fetched
+ * @param postsPerPage the posts-per-page setting used while fetching this page
+ * @returns new or updated data for this thread, represented as a ContentValues (see [AwfulThread])
+ */
+class ThreadPageParseTask(
+        private val resolver: ContentResolver,
+        private val page: Document,
+        private val threadId: Int,
+        private val pageNumber: Int,
+        private val postsPerPage: Int,
+        private val prefs: AwfulPreferences
+) : Callable<ContentValues> {
+
+    companion object {
+        val FORUM_ID_REGEX: Pattern = Pattern.compile("forumid=(\\d+)")
+    }
+
+    override fun call(): ContentValues {
+        // try and load the current thread data from the DB, otherwise create a new AwfulThread
+        val uri = ContentUris.withAppendedId(AwfulThread.CONTENT_URI, threadId.toLong())
+        val thread = resolver.query(uri, AwfulProvider.ThreadProjection, null, null, null).use {
+            it?.apply { moveToFirst() }?.let(::fromCursorRow) ?: AwfulThread()
+        }
+
+        with(thread) {
+            id = threadId
+            title = page.selectFirst(".bclast")?.text() ?: "UNKNOWN TITLE"
+            // look for a real reply button - if there isn't one, this thread is locked
+            isLocked = page.selectFirst("[alt=Reply]:not([src*='forum-closed'])") == null
+            canOpenClose = page.selectFirst("[alt='Close thread']") != null
+
+            val bookmarkButton = page.selectFirst(".thread_bookmark")
+            archived = bookmarkButton == null
+            val bookmarked = bookmarkButton != null && bookmarkButton.attr("src").contains("unbookmark")
+            if (!bookmarked) {
+                bookmarkType = 0
+            } else if (bookmarkType == 0) {
+                // so if the thread IS bookmarked, check if the data has an 'unbookmarked' value (i.e. 0) and give it a bookmarked one if necessary
+                bookmarkType = 1
+            }
+
+            forumId = page.select(".breadcrumbs [href]")
+                    .map { FORUM_ID_REGEX.matcher(it.attr("href")) }
+                    .firstOrNull(Matcher::find)
+                    ?.group(1)?.toInt() ?: -1
+
+
+            // now calculate some read/unread numbers based on what we can see on the page
+            val lastPageNumber = AwfulPagedItem.parseLastPage(page)
+            val firstPostOnPageIndex = AwfulPagedItem.pageToIndex(pageNumber, postsPerPage, 0)
+            val firstUnreadIndex = if (!hasBeenViewed) 0 else postCount - unreadCount
+
+            // hand off the page for post parsing, and get back the number of posts it found
+            // TODO: 02/06/2017 sort out the ignored posts issue, the post parser doesn't put them in the DB (if you have 'always hide' on in the settings) and it messes up the numbers
+            val postsOnThisPage = syncPosts(resolver, page, threadId, firstUnreadIndex, authorId, prefs, firstPostOnPageIndex)
+            val postsOnPreviousPages = (pageNumber - 1) * postsPerPage
+            // calculate the read total by counting posts on this + preceding pages - only update the read count if it has grown (e.g. going back to an old page will give a lower count)
+            val postsRead = (postsOnPreviousPages + postsOnThisPage).coerceAtLeast(readCount)
+
+            postCount = if (pageNumber == lastPageNumber) {
+                // this is the last page, so we've read all the posts in the thread
+                postsRead
+            } else {
+                // not the last page, so we can't tell how many posts the thread has, we have to estimate it
+                // we can calculate a minimum and maximum posts range by looking at the last page number
+                val minPosts = (lastPageNumber - 1) * postsPerPage + 1   // one post on the last page, any preceding pages are full
+                val maxPosts = lastPageNumber * postsPerPage             // all pages full
+                // if the old post count is within this range, let's just assume it's more accurate than taking the minimum
+                // if it's outside of that range it's obviously a stale value, use the min as our best guess
+                if (postCount in minPosts..maxPosts) postCount else minPosts
+            }
+            // TODO: 16/06/2017 would it be better to store postCount and postsRead in the DB, and calculate the unread count from that?
+            unreadCount = postCount - postsRead
+
+            Timber.d("getThreadPosts: Thread ID %d, page %d of %d, %d posts on page%n%d posts total: %d read/%d unread",
+                    id, pageNumber, lastPageNumber, postsOnThisPage, postCount, postsRead, unreadCount)
+
+        }
+        return thread.toContentValues()
+    }
+}
+


### PR DESCRIPTION
- I've reimplemented the 'parse a list of threads' and 'parse thread data from a thread page' tasks in ForumParsing, with some efficiency tweaks. Thread list parsing is a little faster.
- Parsing post previews has its own special (incredibly simple) task now - it has almost nothing to do with
the normal post parsing and combining the two just complicated both.
- The multithreading code has also been moved into ForumParsing, so now you can just call a ``parse`` method to have your tasks run on a dedicated thread pool. Might be worth using this for other parsing tasks too, like the forum spider one.
- Also changed some ``Log`` calls to ``Timber``
  