### PR TITLE
Fix parent forum parsing for thread pages

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -356,9 +356,12 @@ class ThreadPageParseTask(
                 // so if the thread IS bookmarked, check if the data has an 'unbookmarked' value (i.e. 0) and give it a bookmarked one if necessary
                 bookmarkType = 1
             }
-            forumId = page.select(".breadcrumbs [href]")
-                    .map { FORUM_ID_REGEX.matcher(it.attr("href")) }
-                    .firstOrNull(Matcher::find)
+            // The breadcrumbs display the forum hiearchy, from the top level down through forums and subforums to the thread.
+            // So the thread's parent forum is the last forum element in that sequence
+            forumId = page.selectFirst(".breadcrumbs")
+                    ?.select("[href]")
+                    ?.map { FORUM_ID_REGEX.matcher(it.attr("href")) }
+                    ?.lastOrNull(Matcher::find)
                     ?.group(1)?.toInt() ?: -1
 
 


### PR DESCRIPTION
The HTML from the page request is actually different to the HTML that ends up
in the browser DOM (thanks Sereri!), so we were basically parsing a different
structure and picking up elements that weren't present in the browser.

I rewrote the parsing logic so it makes more sense - instead of taking the first
element in a list we assume has a single forum in it, now we just pick the last
in the list (which should always be the immediate parent)