### PR TITLE
Fix launcher icon navigating the open app back to the forum index

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.kt
@@ -311,6 +311,7 @@ abstract class AwfulActivity : AppCompatActivity(), AwfulPreferences.AwfulPrefer
 sealed class NavigationEvent {
 
     object ReAuthenticate : NavigationEvent()
+    object MainActivity: NavigationEvent()
     object Bookmarks : NavigationEvent()
     object ForumIndex : NavigationEvent()
     data class Thread(val id: Int, val page: Int? = null, val postJump: String? = null) :
@@ -346,7 +347,7 @@ sealed class NavigationEvent {
         private const val TYPE_RE_AUTHENTICATE = "re-auth"
 
         /**
-         * Parse an intent as one of the navigation events we handle. Defaults to [ForumIndex]
+         * Parse an intent as one of the navigation events we handle. Defaults to [MainActivity]
          */
         fun Intent.parse(): NavigationEvent {
             parseUrl()?.let { return it }
@@ -366,7 +367,7 @@ sealed class NavigationEvent {
                         id = getIntExtra(FORUM_ID)!!,
                         page = getIntExtra(FORUM_PAGE)
                     )
-                else -> ForumIndex
+                else -> MainActivity
             }
         }
 


### PR DESCRIPTION
NavigationEvent is treating the intent that the launcher sends when
opening the app as a "show the forum index" event. This means that when
the app is already open, tapping the icon in the launcher will resume
the app as normal in its saved state, but it will move the viewpager to
the forums index too.

This is happening because "show the forum index" is the default
NavigationEvent, so I've changed that to a new MainActivity event which
just means "show ForumsIndexActivity". If it's already created, it'll
just display in its current state without moving to a particular page.
If it needs to be created (e.g. on a cold open) the viewpager will
default to showing the forums index anyway.

NavigationEvent needs implementing fully anyway - probably best to have
the parsing function return null if a particular Intent isn't recognised
(i.e. no default) and define every event's Intent signature explicitly