### PR TITLE
Set navigationBarColor for the base themes

### DIFF
--- a/Awful.apk/src/main/res/values/themes.xml
+++ b/Awful.apk/src/main/res/values/themes.xml
@@ -67,6 +67,7 @@
         <item name="awfulPopUpTheme">@style/ThemeOverlay.AppCompat.Light</item>
         <item name="windowActionModeOverlay">true</item>
 
+        <item name="android:navigationBarColor">?colorPrimaryDark</item>
     </style>
 
 
@@ -120,6 +121,7 @@
         <item name="awfulPopUpTheme">@style/ThemeOverlay.AppCompat</item>
         <item name="windowActionModeOverlay">true</item>
 
+        <item name="android:navigationBarColor">@android:color/black</item>
     </style>
 
     <!-- OLED-type themes -->


### PR DESCRIPTION
This fixes the navigation bar always being bright white, even in dark themes. At least on my new phone.

I think it also changes it from black to forums_blue_darker in the default theme for older phones. Wasn't sure whether to just have them both as black.