### PR TITLE
Fix typo in build.gradle

### DIFF
--- a/Awful.apk/build.gradle
+++ b/Awful.apk/build.gradle
@@ -160,5 +160,5 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
 
-    implementation 'androidx.core:core-splashscreen:1.0.0-alpha2'
+    implementation 'androidx.core:core-splashscreen:1.0.0-alpha02'
 }


### PR DESCRIPTION
Gradle sync was failing due to library name mismatch.