### PR TITLE
Fix stuck background colors on threads whose views were previously locked.

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -388,11 +388,6 @@ public class AwfulThread extends AwfulPagedItem  {
         ImageView threadSticky = item.findViewById(R.id.thread_sticky);
         threadSticky.setVisibility(thread.isSticky ? VISIBLE : GONE);
         threadLocked.setVisibility(thread.isLocked && !thread.isSticky ? VISIBLE : GONE);
-        if (thread.isLocked && !thread.isSticky) {
-            // TODO: 03/06/2017 what's this about?
-            item.setBackgroundColor(ColorProvider.BACKGROUND.getColor(forumId));
-        }
-
 
         // unread counter
         TextView unread = item.findViewById(R.id.unread_count);


### PR DESCRIPTION
Should resolve issue #665. As @Sereri noted on the forums,

> [...] the code was brought over from the old listview to the recyclerview. Where this would not have a problem in the former, the reuse of the viewholders leads to the threads keeping their colored stated even when reused.

Old code was likely meant to differentiate locked threads by using different background colors, but wasn't totally implemented. Now the lock icon should be enough :)