### PR TITLE
Fix Intent handling, state restoration in ForumIndex/DisplayFragment

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
@@ -57,7 +57,6 @@ import com.ferg.awfulapp.messages.PmManager;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.sync.SyncManager;
-import com.ferg.awfulapp.util.AwfulUtils;
 import com.ferg.awfulapp.widget.ToggleViewPager;
 
 import org.jetbrains.annotations.NotNull;
@@ -66,7 +65,6 @@ import java.util.Locale;
 
 import timber.log.Timber;
 
-//import com.ToxicBakery.viewpager.transforms.*;
 
 public class ForumsIndexActivity extends AwfulActivity
         implements PmManager.Listener, AnnouncementsManager.AnnouncementListener, PagerCallbacks {
@@ -100,6 +98,11 @@ public class ForumsIndexActivity extends AwfulActivity
         setupImmersion();
         PmManager.registerListener(this);
         AnnouncementsManager.getInstance().registerListener(this);
+
+        // only handle the Activity's intent when it's first created, or that navigation event will be fired whenever the activity is restored
+        if (savedInstanceState == null) {
+            handleIntent(getIntent());
+        }
     }
 
     @Override
@@ -337,6 +340,14 @@ public class ForumsIndexActivity extends AwfulActivity
     @Override
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
+        handleIntent(intent);
+    }
+
+
+    /**
+     * Parse and process an intent, e.g. to handle a navigation event.
+     */
+    private void handleIntent(@NonNull Intent intent) {
         NavigationEvent parsed = NavigationEvent.Companion.parse(intent);
         Timber.i("Parsed intent as %s", parsed.toString());
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexFragment.java
@@ -54,6 +54,8 @@ import static com.ferg.awfulapp.forums.ForumStructure.TWO_LEVEL;
 public class ForumsIndexFragment extends AwfulFragment
         implements ForumRepository.ForumsUpdateListener, ForumListAdapter.EventListener {
 
+    private static final String KEY_SHOW_FAVOURITES = "show_favourites";
+
     @BindView(R.id.forum_index_list)
     RecyclerView forumRecyclerView;
     @BindView(R.id.view_switcher)
@@ -82,6 +84,9 @@ public class ForumsIndexFragment extends AwfulFragment
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        if (savedInstanceState != null) {
+            showFavourites = savedInstanceState.getBoolean(KEY_SHOW_FAVOURITES);
+        }
         setHasOptionsMenu(true);
         setRetainInstance(false);
     }
@@ -129,6 +134,11 @@ public class ForumsIndexFragment extends AwfulFragment
         super.onPause();
     }
 
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(KEY_SHOW_FAVOURITES, showFavourites);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // Menus


### PR DESCRIPTION
The app now handles intents properly, so the bookmarks widget and external URL
handling works correctly. This also fixes earlier bugs where those intents
would 'stick', e.g. a thread opened through a URL intent would always show when
the app restored, or the current forum would reset to Bookmarks again.

ForumsPagerController has some deferred event code added - basically methods like
"openThread" might be called before the pager actually has the fragment that
will handle that event (e.g. when the app is opening from an intent), so the
call needs to be deferred until the fragment is added to the pager. It's pretty
naive (just queues them all up, doesn't account for concurrency issues) but it
really only happens when initialising, so there shouldn't be time for anything
bad to happen (?)

ForumsIndexFragment now restores its last mode (Forums/Favourites) and
ForumDisplayFragment restores the correct forum and page. Neither handle scroll
positions - for ForumDisplayFragment it *sometimes* works automatically, but
the ListView will only restore if it has its data on the first layout, which
isn't always the case (because of the Loader). Doing it manually probably
requires saving the top ListView item and scroll offset, and storing those as
deferred scroll data for when the Loader finishes. ForumsIndexActivity is
probably more complicated since it has expandable items that would need to be
restored in the same state

ThreadDisplayFragment needs a lot of cleaning up, but especially to remove the
startup code that messes with the activity's intent. I don't think it will ever
have one it will use now, but it still needs to go