### PR TITLE
Remove hard failures when probed

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewEditRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewEditRequest.java
@@ -54,6 +54,6 @@ public class PreviewEditRequest extends AwfulRequest<String> {
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
         Timber.e(error);
-        return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+        return error.isCritical();
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewPostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PreviewPostRequest.java
@@ -63,6 +63,6 @@ public class PreviewPostRequest extends AwfulRequest<String> {
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
         Timber.e(error);
-        return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+        return error.isCritical();
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/SearchForumsRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/SearchForumsRequest.java
@@ -2,10 +2,8 @@ package com.ferg.awfulapp.task;
 
 import android.content.Context;
 import android.net.Uri;
-import android.util.Log;
 
 import com.ferg.awfulapp.constants.Constants;
-import com.ferg.awfulapp.thread.AwfulSearch;
 import com.ferg.awfulapp.thread.AwfulSearchForum;
 import com.ferg.awfulapp.util.AwfulError;
 
@@ -33,6 +31,6 @@ public class SearchForumsRequest extends AwfulRequest<ArrayList<AwfulSearchForum
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+        return error.isCritical();
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/SearchRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/SearchRequest.java
@@ -1,26 +1,14 @@
 package com.ferg.awfulapp.task;
 
-import android.content.ContentValues;
 import android.content.Context;
 import android.net.Uri;
-import android.text.TextUtils;
-import android.util.Log;
-import android.widget.Toast;
 
 import com.ferg.awfulapp.constants.Constants;
-import com.ferg.awfulapp.network.NetworkUtils;
-import com.ferg.awfulapp.thread.AwfulMessage;
-import com.ferg.awfulapp.thread.AwfulPost;
 import com.ferg.awfulapp.thread.AwfulSearch;
 import com.ferg.awfulapp.thread.AwfulSearchResult;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
-
-import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Created by matt on 8/8/13.
@@ -52,6 +40,6 @@ public class SearchRequest extends AwfulRequest<AwfulSearchResult> {
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+        return error.isCritical();
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/SearchResultRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/SearchResultRequest.java
@@ -2,7 +2,6 @@ package com.ferg.awfulapp.task;
 
 import android.content.Context;
 import android.net.Uri;
-import android.util.Log;
 
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.thread.AwfulSearch;
@@ -42,6 +41,6 @@ public class SearchResultRequest extends AwfulRequest<ArrayList<AwfulSearch>> {
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+        return error.isCritical();
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/SendEditRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/SendEditRequest.java
@@ -56,6 +56,6 @@ public class SendEditRequest extends AwfulRequest<Void> {
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+        return error.isCritical();
     }
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/SendPostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/SendPostRequest.java
@@ -54,6 +54,6 @@ public class SendPostRequest extends AwfulRequest<Void> {
 
     @Override
     protected boolean handleError(AwfulError error, Document doc) {
-        return error.getErrorCode() == AwfulError.ERROR_PROBATION || error.isCritical();//Don't allow probation to pass
+        return error.isCritical();
     }
 }


### PR DESCRIPTION
I've removed the checks that cause response handlers to fail if the
user is on probation, because it stops pages from loading even when the
user should be able to use them.

For some reason, being on probation produces an AwfulError, even though
it's basically a state and not indicative of a site error etc. This is
recognised through an #isCritical check on AwfulError, which basically
whitelists PROBATION errors as being fine, and not something that should
halt response handling.

But then all the response handlers explicitly fail if #isCritical returns
true OR it's a probation. And I can't see any reason to do that, except
where probations actually block the user from using something, e.g.
composing a reply. And even then, it's better to handle it directly
instead of just letting the action fail