### PR TITLE
Fix post menu CSS even better

### DIFF
--- a/Awful.apk/src/main/assets/css/amberpos.css
+++ b/Awful.apk/src/main/assets/css/amberpos.css
@@ -75,6 +75,10 @@ body {
     border-top: 2px solid #eacf4c;
 }
 
+
+/*
+    square dots for computers
+*/
 .postmenu:after {
     content: "\e901";
 }

--- a/Awful.apk/src/main/assets/css/classic.css
+++ b/Awful.apk/src/main/assets/css/classic.css
@@ -85,7 +85,14 @@ body {
     border: none;
 }
 
+/* compensating for the smaller padding in .postheader */
+.postmenu {
+    margin-top: -9px;
+}
+
+/*
+    square dots for... classic look?
+*/
 .postmenu:after {
     content: "\e901";
-    padding-right: 2px;
 }

--- a/Awful.apk/src/main/assets/css/general.css
+++ b/Awful.apk/src/main/assets/css/general.css
@@ -29,24 +29,40 @@
     padding: 15px 0px 5px;
 }
 
+
+/*
+    .postmenu acts as the touch target for the menu button (added with the :after pseudo-element)
+    it's positioned to align basically in the top-right corner, with some adjustments to the
+    margins so full-width themes line up the menu icon with the one in the toolbar (it looks
+    messy when they're just slightly unaligned)
+*/
+
 .postmenu {
-    font-weight: bolder;
-    font-size: 1.7em;
     width: 24px;
     height: 24px;
-    margin-right: 5px;
-    margin-top: -4px;
+    margin-right: 2px;
+    margin-top: -13px;
+    padding: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
+
+/*a
+    the :after element holds the ... menu glyph, but doesn't reliably handle onClick events - so
+    the main element above defines the touch area, and this sits in it. The font size is fixed
+    since it's an icon and shouldn't adjust based on the user's font size, and it sits in the
+    middle of the .postmenu element.
+*/
 .postmenu:after {
     font-family: 'icons' !important;
     content: "\e902";
     font-weight: normal;
+    font-size: 13pt; !important
     -webkit-font-smoothing: antialiased;
     -webkit-user-select: none;
     user-select: none;
-    padding: 4px;
-    display:block;
 }
 
 /*

--- a/Awful.apk/src/main/assets/css/oled.css
+++ b/Awful.apk/src/main/assets/css/oled.css
@@ -89,6 +89,11 @@ body {
     padding-right: 0;
 }
 
+/* compensating for the smaller padding in .postheader */
+.postmenu {
+    margin-top: -9px;
+}
+
 .postseparator {
     height: 1px;
     background-color: #e7e7e7;

--- a/Awful.apk/src/main/assets/css/yospos.css
+++ b/Awful.apk/src/main/assets/css/yospos.css
@@ -80,6 +80,9 @@ body {
     border-top: 2px solid #0F0;
 }
 
+/*
+    square dots for computers
+*/
 .postmenu:after {
     content: "\e901";
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -33,7 +33,7 @@ import static com.ferg.awfulapp.constants.Constants.DEBUG;
  * call {@link #onPause()} and {@link #onResume()} to handle those lifecycle events.
  * <p>
  * Most of the time you'll want to use {@link #setContent(String)} to add the template from
- * {@link AwfulHtmlPage#getContainerHtml(AwfulPreferences, int)}, which
+ * {@link AwfulHtmlPage#getContainerHtml(AwfulPreferences, Integer, boolean)}, which
  * loads the HTML, CSS and JS for displaying thread content, and then use {@link #setBodyHtml(String)}
  * to add and display that content. {@link #setJavascriptHandler(WebViewJsInterface)} needs to be
  * called, since the thread JS relies on it.


### PR DESCRIPTION
Some larger text settings would let the ... glyph expand to the point
where it pushed out of the defined touch area, making the page wider
and introducing a horizontal scrollbar.

I've made that glyph a fixed size since it's basically an icon and
shouldn't be changing with the page's font size anyway, and adjusted
the CSS to position it better and give it a 40px touch target, which
basically sits in the top right of the post header. It's not exactly
where it was aligned before, but it's in the right place for a 40px
button.

I set a font size that matches what I was already seeing with my current
(small) text size - it's smaller than the ... icon in the toolbar, which
I think looks better and clearer than matching it. I also tweaked the
margins slightly so that themes with full-width post headers (OLED and
Classic) have the post menu icon line up horizontally with the toolbar
one - before they were sliiiightly off and that looks pretty bad.
The other themes have a clear visual offset so they don't look like
the icons should align.

(if you do want to match the toolbar icon size, 18pt seems about right)