### PR TITLE
Remove GIF warning popup, move disable option to Images settings

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumsIndexActivity.java
@@ -31,7 +31,6 @@ package com.ferg.awfulapp;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
@@ -102,6 +101,7 @@ public class ForumsIndexActivity extends AwfulActivity
         if (savedInstanceState == null) {
             handleIntent(getIntent());
         }
+        showChangelogIfRequired();
     }
 
     @Override
@@ -369,31 +369,16 @@ public class ForumsIndexActivity extends AwfulActivity
     }
 
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-
+    private void showChangelogIfRequired() {
         int versionCode = 0;
         try {
             versionCode = getPackageManager().getPackageInfo(getPackageName(), 0).versionCode;
         } catch (PackageManager.NameNotFoundException e) {
             e.printStackTrace();
         }
-
-        // check if this is the first run, and if so show the 'welcome' dialog
-        if (getMPrefs().alertIDShown == 0) {
-            new AlertDialog.Builder(this).
-                    setTitle(getString(R.string.alert_title_1))
-                    .setMessage(getString(R.string.alert_message_1))
-                    .setPositiveButton(getString(R.string.alert_ok), (dialog, which) -> dialog.dismiss())
-                    .setNegativeButton(getString(R.string.alert_settings), (dialog, which) -> {
-                        dialog.dismiss();
-                        showSettings();
-                    })
-                    .show();
-            getMPrefs().setPreference(Keys.ALERT_ID_SHOWN, 1);
-        } else if (getMPrefs().lastVersionSeen != versionCode) {
-            Log.i(TAG, String.format("App version changed from %d to %d - showing changelog", getMPrefs().lastVersionSeen, versionCode));
+        int lastVersionSeen = getMPrefs().lastVersionSeen;
+        if (lastVersionSeen != versionCode) {
+            Timber.i("App version changed from %d to %d - showing changelog", lastVersionSeen, versionCode);
             ChangelogDialog.show(this);
             getMPrefs().setPreference(Keys.LAST_VERSION_SEEN, versionCode);
         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/MiscSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/MiscSettings.java
@@ -1,7 +1,6 @@
 package com.ferg.awfulapp.preferences.fragments;
 
 import android.app.Dialog;
-import android.os.Build;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.support.annotation.NonNull;
@@ -24,11 +23,6 @@ public class MiscSettings extends SettingsFragment {
         VALUE_SUMMARY_PREF_KEYS = new int[] {
                 R.string.pref_key_orientation
         };
-        VERSION_DEPENDENT_SUMMARY_PREF_KEYS = new int[] {
-                R.string.pref_key_disable_gifs,
-                R.string.pref_key_immersion_mode,
-                R.string.pref_key_transformer
-        };
         prefClickListeners.put(new P2RDistanceListener(), new int[] {
                 R.string.pref_key_pull_to_refresh_distance
         });
@@ -45,15 +39,9 @@ public class MiscSettings extends SettingsFragment {
     @Override
     protected void initialiseSettings() {
         super.initialiseSettings();
-
-        findPrefById(R.string.pref_key_disable_gifs).setEnabled(true);
-        findPrefById(R.string.pref_key_immersion_mode).setEnabled(true);
         boolean tab = AwfulUtils.isTablet(getActivity(), true);
         findPrefById(R.string.pref_key_page_layout).setEnabled(tab);
         findPrefById(R.string.pref_key_transformer).setEnabled(!tab);
-//        if(!tab){
-//            findPreference("page_layout").setSummary(getString(R.string.page_layout_summary_disabled));
-//        }
     }
 
 

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -436,7 +436,6 @@
     <string name="select_font">Font</string>
 
     <!-- Misc Settings page -->
-    <string name="misc_category_performance">Performance tweaks</string>
     <string name="disable_gifs">Disable GIF animation</string>
     <string name="disable_gifs_summary">Extends battery life significantly</string>
     <string name="misc_category_display">Display</string>
@@ -454,8 +453,8 @@
         <item>Portrait</item>
         <item>Landscape</item>
     </string-array>
-    <string name="immersion_mode">Immersion Mode</string>
-    <string name="immersion_mode_summary">Fullscreen mode for KitKat and above</string>
+    <string name="immersion_mode">Immersive mode</string>
+    <string name="immersion_mode_summary">Use the full screen, swipe the top or bottom for controls</string>
     <string name="misc_category_navigation">Navigation</string>
     <string name="disable_pull_next">Disable pull-for-next</string>
     <string name="disable_pull_next_summary">Disable pull at bottom of thread navigation</string>

--- a/Awful.apk/src/main/res/xml/imagesettings.xml
+++ b/Awful.apk/src/main/res/xml/imagesettings.xml
@@ -20,6 +20,12 @@
             android:defaultValue="false"
             />
         <com.ferg.awfulapp.preferences.CustomSwitchPreference
+            android:key="@string/pref_key_disable_gifs"
+            android:title="@string/disable_gifs"
+            android:summary="@string/disable_gifs_summary"
+            android:defaultValue="true"
+            />
+        <com.ferg.awfulapp.preferences.CustomSwitchPreference
             android:key="@string/pref_key_avatars_enabled"
             android:title="@string/load_avatars"
             android:defaultValue="true"

--- a/Awful.apk/src/main/res/xml/miscsettings.xml
+++ b/Awful.apk/src/main/res/xml/miscsettings.xml
@@ -1,16 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-        <PreferenceCategory android:title="@string/misc_category_performance">
-            <com.ferg.awfulapp.preferences.CustomSwitchPreference
-                android:key="@string/pref_key_disable_gifs"
-                android:title="@string/disable_gifs"
-                android:summary="@string/disable_gifs_summary"
-                android:defaultValue="true"
-                android:enabled="false"
-                />
-        </PreferenceCategory>
-
         <PreferenceCategory android:title="@string/misc_category_display">
             <ListPreference
                 android:key="@string/pref_key_page_layout"
@@ -38,7 +28,6 @@
                 android:title="@string/immersion_mode"
                 android:summary="@string/immersion_mode_summary"
                 android:defaultValue="false"
-                android:enabled="false"
                 />
             <ListPreference
                 android:key="@string/pref_key_transformer"


### PR DESCRIPTION
The popup on first run has gone, and the toggle is under images now (where people
look for it) instead of the general device section (where it was meant to be a
performance tweak)

Also cleaned up some settings code to reflect the move to Lollipop (mostly
changed things to standard preferences that were version-dependent before)

Closes #581 