### PR TITLE
Fix pull-to-refresh behaviour on non-full pages

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -187,6 +187,8 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
     private String mTitle = null;
 	private String postJump = "";
 	private int savedScrollPosition = 0;
+	/** Whether the currently displayed page represents a full page of posts */
+	private boolean displayingFullPage = false;
 	
 	private ShareActionProvider shareProvider;
 
@@ -1042,6 +1044,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
             String html = ThreadDisplay.getHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPageNumber(), mLastPage);
             refreshSessionCookie();
 			mThreadView.setBodyHtml(html);
+			displayingFullPage = aPosts.size() >= getPrefs().postPerPage; // shouldn't ever be > but just to be safe
             setProgress(100);
         } catch (Exception e) {
             // If we've already left the activity the webview may still be working to populate,
@@ -1053,9 +1056,13 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
     
 	@Override
 	public void onRefresh(SwipyRefreshLayoutDirection swipyRefreshLayoutDirection) {
-		if(swipyRefreshLayoutDirection == SwipyRefreshLayoutDirection.TOP){
+		if (swipyRefreshLayoutDirection == SwipyRefreshLayoutDirection.TOP) {
+			// no page turn when swiping at the top of the page
 			refresh();
-		}else{
+		} else if (!displayingFullPage) {
+			// always refresh if there could be more posts
+			refresh();
+		} else {
 			turnPage(true);
 		}
 	}


### PR DESCRIPTION
P2R now refreshes if the currently displayed page is not full
(according to the user's posts-per-page setting). This avoids a situation
where the thread data updates, in the background, and the current page is
no longer the last one - previously this would trigger a page turn,
assuming the current page's posts are all being displayed since it's not
the last page, which wasn't the case when the displayed contents were
generated.

fixes #675