### PR TITLE
Streamline building from scratch and update README.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ bin
 /libraries/tree-view-list-android/.hgtags
 /libraries/tree-view-list-android/.pmd
 
-
 /.idea/*
 !/.idea/codeStyleSettings.xml
 *.iml
@@ -42,7 +41,11 @@ bin
 tests
 out
 build/
-gradle/
+# Specifically keep gradle-wrapper.properties so projects can be built from an import.
+gradle/*
+!/gradle/wrapper/
+/gradle/wrapper/*
+!/gradle/wrapper/gradle-wrapper.properties
 
 # Secrets as resources
 **/*/res/values/secrets.xml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,51 @@
 # Awful
 
-An unofficial viewer for the SomethingAwful forums (http://forums.somethingawful.com).
+Awful is an unofficial viewer for the [SomethingAwful forums][forums] on Android platforms. Come check out the [Awful forum thread][forum-thread]!
 
-## Forum Thread
+<a href='https://play.google.com/store/apps/details?id=com.ferg.awfulapp'><img alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png' height='80px'/></a>
 
-http://forums.somethingawful.com/showthread.php?threadid=3571717
+## Contributing
+
+Want to help? Come join us in the [development and beta testing thread][dev-thread], and [join the beta testing program][join-beta].
+
+Or take a look at [our issues][issues] and set up your own fork to quash some bugs!
+
+### Build using Android Studio (recommended)
+
+1. Download and install [Android Studio][android-studio].
+    * __[After install, make sure to accept licenses for SDKs.][accept-licensing]__ From the welcome screen, choose the three-dot menu in the upper right-hand corner -> `SDK Manager` -> `SDK Tools` -> check `Google Play Licensing Library` -> click `Apply` -> click `OK`.
+2. [Fork Awful.apk on Github][github-fork-howto].
+3. Download your fork's Git repository and open the project in Android Studio.
+    * Quick way: from the welcome screen, choose `Get from VCS` and enter the Github URL for your new fork.
+4. Create your own `google-services.json`.
+    1. [Create your own Firebase project][firebase-console] for Awful.
+    2. Add an Android app to your Firebase project.
+    3. For Android package name, enter `com.ferg.awfulapp.debug`.
+    4. Download the `google-services.json` config file.
+    5. Place `google-services.json` in the inner `/Awful.apk/` folder.
+5. __(Optional)__ If you'd like to be able to upload images to Imgur:
+    1. [Register a new application for the Imgur API][imgur-api-docs].
+    2. Create the file [`secrets.xml`][secrets-example] in `/Awful.apk/src/main/res/values/`.
+    3. Place the client ID in `secrets.xml`, like so:
+```
+<?xml version=1.0 encoding="utf-8"?>
+<resources>
+    <string name="imgur_api_client_id">YOUR_CLIENT_ID</string>
+</resources>
+```
+6. `Build > Make Project` should run without any issues!
+
+Further questions or problems? Please let us know in the [dev thread][dev-thread].
+
+[forums]: https://forums.somethingawful.com
+[forum-thread]: https://forums.somethingawful.com/showthread.php?threadid=3571717
+[dev-thread]: https://forums.somethingawful.com/showthread.php?threadid=3743815
+[issues]: https://github.com/Awful/Awful.apk/issues?state=open
+[join-beta]: https://play.google.com/apps/testing/com.ferg.awfulapp
+
+[android-studio]: https://developer.android.com/studio
+[accept-licensing]: https://stackoverflow.com/a/69897480
+[github-fork-howto]: https://docs.github.com/en/get-started/quickstart/fork-a-repo
+[firebase-console]: https://console.firebase.google.com/
+[imgur-api-docs]: https://apidocs.imgur.com
+[secrets-example]: https://forums.somethingawful.com/showthread.php?threadid=3743815&userid=0&perpage=40&pagenumber=17#post505621360

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
I wrote the build instructions against a fresh install of Android Studio 2020.3.1 (Arctic Fox) on Windows 10 Professional.

I included `gradle-wrapper.properties` [on internet advice](https://stackoverflow.com/questions/21762180/should-you-include-or-ignore-gradle-wrapper-properties) because Gradle was failing with the error message `Minimum supported Gradle version is 7.0.2. Current version is 6.8.` I believe the version listed, 7.0.2, is appropriate for the [project's dependency of Gradle 7.0.4](https://github.com/Awful/Awful.apk/blob/402af0c08308a9a949098107c85bbe3819342765/Awful.apk/build.gradle#L10).

Hopefully these make sense!