### PR TITLE
Restore web search menu during text selection (Pixel 3XL, Android 11.)

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -282,6 +282,9 @@
             <data android:mimeType="text/plain" />
         </intent>
         <intent>
+            <action android:name="android.intent.action.WEB_SEARCH" />
+        </intent>
+        <intent>
             <action android:name="android.intent.action.VIEW" />
         </intent>
     </queries>


### PR DESCRIPTION
Apparently Pixel 3XL users with Android 11 [lost the web search option on highlighted text](https://forums.somethingawful.com/showthread.php?threadid=3571717&userid=0&perpage=40&pagenumber=188#post523254788), presumably after a WebView update. This commit appears to fix the issue, and was tested to be compatible with various emulated devices running APIs 23, 25, 29, 30 and 31.

(I am honestly not clear if this is the appropriate fix for this situation, it's really confusing when it's the environment *around* the app breaking things.)