### PR TITLE
Fix loading behaviour when displaying the currently open thread

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -1564,7 +1564,11 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 				deferNavigation(event);
 			} else {
 				NavigationEvent.Thread thread = (NavigationEvent.Thread) event;
-				openThread(thread.getId(), thread.getPage(), thread.getPostJump());
+				// if we're currently displaying this thread, and no page was specified (i.e. it's
+				// a "show this thread" navigation) then we don't need to do anything
+				if (thread.getId() != currentThreadId || thread.getPage() != null) {
+					openThread(thread.getId(), thread.getPage(), thread.getPostJump());
+				}
 			}
 			return true;
 		} else if (event instanceof NavigationEvent.Url) {
@@ -1590,18 +1594,13 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 
 	/**
 	 * Open a thread, jumping to a specific page and post if required.
-	 *  @param id        The thread's ID
+	 * @param id          The thread's ID
 	 * @param page        An optional page to display, otherwise it defaults to the first page
 	 * @param postJump    An optional URL fragment representing the post ID to jump to
 	 */
 	private void openThread(int id, @Nullable Integer page, @Nullable String postJump){
 		Timber.i("Opening thread (old/new) ID:%d/%d, PAGE:%s/%s, JUMP:%s/%s",
 				getThreadId(), id, getPageNumber(), page, getPostJump(), postJump);
-		if (id == currentThreadId && (page == null || page == currentPage)) {
-			// do nothing if there's no change
-			// TODO: 15/01/2018 handle a change in postJump though? Right now this reflects the old logic from ForumsIndexActivity
-			return;
-		}
 		clearBackStack();
 		int threadPage = (page == null) ? FIRST_PAGE : page;
     	loadThread(id, threadPage, postJump, true);


### PR DESCRIPTION
The last fix (ebb2d87) introduced an issue where #openThread would skip
the page load if the specified thread and page referred to the page
that was already being displayed. This was meant to allow the app to
navigate to the thread view without forcing a reload, but since thread
list entries open threads by specifying a thread ID and page, it wouldn't
reload to show new posts if that page was already open.

I've basically moved this check into #handleNavigation (since it's more
about navigating to the thread view and then deciding if anything else
needs to happen), and now #openThread always loads a page. I've reworked
the behaviour, so a NavigationEvent that only specifies a thread ID (and
no specific page number) will do nothing if that thread is what's
currently being displayed - meaning the NavigationEvent will effectively
just page to the ThreadDisplayFragment. If a different thread ID is
specified (or a certain page is requested) then a load will happen