### PR TITLE
Revert support library to 27.0.2 to avoid a breaking change

### DIFF
--- a/Awful.apk/build.gradle
+++ b/Awful.apk/build.gradle
@@ -118,8 +118,9 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support:design:27.1.1'
+    // held back to fix Issue #616 - breaking Loader change introduced in 27.1.0
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:design:27.0.2'
 
     // used to fix SSL issues on older devices
     implementation 'com.google.android.gms:play-services-auth:15.0.1'


### PR DESCRIPTION
See Issue #616
They changed the behaviour of Loaders, including forcing them to reload
when a fragment or activity hits #onStart
Changes:
https://developer.android.com/topic/libraries/support-library/revisions#27-1-0
Intended behavior / WONTFIX:
https://issuetracker.google.com/issues/74278849

This makes the thread page reload every time the user switches away from
the app, or visits a link and returns, turns the screen off... page
loading isn't designed to handle this, and if it was initially loaded
with a post to jump to (either a post ID fragment or "jump to last read")
it'll jump back there again, every time. It makes catching up with a
thread a really bad experience

A real fix would require an overhaul - I can't see any reliable way to
block these specific reloads and not others (e.g. recreating a fragment)
without a lot of additional complexity. Vetoing the scroll behaviour
would require keeping track of when a post jump has been "consumed" so
it doesn't happen more than once, but it also needs to be able to identify
a "new" load - if the user hits a "jump to post" link that scrolls
somewhere in the same page, and then scrolls down, you don't want it to
scroll back if they navigate away and back to the app. But if they scroll
to the jump link again and hit it, the scroll needs to happen this time

Scrolling in the WebView needs fixing in general - right now there's no
way to get and restore the current scroll position, so we can't really
recreate fragment state