### PR TITLE
Fix Imgur text inserting at beginning of PM rather than cursor location.

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
@@ -386,12 +386,16 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
         		String replyTitle = aData.getString(aData.getColumnIndex(AwfulMessage.REPLY_TITLE));
         		String replyContent = aData.getString(aData.getColumnIndex(AwfulMessage.REPLY_CONTENT));
         		if(replyContent != null){
-            		messageComposer.setText(replyContent, false);
+					if (!replyContent.equals(messageComposer.getText())) {
+						messageComposer.setText(replyContent, false);
+					}
         		}else{
         			messageComposer.setText(null, false);
         		}
         		if(replyTitle != null){
-        			mSubject.setText(replyTitle);
+					if (!replyTitle.equals(mSubject.getText().toString())) {
+						mSubject.setText(replyTitle);
+					}
         		}else{
         			mSubject.setText(title);
         		}


### PR DESCRIPTION
When writing a PM, inserting from Imgur using the upload image capability will always insert the Imgur link at the beginning of the PM rather than the cursor location.

To reproduce:
1. Open a PM reply page and set the cursor at the end of the message field.
2. Choose `[bb]` menu > `Insert Imgur` > Upload `from image` and tap to select an image.
3. Back out (not necessary to actually choose an image.)
4. The cursor has been reset to the beginning of the message field.

This appears to happen in `onLoadFinished()` for the `PMCallback` class at `MessageFragment.java:374`. The message field `messageComposer` is always overwritten using `setText()`, which also resets the cursor position. This fix only calls `setText()` if the content actually differs, incidentally preserving the cursor position.

I don't like this fix, honestly, but `onLoadFinished()` gets called at many points in the Android lifecycle, and changing the implementation of `setText()` in `MessageComposer.java` doesn't seem like a great idea either. Hopefully this is the least terrible hack.