### PR TITLE
Fix loader behaviour with new Support Libraries

### DIFF
--- a/Awful.apk/build.gradle
+++ b/Awful.apk/build.gradle
@@ -119,8 +119,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
 
     // held back to fix Issue #616 - breaking Loader change introduced in 27.1.0
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
 
     // used to fix SSL issues on older devices
     implementation 'com.google.android.gms:play-services-auth:15.0.1'

--- a/Awful.apk/src/main/assets/javascript/thread.js
+++ b/Awful.apk/src/main/assets/javascript/thread.js
@@ -99,7 +99,9 @@ function findInPath(event, cssClass, returnElement) {
  * Loads the thread html into the container
  * @param {Boolean} checkFirst If true checks whether the webview has actually already been initialized
  */
-function loadPageHtml(checkFirst) {
+function loadPageHtml(html, checkFirst) {
+// TODO: what is this even for? only load if the webview hasn't been set up with its container html? why?
+// in what situation would you want to show a page if it's currently blank, but not bother updating whatever's currently there?
 	if (checkFirst !== undefined && document.getElementById('container').innerHTML != '') {
 		return;
 	}

--- a/Awful.apk/src/main/assets/javascript/thread.js
+++ b/Awful.apk/src/main/assets/javascript/thread.js
@@ -96,15 +96,9 @@ function findInPath(event, cssClass, returnElement) {
 }
 
 /**
- * Loads the thread html into the container
- * @param {Boolean} checkFirst If true checks whether the webview has actually already been initialized
+ * Loads the current thread html into the body container
  */
-function loadPageHtml(html, checkFirst) {
-// TODO: what is this even for? only load if the webview hasn't been set up with its container html? why?
-// in what situation would you want to show a page if it's currently blank, but not bother updating whatever's currently there?
-	if (checkFirst !== undefined && document.getElementById('container').innerHTML != '') {
-		return;
-	}
+function loadPageHtml() {
 	if (window.topScrollID) {
 		window.clearTimeout(window.topScrollID);
 	}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
@@ -47,7 +47,6 @@ public class PreviewFragment extends AwfulDialogFragment {
 
     private AwfulWebView postPreView;
     private ProgressBar progressBar;
-    protected String nicefiedContent = "";
 
     HashMap<String, String> preferences;
     WebViewJsInterface jsInterface = new WebViewJsInterface();
@@ -78,10 +77,10 @@ public class PreviewFragment extends AwfulDialogFragment {
     protected void setContent(String content) {
         jsInterface.updatePreferences();
 
-        nicefiedContent = "<style>iframe{height: auto !important;} </style><article><section class='postcontent'>" + content + "</section></article>";
+        String wrappedContent = "<style>iframe{height: auto !important;} </style><article><section class='postcontent'>" + content + "</section></article>";
         progressBar.setVisibility(View.GONE);
         postPreView.setVisibility(View.VISIBLE);
-        postPreView.setBodyHtml(nicefiedContent);
+        postPreView.setBodyHtml(wrappedContent);
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/PreviewFragment.java
@@ -32,7 +32,6 @@ import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.webkit.JavascriptInterface;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -45,19 +44,13 @@ import com.ferg.awfulapp.webview.WebViewJsInterface;
 import java.util.HashMap;
 
 public class PreviewFragment extends AwfulDialogFragment {
-    private final static String TAG = "PreviewFragment";
 
     private AwfulWebView postPreView;
     private ProgressBar progressBar;
     protected String nicefiedContent = "";
 
     HashMap<String, String> preferences;
-    WebViewJsInterface jsInterface = new WebViewJsInterface() {
-        @JavascriptInterface
-        public String getBodyHtml() {
-            return nicefiedContent;
-        }
-    };
+    WebViewJsInterface jsInterface = new WebViewJsInterface();
 
     @Override
     public void onActivityCreated(Bundle aSavedState) {
@@ -67,8 +60,8 @@ public class PreviewFragment extends AwfulDialogFragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View dialogView = inflateView(R.layout.post_preview, container, inflater);
-        progressBar = (ProgressBar) dialogView.findViewById(R.id.preview_progress);
-        postPreView = (AwfulWebView) dialogView.findViewById(R.id.post_pre_view);
+        progressBar = dialogView.findViewById(R.id.preview_progress);
+        postPreView = dialogView.findViewById(R.id.post_pre_view);
         configureWebView();
 
         getDialog().setCanceledOnTouchOutside(true);
@@ -88,7 +81,7 @@ public class PreviewFragment extends AwfulDialogFragment {
         nicefiedContent = "<style>iframe{height: auto !important;} </style><article><section class='postcontent'>" + content + "</section></article>";
         progressBar.setVisibility(View.GONE);
         postPreView.setVisibility(View.VISIBLE);
-        postPreView.refreshPageContents(true);
+        postPreView.setBodyHtml(nicefiedContent);
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -342,7 +342,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 		public void onPageFinished(WebView view, String url) {
 			setProgress(100);
 			if (mThreadView != null && bodyHtml != null && !bodyHtml.isEmpty()) {
-				mThreadView.refreshPageContents(true);
+				mThreadView.setBodyHtml(bodyHtml);
 			}
 		}
 
@@ -424,7 +424,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
         super.onResume();
 		if(mThreadView != null){
 			mThreadView.onResume();
-			mThreadView.refreshPageContents(false);
+			mThreadView.setBodyHtml(bodyHtml);
 		}
         getActivity().getContentResolver().registerContentObserver(AwfulThread.CONTENT_URI, true, mThreadObserver);
         refreshInfo();
@@ -1038,7 +1038,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
             String html = ThreadDisplay.getHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPageNumber(), mLastPage);
             refreshSessionCookie();
             bodyHtml = html;
-			mThreadView.refreshPageContents(true);
+			mThreadView.setBodyHtml(html);
             setProgress(100);
         } catch (Exception e) {
             // If we've already left the activity the webview may still be working to populate,
@@ -1083,11 +1083,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 			// TODO: 23/01/2017 add methods so you can't mess with the map directly
 			preferences.put("postjumpid", postJump);
 			preferences.put("scrollPosition", Integer.toString(savedScrollPosition));
-		}
-
-		@JavascriptInterface
-		public String getBodyHtml(){
-			return bodyHtml;
 		}
 
 		@JavascriptInterface
@@ -1407,7 +1402,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 	private void showBlankPage() {
 		bodyHtml = "";
 		if(mThreadView != null){
-			mThreadView.refreshPageContents(true);
+			mThreadView.setBodyHtml(bodyHtml);
 		}
 	}
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -198,7 +198,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 
 
 
-    private volatile String bodyHtml = "";
 	private final HashMap<String,String> ignorePostsHtml = new HashMap<>();
     private AsyncTask<Void, Void, String> redirect = null;
 	private Uri downloadLink;
@@ -338,14 +337,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 
 
 	private WebViewClient threadWebViewClient = new WebViewClient() {
-		@Override
-		public void onPageFinished(WebView view, String url) {
-			setProgress(100);
-			if (mThreadView != null && bodyHtml != null && !bodyHtml.isEmpty()) {
-				mThreadView.setBodyHtml(bodyHtml);
-			}
-		}
-
 
 		@Override
 		public boolean shouldOverrideUrlLoading(WebView aView, String aUrl) {
@@ -424,7 +415,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
         super.onResume();
 		if(mThreadView != null){
 			mThreadView.onResume();
-			mThreadView.setBodyHtml(bodyHtml);
 		}
         getActivity().getContentResolver().registerContentObserver(AwfulThread.CONTENT_URI, true, mThreadObserver);
         refreshInfo();
@@ -793,7 +783,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 			Timber.i("Syncing - reloading from site (thread %d, page %d) to update DB", getThreadId(), getPageNumber());
 			// cancel pending post loading requests
 			NetworkUtils.cancelRequests(PostRequest.REQUEST_TAG);
-        	bodyHtml = "";
 			// call this with cancelOnDestroy=false to retain the request's specific type tag
 			final int pageNumber = getPageNumber();
 			int userId = postFilterUserId == null ? BLANK_USER_ID : postFilterUserId;
@@ -1037,7 +1026,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
             Timber.d("populateThreadView: displaying %d posts", aPosts.size());
             String html = ThreadDisplay.getHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPageNumber(), mLastPage);
             refreshSessionCookie();
-            bodyHtml = html;
 			mThreadView.setBodyHtml(html);
             setProgress(100);
         } catch (Exception e) {
@@ -1400,9 +1388,8 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 	 * Clear the thread display, e.g. to show a blank page before loading new content
 	 */
 	private void showBlankPage() {
-		bodyHtml = "";
 		if(mThreadView != null){
-			mThreadView.setBodyHtml(bodyHtml);
+			mThreadView.setBodyHtml(null);
 		}
 	}
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
@@ -66,11 +66,6 @@ public class AnnouncementsFragment extends AwfulFragment {
 
     private void initialiseWebView() {
         webView.setJavascriptHandler(new WebViewJsInterface() {
-            // TODO: 27/01/2017 work out which of these we can drop, or maybe make special announcements HTML instead of reusing the thread one
-            @JavascriptInterface
-            public String getBodyHtml() {
-                return bodyHtml;
-            }
 
             @JavascriptInterface
             public String getCSS() {
@@ -104,7 +99,7 @@ public class AnnouncementsFragment extends AwfulFragment {
             @Override
             public void onPageFinished(WebView view, String url) {
                 if (webView != null && !bodyHtml.isEmpty()) {
-                    webView.refreshPageContents(true);
+                    webView.setBodyHtml(bodyHtml);
                 }
             }
 
@@ -149,7 +144,7 @@ public class AnnouncementsFragment extends AwfulFragment {
                             // we just want it to a) display ok, and b) not let the user click anything bad
                             bodyHtml = ThreadDisplay.getHtml(result, AwfulPreferences.getInstance(), 1, 1);
                             if (webView != null) {
-                                webView.refreshPageContents(true);
+                                webView.setBodyHtml(bodyHtml);
                             }
                             statusFrog.setVisibility(View.INVISIBLE);
                         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/announcements/AnnouncementsFragment.java
@@ -52,11 +52,9 @@ public class AnnouncementsFragment extends AwfulFragment {
     @BindView(R.id.status_frog)
     StatusFrog statusFrog;
 
-    private String bodyHtml = "";
-
     @NonNull
     @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflateView(R.layout.announcements_fragment, container, inflater);
         ButterKnife.bind(this, view);
 
@@ -96,13 +94,6 @@ public class AnnouncementsFragment extends AwfulFragment {
 
         });
         webView.setWebViewClient(new WebViewClient() {
-            @Override
-            public void onPageFinished(WebView view, String url) {
-                if (webView != null && !bodyHtml.isEmpty()) {
-                    webView.setBodyHtml(bodyHtml);
-                }
-            }
-
             // this lets links open back in the main activity if we handle them (e.g. 'look at this thread'),
             // and opens them in a browser or whatever if we don't (e.g. 'click here to buy a thing on the site')
             @Override
@@ -142,7 +133,7 @@ public class AnnouncementsFragment extends AwfulFragment {
                             webView.setVisibility(View.VISIBLE);
                             // these page params don't mean anything in the context of the announcement page
                             // we just want it to a) display ok, and b) not let the user click anything bad
-                            bodyHtml = ThreadDisplay.getHtml(result, AwfulPreferences.getInstance(), 1, 1);
+                            String bodyHtml = ThreadDisplay.getHtml(result, AwfulPreferences.getInstance(), 1, 1);
                             if (webView != null) {
                                 webView.setBodyHtml(bodyHtml);
                             }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -11,6 +11,8 @@ import android.webkit.WebView;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.AwfulPreferences;
 
+import timber.log.Timber;
+
 import static com.ferg.awfulapp.constants.Constants.DEBUG;
 
 /**
@@ -40,6 +42,9 @@ public class AwfulWebView extends WebView {
      * thread.js uses this identifier to communicate with any handler we add
      */
     private static final String HANDLER_NAME_IN_JAVASCRIPT = "listener";
+
+    @Nullable
+    private WebViewJsInterface jsInterface = null;
 
     public AwfulWebView(Context context) {
         super(context);
@@ -117,6 +122,7 @@ public class AwfulWebView extends WebView {
      * @param handler an object containing JavaScriptInterface methods to handle JS function calls
      */
     public void setJavascriptHandler(@NonNull WebViewJsInterface handler) {
+        jsInterface = handler;
         addJavascriptInterface(handler, HANDLER_NAME_IN_JAVASCRIPT);
     }
 
@@ -160,6 +166,18 @@ public class AwfulWebView extends WebView {
      */
     public void refreshPageContents(boolean force) {
         runJavascript(String.format("loadPageHtml(%s)", force ? "" : "true"));
+    }
+
+    public void setBodyHtml(@Nullable String html) {
+        // TODO: content comparison etc
+        // TODO: clean up bodyHtml state in calling classes (should be set and forget)
+        // TODO: update docstring in this class (call this not refresh)
+        if (jsInterface != null) {
+            jsInterface.setBodyHtml(html);
+            refreshPageContents(true);
+        } else {
+            Timber.w("Attempted to set html with no JS interface handler added");
+        }
     }
 
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -169,15 +169,18 @@ public class AwfulWebView extends WebView {
     }
 
     public void setBodyHtml(@Nullable String html) {
-        // TODO: content comparison etc
         // TODO: clean up bodyHtml state in calling classes (should be set and forget)
         // TODO: update docstring in this class (call this not refresh)
-        if (jsInterface != null) {
-            jsInterface.setBodyHtml(html);
-            refreshPageContents(true);
-        } else {
+        if (jsInterface == null) {
             Timber.w("Attempted to set html with no JS interface handler added");
+            return;
         }
+        if (html != null && html.hashCode() == jsInterface.getBodyHtml().hashCode()) {
+            Timber.d("New HTML appears to match the current HTML, not updating");
+            return;
+        }
+        jsInterface.setBodyHtml(html);
+        refreshPageContents(true);
     }
 
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -167,17 +167,16 @@ public class AwfulWebView extends WebView {
      * {@link #setBodyHtml(String)}. Calling this with unchanged HTML acts as a refresh, resetting
      * the displayed state of that page.
      *
-     * @param force if false the page will only update if it's currently blank.
      */
-    public void refreshPageContents(boolean force) {
-        runJavascript(String.format("loadPageHtml(%s)", force ? "" : "true"));
+    public void refreshPageContents() {
+        runJavascript("loadPageHtml()");
     }
 
 
     /**
      * Set and display the current HTML for the container body.
      * <p>
-     * Call this to update the WebView with new HTML content, calling {@link #refreshPageContents(boolean)}
+     * Call this to update the WebView with new HTML content, calling {@link #refreshPageContents()}
      * to display it. Does nothing if the passed HTML is unchanged from the currently added HTML,
      * or if {@link #setJavascriptHandler(WebViewJsInterface)} hasn't been called yet.
      */
@@ -191,7 +190,7 @@ public class AwfulWebView extends WebView {
             return;
         }
         jsInterface.setBodyHtml(html);
-        refreshPageContents(true);
+        refreshPageContents();
     }
 
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -31,8 +31,13 @@ import static com.ferg.awfulapp.constants.Constants.DEBUG;
  * some debug logging, and the default {@link android.webkit.WebViewClient}. You should
  * call {@link #onPause()} and {@link #onResume()} to handle those lifecycle events.
  * <p>
- * You can run arbitrary JavaScript code with the {@link #runJavascript(String)} method, or invoke
- * the thread JavaScript's own loadPageHtml function with {@link #refreshPageContents(boolean)}.
+ * Most of the time you'll want to use {@link #setContent(String)} to add the template from
+ * {@link com.ferg.awfulapp.thread.ThreadDisplay#getContainerHtml(AwfulPreferences, int)}, which
+ * loads the HTML, CSS and JS for displaying thread content, and then use {@link #setBodyHtml(String)}
+ * to add and display that content. {@link #setJavascriptHandler(WebViewJsInterface)} needs to be
+ * called, since the thread JS relies on it.
+ * <p>
+ * You can also run arbitrary JavaScript code with the {@link #runJavascript(String)} method.
  */
 
 public class AwfulWebView extends WebView {
@@ -156,11 +161,11 @@ public class AwfulWebView extends WebView {
 
 
     /**
-     * Calls the javascript function that updates some page content from its source.
+     * Calls the javascript function that displays the current body HTML
      * <p>
-     * This calls the #loadPageHtml function in <i>thread.js</i>, which in turn calls #getBodyHtml
-     * on the handler passed to {@link #setJavascriptHandler(WebViewJsInterface)}, and inserts the
-     * results into a container on the page.
+     * This calls the #loadPageHtml function in <i>thread.js</i>, which displays the HTML passed to
+     * {@link #setBodyHtml(String)}. Calling this with unchanged HTML acts as a refresh, resetting
+     * the displayed state of that page.
      *
      * @param force if false the page will only update if it's currently blank.
      */
@@ -168,9 +173,15 @@ public class AwfulWebView extends WebView {
         runJavascript(String.format("loadPageHtml(%s)", force ? "" : "true"));
     }
 
+
+    /**
+     * Set and display the current HTML for the container body.
+     * <p>
+     * Call this to update the WebView with new HTML content, calling {@link #refreshPageContents(boolean)}
+     * to display it. Does nothing if the passed HTML is unchanged from the currently added HTML,
+     * or if {@link #setJavascriptHandler(WebViewJsInterface)} hasn't been called yet.
+     */
     public void setBodyHtml(@Nullable String html) {
-        // TODO: clean up bodyHtml state in calling classes (should be set and forget)
-        // TODO: update docstring in this class (call this not refresh)
         if (jsInterface == null) {
             Timber.w("Attempted to set html with no JS interface handler added");
             return;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/WebViewJsInterface.java
@@ -1,5 +1,7 @@
 package com.ferg.awfulapp.webview;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 import android.util.Log;
 import android.webkit.JavascriptInterface;
@@ -26,8 +28,18 @@ public class WebViewJsInterface {
 
     private final Map<String, String> preferences = new ConcurrentHashMap<>();
 
+    @NonNull
+    private String bodyHtml = "";
+
+    @Nullable
+    private AwfulWebView webView = null;
+
     public WebViewJsInterface() {
         updatePreferences();
+    }
+
+    void setWebView(@NonNull AwfulWebView webView) {
+        this.webView = webView;
     }
 
     /**
@@ -64,6 +76,17 @@ public class WebViewJsInterface {
     protected void setCustomPreferences(Map<String, String> preferences) {
     }
 
+    // TODO: sync for threads? check html -> update html needs to be atomic?
+
+    @NonNull
+    @JavascriptInterface
+    public final String getBodyHtml() {
+        return bodyHtml;
+    }
+
+    final void setBodyHtml(@Nullable String html) {
+        bodyHtml = (html == null) ? "" : html;
+    }
 
     @JavascriptInterface
     public String getPreference(String preference) {


### PR DESCRIPTION
All right, this should get around the issue with the loaders triggering on resume, hopefully. I'll test it a bit more and see if anything comes up or anyone notices something bad!

It basically works by handing all the HTML state management over to the webview components, so the components that use it just say "here display this" when they want to show something. And with the webview storing that state, it can ignore a call to display the same thing by comparing them (just using the String hashcodes here).

So when the loader retriggers and does a "display this content!" call, the webview can see nothing's changed - and since the loader grabs data from the thread cache, it's not actually querying the site for an update, so even on a page with changes (like the last page of a thread) the app shouldn't update the display until the page content is actually reloaded. So it should be pretty stable

I wanted to add something like this anyway (I've got a rework that loads from the cache while firing off the network request, and does nothing if the resulting page is the same, so it feels really fast to go through cached pages) so it's cool if it works here

