### PR TITLE
Restore single-page search results

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/search/SearchFragment.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/search/SearchFragment.kt
@@ -141,16 +141,16 @@ class SearchFragment : AwfulFragment(), com.orangegangsters.github.swipyrefreshl
                     override fun success(result: AwfulSearchResult) {
                         removeLoadingDialog()
                         with(result) {
-                            if (queryId != 0) {
+                            if (resultsFound) {
                                 mSearchResults = resultList
                                 mQueryPages = pages
                                 mQueryId = queryId
                                 mSearchResultList.adapter?.notifyDataSetChanged()
 
                                 mMaxPageQueried = 1
-                                if (mMaxPageQueried < pages) mSRL.isEnabled = true
+                                mSRL.isEnabled = (queryId != 0 && mMaxPageQueried < pages)
                             }
-                            Timber.e("mQueryPages: %s\nmQueryId: %s", mQueryPages, mQueryId)
+                            Timber.e("resultsFound: %s\nmQueryPages: %s\nmQueryId: %s", result.resultsFound, mQueryPages, mQueryId)
                         }
                     }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulSearchResult.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulSearchResult.java
@@ -13,9 +13,14 @@ import java.util.ArrayList;
  */
 public class AwfulSearchResult {
 
+    boolean resultsFound;
     int queryId;
     int pages;
     ArrayList<AwfulSearch> resultList;
+
+    public boolean getResultsFound() { return resultsFound; }
+
+    public void setResultsFound(boolean resultsFound) { this.resultsFound = resultsFound; }
 
     public int getQueryId() {
         return queryId;
@@ -43,6 +48,10 @@ public class AwfulSearchResult {
 
     public static AwfulSearchResult parseSearch(Document doc) {
         AwfulSearchResult result = new AwfulSearchResult();
+        /* If no results, then no class="this_page" or class="last_page" elements.
+        *  If one page of results, class="this_page" but no class="last_page" element.
+        *  If more than one page of results, both class="this_page" and class="last_page" elements. */
+        result.setResultsFound(doc.getElementsByClass("this_page").first() != null);
         Element lastPage = doc.getElementsByClass("last_page").first();
         if(lastPage != null){
             Element link = lastPage.child(0);
@@ -51,6 +60,8 @@ public class AwfulSearchResult {
             result.setPages(Integer.parseInt(TextUtils.split(params[2],"=")[1]));
         }else{
             result.setPages(1);
+            /* If there is only one page of results, there are no elements that allow us to scrape
+            *  a query ID from the response body itself. */
             result.setQueryId(0);
         }
         return result;


### PR DESCRIPTION
[From the forums:](https://forums.somethingawful.com/showthread.php?noseen=1&threadid=3571717&pagenumber=191&perpage=40#post524894537)
> Currently, if a search produces only a single page of results, there is no "Last" button that it can scrape information from, and it treats the search as if it found no results. In the thread above, now that "wesker" appears >10 times in the thread, it has two pages of results and works fine.

The problem can be seen with these searches:
> threadid:3989401 wesker
> threadid:3989401 wesker cute
> threadid:3989401 wesker no results

I feel like a more robust solution involves pulling the query ID from the URI that returns the document body itself, but I haven't figured out how to do that and wanted to submit this patch in case it's sufficient.