### PR TITLE
Extract NavigationDrawer to own class, cleanup in ForumsIndexActivity

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/NavigationDrawer.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/NavigationDrawer.kt
@@ -1,0 +1,192 @@
+package com.ferg.awfulapp
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.AsyncTask
+import android.support.design.widget.NavigationView
+import android.support.v4.view.GravityCompat
+import android.support.v4.widget.DrawerLayout
+import android.support.v7.app.ActionBarDrawerToggle
+import android.support.v7.widget.Toolbar
+import android.view.MenuItem
+import android.widget.ImageView
+import android.widget.TextView
+import com.android.volley.VolleyError
+import com.android.volley.toolbox.ImageLoader
+import com.ferg.awfulapp.ForumsIndexActivity.NULL_FORUM_ID
+import com.ferg.awfulapp.ForumsIndexActivity.NULL_THREAD_ID
+import com.ferg.awfulapp.announcements.AnnouncementsManager
+import com.ferg.awfulapp.constants.Constants
+import com.ferg.awfulapp.network.NetworkUtils
+import com.ferg.awfulapp.preferences.AwfulPreferences
+import com.ferg.awfulapp.provider.StringProvider
+import com.ferg.awfulapp.provider.StringProvider.getString
+import com.ferg.awfulapp.util.AwfulUtils
+import java.lang.ref.WeakReference
+
+/**
+ * Created by baka kaba on 11/01/2018.
+ *
+ * The navigation drawer code extracted from ForumsIndexActivity, with some refinement.
+ *
+ * The idea is to separate and encapsulate the behaviour, so this drawer is an independent component
+ * that can listen for its own events (e.g. new private messages and announcements) and let the main
+ * activity know when it needs to do something. The app code is still fairly tangled up, so some of
+ * this (especially the 'set current forum' handling and display code) will need to be improved when
+ * those issues are fixed. For now though, it should work like the old version.
+ */
+
+/**
+ * A navigation drawer for use with ForumsIndexActivity.
+ *
+ * Create this after inflating your activity's layout. You can call [open] and [close] on the drawer,
+ * and [setCurrentForumAndThread] to update the hierarchy view. [drawerToggle] is exposed so the
+ * activity can call lifecycle events like [ActionBarDrawerToggle.syncState], and set things like
+ * the arrow behaviour if required.
+ *
+ * @param activity the Activity this navigation drawer is attached to
+ * @param toolbar the Activity's action bar
+ */
+class NavigationDrawer(val activity: ForumsIndexActivity, toolbar: Toolbar, val prefs: AwfulPreferences) {
+
+    private val navigationMenu: NavigationView = activity.findViewById(R.id.navigation)
+    private val drawerLayout: DrawerLayout = activity.findViewById(R.id.drawer_layout)
+    private val username: TextView
+    private val avatar: ImageView
+    private val forumItem = menuItem(R.id.sidebar_forum)
+    private val threadItem = menuItem(R.id.sidebar_thread)
+    private val pmItem = menuItem(R.id.sidebar_pm)
+    private val searchItem = menuItem(R.id.sidebar_search)
+    private val announcementsItem = menuItem(R.id.sidebar_announcements)
+
+    val drawerToggle: ActionBarDrawerToggle
+    /** items that represent platinum-only features */
+    private val platFeatures = listOf(pmItem, searchItem)
+
+    private var currentForumId = NULL_FORUM_ID
+    private var currentThreadId = NULL_THREAD_ID
+
+
+    init {
+        navigationMenu.setNavigationItemSelectedListener(::handleItemSelection)
+        drawerToggle = ActionBarDrawerToggle(activity, drawerLayout, toolbar, R.string.drawer_open, R.string.drawer_close)
+        drawerLayout.setDrawerListener(drawerToggle)
+
+        val nav = navigationMenu.getHeaderView(0)
+        username = nav.findViewById(R.id.sidebar_username) as TextView
+        avatar = nav.findViewById(R.id.sidebar_avatar) as ImageView
+
+        prefs.registerCallback { _, _ -> refresh() }
+        AnnouncementsManager.getInstance().registerListener { _, _, _, _ -> refresh() }
+        refresh()
+    }
+
+    private fun menuItem(resId: Int) = navigationMenu.menu.findItem(resId)
+
+
+    private fun loadAvatar(userTitle: String, avatar: ImageView) {
+        NetworkUtils.getImageLoader().get(userTitle, object : ImageLoader.ImageListener {
+            override fun onResponse(response: ImageLoader.ImageContainer, isImmediate: Boolean) {
+                response.bitmap?.let(avatar::setImageBitmap)
+                return
+            }
+
+            override fun onErrorResponse(error: VolleyError) = avatar.setImageResource(R.drawable.frog_icon)
+        })
+    }
+
+
+    private fun handleItemSelection(menuItem: MenuItem): Boolean {
+        with(activity) {
+            when (menuItem.itemId) {
+                R.id.sidebar_index -> displayForumIndex()
+                R.id.sidebar_forum -> showForumView(currentForumId)
+                R.id.sidebar_thread -> showThreadView(currentThreadId, currentForumId)
+                R.id.sidebar_bookmarks -> showBookmarks()
+                R.id.sidebar_settings -> showSettings()
+                R.id.sidebar_search -> showSearch()
+                R.id.sidebar_pm -> showPrivateMessages()
+                R.id.sidebar_announcements -> showAnnouncements()
+                R.id.sidebar_logout -> showLogout()
+                else -> return false //not handled, exit early without closing
+            }
+            close()
+            return true
+        }
+    }
+
+
+    private fun refresh() {
+        username.text = prefs.username
+        prefs.userTitle?.let { customTitle ->
+            if (customTitle.isNotBlank()) loadAvatar(customTitle, avatar) else avatar.setImageResource(R.drawable.frog_icon)
+            if (AwfulUtils.isLollipop()) avatar.clipToOutline = customTitle.isNotBlank()
+        }
+
+        // display the current forum title (or not)
+        forumItem.isVisible = currentForumId != NULL_FORUM_ID && currentForumId != Constants.USERCP_ID
+        threadItem.isVisible = currentThreadId != NULL_THREAD_ID
+
+        // update the forum and thread titles in the background, to avoid hitting the DB on the UI thread
+        // to keep things simple, it also sets the text on anything we just hid, which will be placeholder text if the IDs are invalid
+        HierarchyTextUpdater(currentForumId, currentThreadId, activity, forumItem, threadItem).execute()
+        platFeatures.forEach { it.setEnabled(prefs.hasPlatinum).isVisible = prefs.hasPlatinum }
+        val unread = AnnouncementsManager.getInstance().unreadCount
+        announcementsItem.title = getString(R.string.announcements) + if (unread == 0) "" else " ($unread)"
+    }
+
+    fun setCurrentForumAndThread(forumId: Int?, threadId: Int?) {
+        currentForumId = forumId ?: NULL_FORUM_ID
+        currentThreadId = threadId ?: NULL_THREAD_ID
+        refresh()
+    }
+
+    fun open(): Boolean = drawerLayout.changeState(toOpen = true)
+    fun close(): Boolean = drawerLayout.changeState(toOpen = false)
+    /** Try to open or close the drawer, returning false if it was already in the requested state */
+    private fun DrawerLayout.changeState(toOpen: Boolean): Boolean {
+        return when (toOpen) {
+            isDrawerOpen(GravityCompat.START) -> false
+            true -> true.also { openDrawer(GravityCompat.START); }
+            false -> true.also { closeDrawer(GravityCompat.START); }
+        }
+    }
+}
+
+
+/**
+ * Updates the SA Forums -> Forum -> Thread hierarchy bit by loading titles from the DB on a background thread.
+ *
+ * This is not great (and updates get requested way too much right now) but this avoids the UI glitching
+ * we were getting by doing it on the main thread.
+ * Ideally in future we'll be passing around Forum and Thread objects that carry this data, so we can
+ * avoid this completely.
+ */
+private class HierarchyTextUpdater(
+        val forumId: Int,
+        val threadId: Int,
+        context: Context,
+        forumItem: MenuItem,
+        threadItem: MenuItem
+) : AsyncTask<Void, Void, Void>() {
+
+    private var forumName: String? = null
+    private var threadName: String? = null
+    // avoiding any strong references to the activity or drawer (which holds an activity reference too)
+    @SuppressLint("StaticFieldLeak") // what do you want from me here
+    private val appContext = context.applicationContext
+    private val forumMenuItem = WeakReference(forumItem)
+    private val threadMenuItem = WeakReference(threadItem)
+
+    override fun doInBackground(vararg params: Void?): Void? {
+        threadName = StringProvider.getThreadName(appContext, threadId)
+        if (forumId != NULL_FORUM_ID) forumName = StringProvider.getForumName(appContext, forumId)
+        return null
+    }
+
+    override fun onPostExecute(aVoid: Void?) {
+        forumMenuItem.get()?.title = forumName ?: ""
+        threadMenuItem.get()?.title = threadName ?: ""
+    }
+
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -163,7 +163,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
 	private int pageBeforeFiltering = 0;
 
 	private static final int BLANK_USER_ID = 0;
-	private static final int FIRST_PAGE = 1;
+	public static final int FIRST_PAGE = 1;
 
 	// TODO: fix this it's all over the place, getting assigned as 1 in loadThread etc - maybe it should default to FIRST_PAGE?
 	/** Current thread's last page */
@@ -1349,7 +1349,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements SwipyRefresh
         return mLastPage;
     }
 
-    private int getThreadId() {
+    public int getThreadId() {
         return parentActivity.getThreadId();
     }
 	

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/StringProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/StringProvider.java
@@ -2,10 +2,10 @@ package com.ferg.awfulapp.provider;
 
 import android.content.ContentResolver;
 import android.content.ContentUris;
+import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 
-import com.ferg.awfulapp.AwfulActivity;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.thread.AwfulForum;
 import com.ferg.awfulapp.thread.AwfulThread;
@@ -18,18 +18,18 @@ public class StringProvider {
         return prefs.getResources().getString(stringId);
     }
 
-    public static String getForumName(AwfulActivity context, int forumId){
+    public static String getForumName(Context context, int forumId){
         return getName(context, forumId, AwfulForum.CONTENT_URI, AwfulProvider.ForumProjection,
                 AwfulForum.TITLE, "Forum #");
     }
 
-    public static String getThreadName(AwfulActivity context, int threadId){
+    public static String getThreadName(Context context, int threadId){
         return getName(context, threadId, AwfulThread.CONTENT_URI, AwfulProvider.ThreadProjection,
                 AwfulThread.TITLE, "Thread #");
     }
 
 
-    private static String getName(AwfulActivity context, int id, Uri contentUri, String[] projection,
+    private static String getName(Context context, int id, Uri contentUri, String[] projection,
                                   String columnName, String defaultPrefix) {
         String result;
         ContentResolver contentResolver = context.getContentResolver();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/ViewExt.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/ViewExt.kt
@@ -1,5 +1,7 @@
 package com.ferg.awfulapp.util
 
+import android.app.Activity
+import android.support.v4.app.Fragment
 import android.view.View
 
 
@@ -9,3 +11,10 @@ fun View.isHidden() = (this.visibility == View.INVISIBLE || this.visibility == V
 fun View.hide() { this.visibility = View.GONE }
 fun View.show() { this.visibility = View.VISIBLE }
 fun View.setInvisible() { this.visibility = View.INVISIBLE }
+
+/**
+ * These let you late-bind views as vals, so long as you only access them after the view has been created
+ * e.g. "val myTextView: TextView by bind(R.id.some_textview)"
+ */
+fun <T : View> Fragment.bind(resId: Int): Lazy<T?> = lazy(LazyThreadSafetyMode.NONE) { view!!.findViewById<T>(resId) }
+fun <T : View> Activity.bind(resId: Int): Lazy<T?> = lazy(LazyThreadSafetyMode.NONE) { findViewById<T>(resId) }


### PR DESCRIPTION
The navigation drawer is now its own separate component added to the activity.
It handles its own display, listens for relevant callbacks (e.g. new
announcements) and calls the activity when the user clicks on an item.

I've refactored the activity so it exposes methods for these navigation events -
so now there are functions for "show announcements", "show logout" etc. This
basically extends the interface we were already using ("display thread", "display
forum") and makes the activity more of a central coordinator for any events one
of the components might trigger.

It's still not perfect, but until the rest of the activity/fragment code and
interaction is cleaned up, it at least works like it used to

I also cleaned up a few lint issues while I was at it (adding lambdas mostly)

Docs