### PR TITLE
Fix cleartext content in API 28+, use stricter mixed content policy

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -23,7 +23,9 @@
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher"
-        android:theme="@style/Theme.AwfulTheme.Launcher">
+        android:theme="@style/Theme.AwfulTheme.Launcher"
+        android:usesCleartextTraffic="true"
+        >
         <uses-library android:name="org.apache.http.legacy" android:required="false" />
 
         <!--

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -87,7 +87,7 @@ public class AwfulWebView extends WebView {
         webSettings.setDefaultFontSize(prefs.postFontSizeSp);
         webSettings.setDefaultFixedFontSize(prefs.postFixedFontSizeSp);
         webSettings.setDomStorageEnabled(true);
-        webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_ALWAYS_ALLOW);
+        webSettings.setMixedContentMode(WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE);
 
         if (DEBUG) {
             WebView.setWebContentsDebuggingEnabled(true);


### PR DESCRIPTION
HTTP content (rather than HTTPS) used to be the default in Android, but
in API 28 it's become opt-in instead of opt-out. I've explicitly allowed
it in the manifest.

I've also switched the WebView's MixedContentMode from ALWAYS_ALLOW to
COMPATIBILITY_MODE. The latter should still allow cleartext content that
people post, like images, while blocking any dodgier filetypes. It always
felt like a security hole leaving it on "allow anything", ideally this
will let the WebView people manage the security side without being
restrictive