### PR TITLE
Export settings now retries when file access permissions are granted.

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:roundIcon="@mipmap/ic_launcher"
         android:theme="@style/Theme.AwfulTheme.Launcher"
         android:usesCleartextTraffic="true"
+        android:requestLegacyExternalStorage="true"
         >
         <uses-library android:name="org.apache.http.legacy" android:required="false" />
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/RootSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/RootSettings.java
@@ -100,7 +100,7 @@ public class RootSettings extends SettingsFragment {
             if (AwfulUtils.isMarshmallow()) {
                 int permissionCheck = ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
-                    getActivity().requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, Constants.AWFUL_PERMISSION_WRITE_EXTERNAL_STORAGE);
+                    requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, Constants.AWFUL_PERMISSION_WRITE_EXTERNAL_STORAGE);
                 } else {
                     exportSettings();
                 }


### PR DESCRIPTION
Should fix #705? On my machine/test device running Android 10, I needed to change `AndroidManifest.xml` to get the fix to work reliably from a clean install, but didn't discover that until I had already pushed the other change 🤦‍♀️ sorry!