### PR TITLE
Small fixes

### DIFF
--- a/Awful.apk/src/main/assets/javascript/thread.js
+++ b/Awful.apk/src/main/assets/javascript/thread.js
@@ -184,7 +184,7 @@ function scrollPost() {
 	var postjump = listener.getPostJump();
 	if (postjump !== '') {
 		try {
-			window.topScrollItem = document.getElementById('post' + postjump);
+			window.topScrollItem = document.getElementById(postjump);
 			window.topScrollPos = window.topScrollItem.getBoundingClientRect().top + document.body.scrollTop;
 			window.scrollTo(0, window.topScrollPos);
 			window.topScrollCount = 200;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/NavigationEvent.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/NavigationEvent.kt
@@ -207,9 +207,8 @@ sealed class NavigationEvent(private val extraTypeId: String) {
                 // TODO: can we spot null pages here? OR at least default ones?
                     isForum ->
                         Forum(id.toInt(), page.toInt())
-                // TODO: can we get the fragment?
                     isThread ->
-                        Thread(id.toInt(), page.toInt())
+                        Thread(id.toInt(), page.toInt(), fragment)
                     isForumIndex ->
                         ForumIndex
                     else -> null

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -530,7 +530,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
     public boolean onOptionsItemSelected(MenuItem item) {
         switch(item.getItemId()) {
 			case R.id.close:
-				toggleCloseThread();
+				showThreadOpenCloseDialog();
 				break;
 			case R.id.reply:
 				displayPostReplyDialog();
@@ -1001,6 +1001,23 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
     private void displayPostReplyDialog() {
         displayPostReplyDialog(getThreadId(), -1, AwfulMessage.TYPE_NEW_REPLY);
     }
+
+
+	/**
+	 * Show a dialog that allows the user to lock or unlock the current thread, as appropriate.
+	 */
+	private void showThreadOpenCloseDialog() {
+    	new AlertDialog.Builder(getActivity())
+				.setTitle((threadClosed ? "Reopen" : "Close") + " this thread?")
+				.setPositiveButton(R.string.alert_ok, (dialogInterface, i) -> toggleCloseThread())
+				.setNegativeButton(R.string.cancel, null)
+				.show();
+	}
+
+
+	/**
+	 * Trigger a request to toggle the current thread's locked/unlocked state.
+	 */
 	private void toggleCloseThread(){
 		queueRequest(new CloseOpenRequest(getActivity(), getThreadId()).build(mSelf, new AwfulRequest.AwfulResultCallback<Void>() {
 			@Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -910,7 +910,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
                 if (result.getType() == TYPE.THREAD) {
 					int threadId = (int) result.getId();
 					int threadPage = (int) result.getPage(getPrefs().postPerPage);
-					String postJump = result.getFragment().replaceAll("\\D", "");
+					String postJump = result.getFragment();
 					if (bypassBackStack) {
                         openThread(threadId, threadPage, postJump);
                     } else {
@@ -1069,8 +1069,9 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 		return postJump;
 	}
 
-	private void setPostJump(String postJump) {
-		this.postJump = postJump;
+	private void setPostJump(@NonNull String postJump) {
+		// TODO: this strips out any prefix (so it handles prefixed fragments AND bare IDs) and adds the required prefix to all. Might be better to handle this in AwfulURL?
+		this.postJump = "post" + postJump.replaceAll("\\D", "");
 	}
 
 	private class ClickInterface extends WebViewJsInterface {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
@@ -65,7 +65,7 @@ public class Constants {
     public static final String ACTION_ADDLIST 			  = "addlist";
     public static final String ACTION_QUERY 			  = "query";
     public static final String ACTION_RESULTS 			  = "results";
-    public static final String ACTION_OPEN_CLOSE_THREAD   = "openclosethread";
+    public static final String ACTION_TOGGLE_THREAD_LOCKED = "openclosethread";
     
     public static final String PARAM_USER_ID   = "userid";
     public static final String PARAM_USERNAME  = "username";

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadLockUnlockRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadLockUnlockRequest.java
@@ -8,9 +8,9 @@ import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
 
-public class CloseOpenRequest extends AwfulRequest<Void> {
+public class ThreadLockUnlockRequest extends AwfulRequest<Void> {
     private int threadId;
-    public CloseOpenRequest(Context context, int threadId) {
+    public ThreadLockUnlockRequest(Context context, int threadId) {
         super(context, Constants.FUNCTION_POSTINGS);
         this.threadId = threadId;
     }
@@ -19,7 +19,7 @@ public class CloseOpenRequest extends AwfulRequest<Void> {
     protected String generateUrl(Uri.Builder urlBuilder) {
         addPostParam(Constants.PARAM_THREAD_ID, Integer.toString(threadId));
 
-        urlBuilder.appendQueryParameter(Constants.PARAM_ACTION, Constants.ACTION_OPEN_CLOSE_THREAD);
+        urlBuilder.appendQueryParameter(Constants.PARAM_ACTION, Constants.ACTION_TOGGLE_THREAD_LOCKED);
         return urlBuilder.build().toString();
     }
 

--- a/Awful.apk/src/main/res/menu/post_menu.xml
+++ b/Awful.apk/src/main/res/menu/post_menu.xml
@@ -2,8 +2,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/close"
-        android:title="@string/thread_close"
+        android:id="@+id/lock_unlock"
+        android:title="@string/thread_lock"
         android:icon="@drawable/ic_https_dark"
         app:showAsAction="never"
         />

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -94,8 +94,8 @@
     <string name="find">Find on page</string>
     <string name="keep_screen_on">Keep screen on</string>
     <string name="yospos">YOSPOS</string>
-    <string name="thread_close">Close Thread</string>
-    <string name="thread_open">Reopen Thread</string>
+    <string name="thread_lock">Lock thread</string>
+    <string name="thread_unlock">Unlock thread</string>
 
     <string name="next_page">Next page</string>
     <string name="mark_last_read_progress">Marking Last-Read</string>


### PR DESCRIPTION
Just a couple of small issues from the app thread
- added a confirmation dialog for thread lock/unlock
- renamed references to opening or closing a thread as 'lock/unlock' instead, for clarity (since viewing a thread is called "opening" it too, people were even arguing over it)
- fixed ``showthread.php`` links so the post-jump fragments work - this mainly affects external links that open in the app (but some apps strip the url fragment, cheers)

I'll test this a bit more but I don't think there'll be any issues, they're small changes. Any probs with the renaming stuff @Sereri ?