### PR TITLE
Fix rare pull-to-refresh bug from acting on stale data.

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -193,8 +193,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
     private String mTitle = null;
 	private String postJump = "";
 	private int savedScrollPosition = 0;
-	/** Whether the currently displayed page represents a full page of posts */
-	private boolean displayingLastPage = false;
 	
 	private ShareActionProvider shareProvider;
 
@@ -1084,7 +1082,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
             String html = AwfulHtmlPage.getThreadHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPageNumber(), mLastPage);
             refreshSessionCookie();
 			mThreadView.setBodyHtml(html);
-			displayingLastPage = getPageNumber() == getLastPage();
             setProgress(100);
         } catch (Exception e) {
             // If we've already left the activity the webview may still be working to populate,
@@ -1098,9 +1095,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 	public void onRefresh(SwipyRefreshLayoutDirection swipyRefreshLayoutDirection) {
 		if (swipyRefreshLayoutDirection == SwipyRefreshLayoutDirection.TOP) {
 			// no page turn when swiping at the top of the page
-			refresh();
-		} else if (displayingLastPage) {
-			// always refresh if there could be more posts
 			refresh();
 		} else {
 			turnPage(true);


### PR DESCRIPTION
As listed on the forums, there's a [rare bug where pull-to-refresh will just reload the current page](https://forums.somethingawful.com/showthread.php?threadid=3571717&pagenumber=192#post526341997) despite new pages being available. This patch basically just removes the variable holding the stale value in question.

To reproduce:
1. Load a thread where the last page is maxed out on posts.
2. Wait until there are new posts.
3. Switch away from the app, and switch back. Metadata will update and the page bar will reflect the new posts.
4. Swipe up and the page will refresh instead of loading the new page.
