### PR TITLE
Support alternate avatars if primary avatar dimensions are 1x1.

### DIFF
--- a/Awful.apk/src/main/assets/javascript/thread.js
+++ b/Awful.apk/src/main/assets/javascript/thread.js
@@ -188,15 +188,7 @@ function processPosts(scopeElement) {
 
     // handle all GIFs that are not avatars
 	if (listener.getPreference('disableGifs') === 'true') {
-		scopeElement.querySelectorAll('img[title][src$=".gif"]:not(.avatar)').forEach(function each(gif) {
-			if (!gif.complete) {
-				gif.addEventListener('load', function freezeLoadHandler() {
-					freezeGif(this);
-				});
-			} else {
-				freezeGif(gif);
-			}
-		});
+		scopeElement.querySelectorAll('img[title][src$=".gif"]:not(.avatar)').forEach(prepareFreezeGif);
 	}
 
     // this handles all avatar processing, meaning if the avatar is a GIF we need to handle freezing as well
@@ -204,28 +196,14 @@ function processPosts(scopeElement) {
         img.addEventListener('load', processSecondaryAvatar);
     });
     function processSecondaryAvatar() {
-        var newSrc = this.src;
         // when people want to use gangtags as avatars, etc., they often use a 1x1 image as their primary avatar.
         // if this is the case, we change over to a "secondary" avatar, which is probably what's intended.
         if (this.naturalWidth === 1 && this.naturalHeight === 1 && this.dataset.avatarSecondSrc && this.dataset.avatarSecondSrc.length) {
-            newSrc = this.dataset.avatarSecondSrc;
-        }
-
-        // prepare to freeze GIFs
-        if (listener.getPreference('disableGifs') === 'true' && newSrc.slice(-4) === ".gif") {
-            if (newSrc === this.src && this.complete) {
-                // no reloading happening, final image is loaded.
-                freezeGif(this);
-            } else {
-                // the final image is not loaded, whether a new source is used or not.
-                this.addEventListener('load', function freezeLoadHandler() {
-                    freezeGif(this);
-                });
-            }
-        }
-
-        if (newSrc !== this.src) {
             this.src = this.dataset.avatarSecondSrc;
+        }
+
+        if (listener.getPreference('disableGifs') === 'true' && this.src.slice(-4) === ".gif") {
+            prepareFreezeGif(this);
         }
     }
 }
@@ -404,6 +382,20 @@ function freezeGif(image) {
 		canvas.setAttribute(image.attributes[i].name, image.attributes[i].value);
 	}
 	image.parentNode.replaceChild(canvas, image);
+}
+
+/**
+ * Monitors a gif to freeze it when loading's complete.
+ * @param {Element} image Gif image to monitor
+ */
+function prepareFreezeGif(image) {
+    if (!image.complete) {
+        image.addEventListener('load', function freezeLoadHandler() {
+            freezeGif(image);
+        });
+    } else {
+        freezeGif(image);
+    }
 }
 
 /**

--- a/Awful.apk/src/main/assets/mustache/post.mustache
+++ b/Awful.apk/src/main/assets/mustache/post.mustache
@@ -2,7 +2,7 @@
 	<header class="postheader">
         <div class="posterinfo">
             {{#avatarURL}}
-            <img class="avatar" src="{{.}}" title="{{username}}'s avatar" data-avatar-second-src="{{avatarSecondURL}}"/>
+            <img class="avatar" src="{{.}}" title="{{username}}'s avatar" {{#avatarSecondURL}}data-avatar-second-src="{{avatarSecondURL}}"{{/avatarSecondURL}}/>
             {{/avatarURL }}
             <section class="postinfo">
                 <aside class="postinfo-poster"><span class="postinfo-poster-name">{{username}} {{#role}}<img src="file:///android_asset/images/ic_star_{{role}}.png" />{{/role}}</span> {{^role}}{{#plat}}<span class="icon-gren"></span>{{/plat}}{{/role}}</aside>

--- a/Awful.apk/src/main/assets/mustache/post.mustache
+++ b/Awful.apk/src/main/assets/mustache/post.mustache
@@ -2,7 +2,7 @@
 	<header class="postheader">
         <div class="posterinfo">
             {{#avatarURL}}
-            <img class="avatar" src="{{.}}" title="{{username}}'s avatar" />
+            <img class="avatar" src="{{.}}" title="{{username}}'s avatar" data-avatar-second-src="{{avatarSecondURL}}"/>
             {{/avatarURL }}
             <section class="postinfo">
                 <aside class="postinfo-poster"><span class="postinfo-poster-name">{{username}} {{#role}}<img src="file:///android_asset/images/ic_star_{{role}}.png" />{{/role}}</span> {{^role}}{{#plat}}<span class="icon-gren"></span>{{/plat}}{{/role}}</aside>

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
@@ -185,6 +185,7 @@ public class AwfulProvider extends ContentProvider {
         sPostProjectionMap.put(AwfulPost.IS_PLAT, AwfulPost.IS_PLAT);
         sPostProjectionMap.put(AwfulPost.ROLE, AwfulPost.ROLE);
         sPostProjectionMap.put(AwfulPost.AVATAR, AwfulPost.AVATAR);
+        sPostProjectionMap.put(AwfulPost.AVATAR_SECOND, AwfulPost.AVATAR_SECOND);
         sPostProjectionMap.put(AwfulPost.AVATAR_TEXT, AwfulPost.AVATAR_TEXT);
         sPostProjectionMap.put(AwfulPost.CONTENT, AwfulPost.CONTENT);
         sPostProjectionMap.put(AwfulPost.EDITED, AwfulPost.EDITED);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
@@ -20,7 +20,7 @@ import com.ferg.awfulapp.thread.AwfulThread;
 public class DatabaseHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "awful.db";
-    private static final int DATABASE_VERSION = 34;
+    private static final int DATABASE_VERSION = 35;
 
     static final String TABLE_FORUM    = "forum";
     static final String TABLE_THREADS    = "threads";
@@ -109,6 +109,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 AwfulPost.IS_PLAT + " INTEGER," +
                 AwfulPost.ROLE + " VARCHAR," +
                 AwfulPost.AVATAR + " VARCHAR," +
+                AwfulPost.AVATAR_SECOND + " VARCHAR," +
                 AwfulPost.AVATAR_TEXT + " VARCHAR," +
                 AwfulPost.CONTENT + " VARCHAR," +
                 AwfulPost.EDITED + " VARCHAR," +
@@ -182,6 +183,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 dropTables(aDb, TABLE_DRAFTS);
                 createDraftTable(aDb);
             case 33:
+            case 34:
                 dropTables(aDb, TABLE_POSTS);
                 createPostTable(aDb);
                 break;//make sure to keep this break statement on the last case of this switch

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulHtmlPage.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulHtmlPage.java
@@ -205,6 +205,7 @@ public abstract class AwfulHtmlPage {
         for (AwfulPost post : aPosts) {
             String username = post.getUsername();
             String avatar = post.getAvatar();
+            String avatarSecond = post.getAvatarSecond();
 
             postData.put("seen", post.isPreviouslyRead() ? "read" : "unread");
             postData.put("isOP", (aPrefs.highlightOP && post.isOp()) ? "op" : null);
@@ -212,6 +213,7 @@ public abstract class AwfulHtmlPage {
             postData.put("postID", post.getId());
             postData.put("isSelf", (aPrefs.highlightSelf && username.equals(aPrefs.username)) ? "self" : null);
             postData.put("avatarURL", (aPrefs.canLoadAvatars() && avatar != null && avatar.length() > 0) ? avatar : null);
+            postData.put("avatarSecondURL", (aPrefs.canLoadAvatars() && avatarSecond != null && avatarSecond.length() > 0) ? avatarSecond : "");
             postData.put("username", username);
             postData.put("userID", post.getUserId());
             postData.put("postDate", post.getDate());

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulHtmlPage.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulHtmlPage.java
@@ -213,7 +213,7 @@ public abstract class AwfulHtmlPage {
             postData.put("postID", post.getId());
             postData.put("isSelf", (aPrefs.highlightSelf && username.equals(aPrefs.username)) ? "self" : null);
             postData.put("avatarURL", (aPrefs.canLoadAvatars() && avatar != null && avatar.length() > 0) ? avatar : null);
-            postData.put("avatarSecondURL", (aPrefs.canLoadAvatars() && avatarSecond != null && avatarSecond.length() > 0) ? avatarSecond : "");
+            postData.put("avatarSecondURL", (aPrefs.canLoadAvatars() && avatarSecond != null && avatarSecond.length() > 0) ? avatarSecond : null);
             postData.put("username", username);
             postData.put("userID", post.getUserId());
             postData.put("postDate", post.getDate());

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPost.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulPost.java
@@ -85,6 +85,8 @@ public class AwfulPost {
     public static final String IS_PLAT               = "is_plat";
     public static final String ROLE                  = "role";
     public static final String AVATAR                = "avatar";
+    // people may be using gangtags, etc. as avatars with a 1x1 primary av
+    public static final String AVATAR_SECOND         = "avatar_second";
 	public static final String AVATAR_TEXT 			 = "avatar_text";
     public static final String CONTENT               = "content";
     public static final String EDITED                = "edited";
@@ -108,6 +110,7 @@ public class AwfulPost {
     private String mUserId = "";
     private String mUsername = "";
     private String mAvatar = "";
+    private String mAvatarSecond = "";
     private String mAvatarText = "";
     private String mContent = "";
     private String mEdited = "";
@@ -127,6 +130,7 @@ public class AwfulPost {
         result.put("user_id", mUserId);
         result.put("username", mUsername);
         result.put("avatar", mAvatar);
+        result.put("avatar_second", mAvatarSecond);
         result.put("content", mContent);
         result.put("edited", mEdited);
         result.put("previouslyRead", Boolean.toString(mPreviouslyRead));
@@ -213,6 +217,12 @@ public class AwfulPost {
         mAvatar = aAvatar;
     }
 
+    public String getAvatarSecond() {
+        return mAvatarSecond;
+    }
+
+    public void setAvatarSecond(String aAvatarSecond) { mAvatarSecond = aAvatarSecond; }
+
     public String getContent() {
         return mContent;
     }
@@ -238,6 +248,7 @@ public class AwfulPost {
             int isPlatIndex = aCursor.getColumnIndex(IS_PLAT);
             int roleIndex = aCursor.getColumnIndex(ROLE);
             int avatarIndex = aCursor.getColumnIndex(AVATAR);
+            int avatarSecondIndex = aCursor.getColumnIndex(AVATAR_SECOND);
             int avatarTextIndex = aCursor.getColumnIndex(AVATAR_TEXT);
             int contentIndex = aCursor.getColumnIndex(CONTENT);
             int editedIndex = aCursor.getColumnIndex(EDITED);
@@ -259,6 +270,7 @@ public class AwfulPost {
                 current.setIsPlat(aCursor.getInt(isPlatIndex) > 0);
                 current.setRole(aCursor.getString(roleIndex));
                 current.setAvatar(aCursor.getString(avatarIndex));
+                current.setAvatarSecond(aCursor.getString(avatarSecondIndex));
                 current.setAvatarText(aCursor.getString(avatarTextIndex));
                 current.setContent(aCursor.getString(contentIndex));
                 current.setEdited(aCursor.getString(editedIndex));

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -125,15 +125,14 @@ class PostParseTask(
             postData.selectFirst(".title")!!
                 .also { put(AVATAR_TEXT, it.text()) }
                 .select("img")
+                .take(2)
                 .forEachIndexed { index, image ->
-                    if (index < 2) {
-                        image.let {
-                            tryConvertToHttps(it)
-                            put(
-                                if (index == 0) { AVATAR } else { AVATAR_SECOND },
-                                it.attr("src")
-                            )
-                        }
+                    image.let {
+                        tryConvertToHttps(it)
+                        put(
+                            if (index == 0) { AVATAR } else { AVATAR_SECOND },
+                            it.attr("src")
+                        )
                     }
                 }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -121,13 +121,20 @@ class PostParseTask(
             put(IS_PLAT, postData.hasDescendantWithClass("platinum").sqlBool)
             put(ROLE, getRole())
 
-            // grab the custom title, and also the avatar if there is one
+            // grab the custom title, and also avatar and alternate avatar if there are any
             postData.selectFirst(".title")!!
                 .also { put(AVATAR_TEXT, it.text()) }
-                .selectFirst("img")
-                ?.let {
-                    tryConvertToHttps(it)
-                    put(AVATAR, it.attr("src"))
+                .select("img")
+                .forEachIndexed { index, image ->
+                    if (index < 2) {
+                        image.let {
+                            tryConvertToHttps(it)
+                            put(
+                                if (index == 0) { AVATAR } else { AVATAR_SECOND },
+                                it.attr("src")
+                            )
+                        }
+                    }
                 }
 
             // FYAD has its post contents inside the .complete_shit element, so we just grab that instead of the full .postbody


### PR DESCRIPTION
People use long avatars by embedding extra images in their title and setting their avatar to a 1x1 image. This attempts to detect this and use the intended image instead. A test thread is [here](https://forums.somethingawful.com/showthread.php?threadid=3934728) (the irony is not lost on me.)

Feedback is totally welcome as I'm not well-versed in all the areas this touches.