### PR TITLE
Enable fullscreen videos in the WebView

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -386,7 +386,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 			return;
 		}
 		mThreadView.setWebViewClient(threadWebViewClient);
-		mThreadView.setWebChromeClient(new LoggingWebChromeClient() {
+		mThreadView.setWebChromeClient(new LoggingWebChromeClient(mThreadView) {
                 @Override
                 public void onProgressChanged(WebView view, int newProgress) {
                     super.onProgressChanged(view, newProgress);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -68,7 +68,7 @@ public class AwfulWebView extends WebView {
     private void init() {
         AwfulPreferences prefs = AwfulPreferences.getInstance();
         WebSettings webSettings = getSettings();
-        setWebChromeClient(new LoggingWebChromeClient());
+        setWebChromeClient(new LoggingWebChromeClient(this));
         setKeepScreenOn(false); // explicitly setting this since some people are complaining the screen stays on until they toggle it on and off
 
         setBackgroundColor(Color.TRANSPARENT);


### PR DESCRIPTION
Creates a fullscreen dialog and sets the view passed by the webview as
the dialog's contents. This sets the system UI flags to the standard
fullscreen/immersive-sticky setup, and resets them when the activity
regains focus.

There are a couple of issues - one is that the fullscreen dialog is
sometimes blank, but the content is there and you can still interact
with it - you just can't see it. Swiping on the screen makes it appear.
The main issue is that the navigation and status bars remain hidden
after the UI flags are reset, until the userdoes something to bring them
back (poking those areas, flipping the viewpager, rotating the screen
etc).

I've added a handler and a runnable to post to it that forces the
"show UI" flags on a delay, but the delay doesn't seem to make any
difference to when the flag is applied. It doesn't work without setting
the flag, but it can take effect and the UI can pop back in at any time,
before the runnable itself is executed. It Is A Mystery!

So sometimes it behaves and the layout has space ready for the UI to
neatly slide back in, and sometimes the UI appears over the layout and
it redraws and looks janky. I've tried a lot and it seems like you can
either have this inconsistent behaviour, or leave the UI hidden until
the user does something to bring it back.