### PR TITLE
Use Storage Access Framework for exporting settings.

### DIFF
--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -213,8 +213,6 @@
     <string name="alert_ok">@android:string/ok</string>
     <string name="alert_settings">Settings</string>
     <string name="no_file_permission_attachment">Well, you didn\'t allow Awful to access files, so it can\'t add the attachment you just selected. Good job.</string>
-    <string name="no_file_permission_settings_import">You know, you didn\'t allow Awful to access files, so it can\'t import the settings file you just selected. Well done.</string>
-    <string name="no_file_permission_settings_export">You didn\'t allow Awful to access files, so it can\'t export the settings file. Congratulations.</string>
     <string name="no_file_permission_download">Awful doesn\'t have permission to store the download. Welp, guess not then.</string>
     <string name="no_file_permission_theme">Can\'t access custom theme because Awful lacks storage permissions. Reverting to default css.</string>
     <string name="permission_rationale_external_storage">To show custom themes and layouts, Awful needs access to device storage</string>
@@ -333,6 +331,7 @@
     <string name="prefs_misc">Device and navigation</string>
     <string name="export_settings">Export settings</string>
     <string name="export_settings_summary">Save a backup of your Awful choices</string>
+    <string name="export_settings_chooser_title">Select export file</string>
     <string name="import_settings">Import settings</string>
     <string name="import_settings_summary">Restore your backed up settings</string>
     <string name="import_settings_chooser_title">Select settings file</string>


### PR DESCRIPTION
User has a file picker when exporting now, but it's an implicit grant of permissions so the export code is simpler. Also refactored the import process to not crash the app if a user imports a non-JSON file.

Tested in emulators running APIs 21, 25 and 31.