### PR TITLE
Fix (hopefully) screen staying on by default for some people

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -2,17 +2,14 @@ package com.ferg.awfulapp.webview;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 import android.util.AttributeSet;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
-import com.ferg.awfulapp.util.AwfulUtils;
 
 import static com.ferg.awfulapp.constants.Constants.DEBUG;
 
@@ -31,7 +28,7 @@ import static com.ferg.awfulapp.constants.Constants.DEBUG;
  * JavaScript on the page. By default this uses a {@link LoggingWebChromeClient} to add
  * some debug logging, and the default {@link android.webkit.WebViewClient}. You should
  * call {@link #onPause()} and {@link #onResume()} to handle those lifecycle events.
- *
+ * <p>
  * You can run arbitrary JavaScript code with the {@link #runJavascript(String)} method, or invoke
  * the thread JavaScript's own loadPageHtml function with {@link #refreshPageContents(boolean)}.
  */
@@ -39,7 +36,9 @@ import static com.ferg.awfulapp.constants.Constants.DEBUG;
 public class AwfulWebView extends WebView {
 
     public static final String TAG = "AwfulWebView";
-    /** thread.js uses this identifier to communicate with any handler we add */
+    /**
+     * thread.js uses this identifier to communicate with any handler we add
+     */
     private static final String HANDLER_NAME_IN_JAVASCRIPT = "listener";
 
     public AwfulWebView(Context context) {
@@ -57,7 +56,6 @@ public class AwfulWebView extends WebView {
         init();
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     public AwfulWebView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
         init();
@@ -71,6 +69,7 @@ public class AwfulWebView extends WebView {
         AwfulPreferences prefs = AwfulPreferences.getInstance();
         WebSettings webSettings = getSettings();
         setWebChromeClient(new LoggingWebChromeClient());
+        setKeepScreenOn(false); // explicitly setting this since some people are complaining the screen stays on until they toggle it on and off
 
         setBackgroundColor(Color.TRANSPARENT);
         setScrollBarStyle(WebView.SCROLLBARS_OUTSIDE_OVERLAY);
@@ -81,17 +80,14 @@ public class AwfulWebView extends WebView {
         webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
 
         if (DEBUG) {
-            //noinspection AndroidLintNewApi
             WebView.setWebContentsDebuggingEnabled(true);
         }
 
         if (prefs.inlineWebm || prefs.inlineVines) {
-            //noinspection AndroidLintNewApi
             webSettings.setMediaPlaybackRequiresUserGesture(false);
         }
 
         if (prefs.inlineTweets) {
-            //noinspection AndroidLintNewApi
             webSettings.setAllowUniversalAccessFromFileURLs(true);
             webSettings.setAllowFileAccess(true);
             webSettings.setAllowContentAccess(true);
@@ -145,6 +141,7 @@ public class AwfulWebView extends WebView {
 
     /**
      * Helper function to execute some jabbascript in the webview.
+     *
      * @param javascript the code to run
      */
     public void runJavascript(@NonNull String javascript) {
@@ -154,7 +151,7 @@ public class AwfulWebView extends WebView {
 
     /**
      * Calls the javascript function that updates some page content from its source.
-     *
+     * <p>
      * This calls the #loadPageHtml function in <i>thread.js</i>, which in turn calls #getBodyHtml
      * on the handler passed to {@link #setJavascriptHandler(WebViewJsInterface)}, and inserts the
      * results into a container on the page.


### PR DESCRIPTION
Some people are reporting that the screen stays on in the thread view, like the
'keep screen on' menu option is selected (which is isn't), and they have to
toggle the option on and off again every time they start the app.

I can't replicate this problem, and it seems like it shouldn't happen anyway
(the flag is initialised to 'off' and requires the user to select the menu
option to change it), so I'm assuming it's a WebView issue. I've just made the
init code always explicitly set that behaviour to off when the WebView is first
created. Hopefully that's it!

Also removed some old API lint annotations