### PR TITLE
Add more performant AwfulRequest class to speed up page parsing

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
@@ -32,6 +32,8 @@ import com.ferg.awfulapp.BuildConfig;
 public class Constants {
     public static final boolean DEBUG = BuildConfig.DEBUG;
 
+    public static final String SITE_HTML_ENCODING = "CP1252";
+
     //public static final String BASE_URL = "http://forums.somethingawful.com";
     public static final String BASE_URL = "https://forums.somethingawful.com";
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulStrippedRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulStrippedRequest.java
@@ -1,0 +1,101 @@
+package com.ferg.awfulapp.task;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.android.volley.NetworkResponse;
+import com.ferg.awfulapp.util.AwfulError;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import timber.log.Timber;
+
+import static com.ferg.awfulapp.constants.Constants.BASE_URL;
+import static com.ferg.awfulapp.constants.Constants.SITE_HTML_ENCODING;
+
+/**
+ * Created by baka kaba on 11/11/2018.
+ *
+ * Wrapper class for AwfulRequests, allowing a request to receive and handle a response with the
+ * page selector elements stripped out (which can speed up HTML parsing considerably)
+ *
+ * Ideally this is just temporary until all the outstanding requests can be moved over to using it
+ */
+public abstract class AwfulStrippedRequest<T> extends AwfulRequest<T> {
+
+    public AwfulStrippedRequest(Context context, String apiUrl) {
+        super(context, apiUrl);
+    }
+
+    /**
+     * Handle the HTML document parsed from the response, which has had the page selector elements
+     * stripped out.
+     *
+     * Values for the currently selected and last page are passed in - usually this is the only
+     * information you'd need from the page selectors anyway. These may be null if the values
+     * couldn't be parsed, e.g. if the site's page structure changes
+     * @param doc the parsed HTML document, with the page selector elements removed
+     * @param currentPage the value for the current page, according to the page selector
+     * @param totalPages the value for the last page number, according to the page selector
+     */
+    abstract T handleStrippedResponse(Document doc, @Nullable Integer currentPage, @Nullable Integer totalPages) throws AwfulError;
+
+
+    // TODO: can/should this be done with the outer <div class="pages"> tag instead?
+    // matches a single page select block (usually 2 on a page)
+    private final static Pattern pageSelectorRegex = Pattern.compile("<select data-url=\"\\S*\\.php.*</select>");
+    // matches the "value" attribute of the <option> tag with a "selected" attribute
+    private final static Pattern selectedPageRegex = Pattern.compile("value=\"(\\d*)\"\\s*selected");
+    // matches the inner text of the last <option> tag (I can't safely get the contents of its "value" attr without the regex exploding over backtracking)
+    private final static Pattern lastPageRegex = Pattern.compile(">\\s*(\\d*)\\s*</option>\\s*</select>");
+
+    // data pulled after stripping unwanted elements from the source HTML in #parseAsHtml
+    @Nullable
+    private Integer selectedPage = null;
+    @Nullable
+    private Integer lastPage = null;
+
+    @Override
+    protected Document parseAsHtml(@NonNull NetworkResponse response) throws IOException {
+        // TODO: fall back to superclass implementation on error, set retry flag
+        long startTime = System.currentTimeMillis();
+        Timber.d("Stripping page selectors from HTML to speed up parsing");
+        // grab the data as a string, and match the select blocks
+        String data = new String(response.data, SITE_HTML_ENCODING);
+        Matcher pageSelectMatcher = pageSelectorRegex.matcher(data);
+
+        // try and pull out the useful data before we throw the blocks away
+        if (pageSelectMatcher.find()) {
+            // separate matchers so one can fail without breaking the other
+            Matcher selectedPageMatcher = selectedPageRegex.matcher(pageSelectMatcher.group());
+            Matcher lastPageMatcher = lastPageRegex.matcher(pageSelectMatcher.group());
+            if (selectedPageMatcher.find()) {
+                try { selectedPage = Integer.parseInt(selectedPageMatcher.group(1)); }
+                catch (NumberFormatException e) { }
+            }
+            if (lastPageMatcher.find()) {
+                try { lastPage = Integer.parseInt(lastPageMatcher.group(1)); }
+                catch (NumberFormatException e) { }
+            }
+        }
+
+        // now dump the select blocks and parse what's left
+        String smaller = pageSelectMatcher.replaceAll("");
+        Timber.d("Garbage stripped (took " + (System.currentTimeMillis() - startTime) + "ms) - starting Jsoup parse");
+        long jsoupParseStart = System.currentTimeMillis();
+        Document doc = Jsoup.parse(smaller, BASE_URL);
+        Timber.d("Jsoup parsing finished (took " + (System.currentTimeMillis() - jsoupParseStart) + "ms)");
+        return doc;
+    }
+
+    @Override
+    protected T handleResponseDocument(@NonNull Document document) throws AwfulError {
+        return handleStrippedResponse(document, selectedPage, lastPage);
+    }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/LepersColonyRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/LepersColonyRequest.kt
@@ -3,6 +3,7 @@ package com.ferg.awfulapp.task
 import android.content.Context
 import android.net.Uri
 import com.ferg.awfulapp.constants.Constants
+import com.ferg.awfulapp.task.LepersColonyRequest.LepersColonyPage
 import com.ferg.awfulapp.users.LepersColonyFragment.Companion.FIRST_PAGE
 import com.ferg.awfulapp.users.Punishment
 import com.ferg.awfulapp.util.AwfulError
@@ -15,7 +16,7 @@ import org.jsoup.nodes.Document
  */
 
 class LepersColonyRequest(context: Context, val page: Int = 1, val userId: String? = null):
-        AwfulRequest<LepersColonyRequest.LepersColonyPage>(context, Constants.FUNCTION_BANLIST) {
+        AwfulStrippedRequest<LepersColonyPage>(context, Constants.FUNCTION_BANLIST) {
 
     // allow queued requests to be cancelled when a new one starts, e.g. skipping quickly through pages
     companion object {
@@ -45,6 +46,13 @@ class LepersColonyRequest(context: Context, val page: Int = 1, val userId: Strin
             val punishments = select("table.standard.full tr").drop(1).map(Punishment.Companion::parse)
             return LepersColonyPage(punishments, thisPage, lastPage, userId)
         }
+    }
+
+    override fun handleStrippedResponse(doc: Document, currentPage: Int?, lastPage: Int?): LepersColonyPage {
+        val thisPage = currentPage ?: FIRST_PAGE
+        val totalPages = lastPage ?: thisPage
+        val punishments = doc.select("table.standard.full tr").drop(1).map(Punishment.Companion::parse)
+        return LepersColonyPage(punishments, thisPage, totalPages, userId)
     }
 
     override fun handleError(error: AwfulError?, doc: Document?) = true

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/PostRequest.java
@@ -7,12 +7,13 @@ import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.thread.AwfulThread;
 import com.ferg.awfulapp.util.AwfulError;
 
+import org.jetbrains.annotations.Nullable;
 import org.jsoup.nodes.Document;
 
 /**
  * Created by matt on 8/7/13.
  */
-public class PostRequest extends AwfulRequest<Integer> {
+public class PostRequest extends AwfulStrippedRequest<Integer> {
 
     public static final Object REQUEST_TAG = new Object();
 
@@ -44,8 +45,16 @@ public class PostRequest extends AwfulRequest<Integer> {
 
     @Override
     protected Integer handleResponse(Document doc) throws AwfulError {
-        AwfulThread.parseThreadPage(getContentResolver(), doc, threadId, page, getPreferences().postPerPage, getPreferences(), userId);
+        AwfulThread.parseThreadPage(getContentResolver(), doc, threadId, page, -1, getPreferences().postPerPage, getPreferences(), userId);
         return page;
+    }
+
+    @Override
+    public Integer handleStrippedResponse(Document doc, @Nullable Integer currentPage, @Nullable Integer totalPages) {
+        // TODO: this is all kinda janky, best to use the passed data from the response, right? Instead of relying on 'page' from the request
+        int lastPage = totalPages != null ? totalPages : page;
+        AwfulThread.parseThreadPage(getContentResolver(), doc, threadId, page, lastPage, getPreferences().postPerPage, getPreferences(), userId);
+        return null;
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ThreadListRequest.java
@@ -2,11 +2,13 @@ package com.ferg.awfulapp.task;
 
 import android.content.Context;
 import android.net.Uri;
+import android.support.annotation.Nullable;
 
 import com.ferg.awfulapp.announcements.AnnouncementsManager;
 import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.messages.PmManager;
 import com.ferg.awfulapp.thread.AwfulForum;
+import com.ferg.awfulapp.thread.AwfulPagedItem;
 import com.ferg.awfulapp.util.AwfulError;
 
 import org.jsoup.nodes.Document;
@@ -14,11 +16,12 @@ import org.jsoup.nodes.Document;
 /**
  * Created by matt on 8/7/13.
  */
-public class ThreadListRequest extends AwfulRequest<Void> {
+public class ThreadListRequest extends AwfulStrippedRequest<Void> {
 
     public static final Object REQUEST_TAG = new Object();
 
     private int forumId, page;
+
     public ThreadListRequest(Context context, int forumId, int page) {
         // TODO: 19/09/2016 decide whether to handle all USERCP requests as bookmark urls (and do the PmManager calls a different way)
         // I'm so sorry, thanks for forcing me to do this JAVA
@@ -38,7 +41,7 @@ public class ThreadListRequest extends AwfulRequest<Void> {
 
     @Override
     protected String generateUrl(Uri.Builder urlBuilder) {
-        if(forumId != Constants.USERCP_ID){
+        if (forumId != Constants.USERCP_ID) {
             urlBuilder.appendQueryParameter(Constants.PARAM_FORUM_ID, Integer.toString(forumId));
         }
         urlBuilder.appendQueryParameter(Constants.PARAM_PAGE, Integer.toString(page));
@@ -47,12 +50,22 @@ public class ThreadListRequest extends AwfulRequest<Void> {
 
     @Override
     protected Void handleResponse(Document doc) throws AwfulError {
+        int lastPage = AwfulPagedItem.parseLastPage(doc);
+        handleStrippedResponse(doc, page, lastPage);
+        return null;
+    }
+
+    @Override
+    Void handleStrippedResponse(Document doc, @Nullable Integer currentPage, @Nullable Integer totalPages) throws AwfulError {
+        int thisPage = (currentPage == null) ? page : currentPage;
+        int lastPage = (totalPages == null) ? thisPage : totalPages;
+        // TODO: legacy try/catch - work out what this is meant to be catching exactly, and if we can ditch it
         try {
-            if(forumId == Constants.USERCP_ID){
-                AwfulForum.parseUCPThreads(doc, page, getContentResolver());
+            if (forumId == Constants.USERCP_ID) {
+                AwfulForum.parseUCPThreads(doc, page, lastPage, getContentResolver());
                 PmManager.parseUcpPage(doc);
-            }else{
-                AwfulForum.parseThreads(doc, forumId, page, getContentResolver());
+            } else {
+                AwfulForum.parseThreads(forumId, page, lastPage, doc, getContentResolver());
                 AnnouncementsManager.getInstance().parseForumPage(doc);
             }
         } catch (Exception e) {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulForum.java
@@ -93,32 +93,31 @@ public class AwfulForum extends AwfulPagedItem {
 
 	/**
 	 * Parse a forum page, storing the thread list and updating the threads in the database.
-	 *
-	 * @param page             a forum page containing a list of threads
 	 * @param forumId          the ID of the forum being parsed
 	 * @param pageNumber       the number of the page being parsed, e.g. page 2 of GBS
+	 * @param lastPageNumber
+	 * @param page             a forum page containing a list of threads
 	 * @param contentInterface used for database access
 	 */
-	public static void parseThreads(Document page, int forumId, int pageNumber, ContentResolver contentInterface) {
+	public static void parseThreads(int forumId, int pageNumber, int lastPageNumber, Document page, ContentResolver contentInterface) {
 		// get the threads on a (normal) forum page, index them and store
 		List<ContentValues> threads = AwfulThread.parseForumThreads(page, forumId, forumPageToIndex(pageNumber));
 		deletePageOfThreads(forumId, pageNumber, contentInterface);
 		insertThreads(threads, contentInterface);
 
 		// update page count for forum
-		int lastPage = parseLastPage(page);
-		ForumRepository.getInstance(null).setPageCount(forumId, lastPage);
+		ForumRepository.getInstance(null).setPageCount(forumId, lastPageNumber);
 	}
 
 
 	/**
 	 * Parse a Bookmarks page, storing the thread list and updating the threads in the database.
-	 *
-	 * @param page             a page containing the user's bookmarks
+	 *  @param page             a page containing the user's bookmarks
 	 * @param pageNumber       the number of the page being parsed, e.g. page 2 of the bookmarks
+	 * @param lastPageNumber
 	 * @param contentInterface used for database access
 	 */
-	public static void parseUCPThreads(@NonNull Document page, int pageNumber, @NonNull ContentResolver contentInterface) {
+	public static void parseUCPThreads(@NonNull Document page, int pageNumber, int lastPageNumber, @NonNull ContentResolver contentInterface) {
 		// get all the threads on the bookmarks page, with their INDEXes set appropriately, and store them
 		List<ContentValues> threads = AwfulThread.parseForumThreads(page, Constants.USERCP_ID, forumPageToIndex(pageNumber));
 		insertThreads(threads, contentInterface);
@@ -142,7 +141,7 @@ public class AwfulForum extends AwfulPagedItem {
 		deletePageOfBookmarks(pageNumber, contentInterface);
 		insertBookmarks(bookmarks, contentInterface);
 		// update bookmarks forum
-		ForumRepository.getInstance(null).setPageCount(Constants.USERCP_ID, parseLastPage(page));
+		ForumRepository.getInstance(null).setPageCount(Constants.USERCP_ID, lastPageNumber);
 	}
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -257,16 +257,16 @@ public class AwfulThread extends AwfulPagedItem  {
      * <p>
      * Also stores/updates the rest of the thread metadata - title, locked status etc., and passes
      * the page to {@link AwfulPost} for parsing and syncing.
-     *
-     * @param resolver     a ContentResolver used to access the database
+     *  @param resolver     a ContentResolver used to access the database
      * @param page         the thread page's HTML document
      * @param threadId     the ID of this thread
      * @param pageNumber   which page of the thread this document represents
+     * @param lastPageNumber the number of the last page in this thread
      * @param postsPerPage used to calculate post counts
      * @param prefs        a preferences instance
      * @param filterUserId if this page is for a thread filtered by user, this should be set to the user's ID, otherwise 0
      */
-    public static void parseThreadPage(ContentResolver resolver, Document page, int threadId, int pageNumber, int postsPerPage, AwfulPreferences prefs, int filterUserId) {
+    public static void parseThreadPage(ContentResolver resolver, Document page, int threadId, int pageNumber, int lastPageNumber, int postsPerPage, AwfulPreferences prefs, int filterUserId) {
         long startTime = System.currentTimeMillis();
         // TODO: 03/06/2017 see issue #503 on GitHub - filtering by user means the thread data gets overwritten by the pages from this new, shorter thread containing their posts
         final int BLANK_USER_ID = 0;
@@ -274,7 +274,7 @@ public class AwfulThread extends AwfulPagedItem  {
         final boolean filteringOnUserId = filterUserId > BLANK_USER_ID;
 
         // finally write new thread data to the database
-        ContentValues cv = new ThreadPageParseTask(resolver, page, threadId, pageNumber, postsPerPage, prefs).call();
+        ContentValues cv = new ThreadPageParseTask(resolver, page, threadId, pageNumber, lastPageNumber, postsPerPage, prefs).call();
         // TODO: 04/06/2017 this should be handled in the database-management classes
         String update_time = new Timestamp(startTime).toString();
         cv.put(DatabaseHelper.UPDATED_TIMESTAMP, update_time);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -326,12 +326,13 @@ class ForumParseTask(
  * @returns new or updated data for this thread, represented as a ContentValues (see [AwfulThread])
  */
 class ThreadPageParseTask(
-    private val resolver: ContentResolver,
-    private val page: Document,
-    private val threadId: Int,
-    private val pageNumber: Int,
-    private val postsPerPage: Int,
-    private val prefs: AwfulPreferences
+        private val resolver: ContentResolver,
+        private val page: Document,
+        private val threadId: Int,
+        private val pageNumber: Int,
+        private val lastPageNumber: Int,
+        private val postsPerPage: Int,
+        private val prefs: AwfulPreferences
 ) : Callable<ContentValues> {
 
     companion object {
@@ -372,7 +373,6 @@ class ThreadPageParseTask(
 
 
             // now calculate some read/unread numbers based on what we can see on the page
-            val lastPageNumber = AwfulPagedItem.parseLastPage(page)
             val firstPostOnPageIndex = AwfulPagedItem.pageToIndex(pageNumber, postsPerPage, 0)
             val firstUnreadIndex = if (!hasBeenViewed) 0 else postCount - unreadCount
 


### PR DESCRIPTION
When a request's response is handled, AwfulRequest uses jsoup to parse
the page data into a HTML Document, which involves building a tree of
nodes representing all the elements on the page. But the pages are fairly
complex structurally, and a big problem is the page-picker dropdowns -
they have an <option> element for every page in the thread/forum etc.
When this is a large number (in the thousands) each page parse can take
a very long time, several seconds between receiving the network response
and handling the document.

This PR uses a regex to strip out the page selector elements before the
HTML is parsed, resulting in a ~10x speedup when there are a significant
number of pages.

It basically works by adding a new abstract subclass of AwfulRequest,
called AwfulStrippedRequest. If you build a concrete request class from
this, there's a new handler method called #handleStrippedResponse, which
passes in a Document as usual (but with the page selectors removed), as
well as the current and last page numbers parsed from the page selector
(since this is important information and probably the only reason you'd
want the page selectors present in the Document anyway)

Right now only 3 requests implement it - the forum, thread and Leper's
Colony requests, which are the places you're likely to see large page
counts. Ideally every request would use it, but that means you need to
be aware that you aren't getting the full forum page. But we could work
something out, with e.g. opt-in flags if you *need* the entire structure,
so there's only one AwfulRequest base class

fixes #643