### PR TITLE
Store ignored posts in database too.

### DIFF
--- a/Awful.apk/src/main/assets/css/general.css
+++ b/Awful.apk/src/main/assets/css/general.css
@@ -3,6 +3,10 @@
     src: url('iconfont.ttf');
 }
 
+.ignored {
+    display: none;
+}
+
 .avatar {
     align-self: baseline;
     object-fit: contain;

--- a/Awful.apk/src/main/assets/mustache/post.mustache
+++ b/Awful.apk/src/main/assets/mustache/post.mustache
@@ -1,4 +1,4 @@
-<article class="post {{seen}} {{#isMarked}}marked{{/isMarked}} {{#isOP}}op{{/isOP}} {{#isSelf}}self{{/isSelf}}"  id="post{{postID}}">
+<article class="post {{seen}} {{#isIgnored}}ignored{{/isIgnored}} {{#isMarked}}marked{{/isMarked}} {{#isOP}}op{{/isOP}} {{#isSelf}}self{{/isSelf}}"  id="post{{postID}}">
 	<header class="postheader">
         <div class="posterinfo">
             {{#avatarURL}}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -194,8 +194,8 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 	private String postJump = "";
 	private int savedScrollPosition = 0;
 	/** Whether the currently displayed page represents a full page of posts */
-	private boolean displayingLastPage = false;
-	
+	private boolean displayingFullPage = false;
+
 	private ShareActionProvider shareProvider;
 
     private ForumsIndexActivity parentActivity;
@@ -1084,7 +1084,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
             String html = AwfulHtmlPage.getThreadHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPageNumber(), mLastPage);
             refreshSessionCookie();
 			mThreadView.setBodyHtml(html);
-			displayingLastPage = getPageNumber() == getLastPage();
+			displayingFullPage = aPosts.size() >= getPrefs().postPerPage; // shouldn't ever be > but just to be safe
             setProgress(100);
         } catch (Exception e) {
             // If we've already left the activity the webview may still be working to populate,
@@ -1099,7 +1099,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 		if (swipyRefreshLayoutDirection == SwipyRefreshLayoutDirection.TOP) {
 			// no page turn when swiping at the top of the page
 			refresh();
-		} else if (displayingLastPage) {
+		} else if (!displayingFullPage) {
 			// always refresh if there could be more posts
 			refresh();
 		} else {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
@@ -179,6 +179,7 @@ public class AwfulProvider extends ContentProvider {
         sPostProjectionMap.put(AwfulPost.REGDATE, AwfulPost.REGDATE);
         sPostProjectionMap.put(AwfulPost.USER_ID, AwfulPost.USER_ID);
         sPostProjectionMap.put(AwfulPost.USERNAME, AwfulPost.USERNAME);
+        sPostProjectionMap.put(AwfulPost.IS_IGNORED, AwfulPost.IS_IGNORED);
         sPostProjectionMap.put(AwfulPost.PREVIOUSLY_READ, AwfulPost.PREVIOUSLY_READ);
         sPostProjectionMap.put(AwfulPost.EDITABLE, AwfulPost.EDITABLE);
         sPostProjectionMap.put(AwfulPost.IS_OP, AwfulPost.IS_OP);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
@@ -20,7 +20,7 @@ import com.ferg.awfulapp.thread.AwfulThread;
 public class DatabaseHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "awful.db";
-    private static final int DATABASE_VERSION = 35;
+    private static final int DATABASE_VERSION = 36;
 
     static final String TABLE_FORUM    = "forum";
     static final String TABLE_THREADS    = "threads";
@@ -103,6 +103,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 AwfulPost.REGDATE + " VARCHAR," +
                 AwfulPost.USER_ID + " INTEGER," +
                 AwfulPost.USERNAME + " VARCHAR," +
+                AwfulPost.IS_IGNORED + " INTEGER," +
                 AwfulPost.PREVIOUSLY_READ + " INTEGER," +
                 AwfulPost.EDITABLE + " INTEGER," +
                 AwfulPost.IS_OP + " INTEGER," +
@@ -184,6 +185,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 createDraftTable(aDb);
             case 33:
             case 34:
+            case 35:
                 dropTables(aDb, TABLE_POSTS);
                 createPostTable(aDb);
                 break;//make sure to keep this break statement on the last case of this switch

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulHtmlPage.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulHtmlPage.java
@@ -209,6 +209,7 @@ public abstract class AwfulHtmlPage {
 
             postData.put("seen", post.isPreviouslyRead() ? "read" : "unread");
             postData.put("isOP", (aPrefs.highlightOP && post.isOp()) ? "op" : null);
+            postData.put("isIgnored", (aPrefs.hideIgnoredPosts && post.isIgnored()) ? "ignored" : null);
             postData.put("isMarked", aPrefs.markedUsers.contains(username) ? "marked" : null);
             postData.put("postID", post.getId());
             postData.put("isSelf", (aPrefs.highlightSelf && username.equals(aPrefs.username)) ? "self" : null);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -111,6 +111,8 @@ class PostParseTask(
                 postData.attr("data-idx").replace(POST_ID_GARBAGE, "").toIntOrNull() ?: index
             )
 
+            put(IS_IGNORED, postData.hasClass("ignored").sqlBool)
+
             // Check for "class=seenX", or just rely on unread index
             val markedSeen = postData.selectFirst("[class^=seen]") != null
             val postHasBeenRead = markedSeen || index <= lastReadIndex

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -299,6 +299,7 @@
         <item>gibb3h</item>
         <item>Glimm</item>
         <item>Guavanaut</item>
+        <item>handle</item>
         <item>JingleBells</item>
         <item>Literal Hamster</item>
         <item>Oben</item>


### PR DESCRIPTION
It doesn't appear to break anything to store ignored posts in the database, instead of skipping storage if the user has "Hide ignored posts" selected in preferences.

This adds an extra field to the posts table, but keeping ignored posts in the flow incidentally allows pull-to-refresh to rely on the number of posts on a page, fixing the [rare bug in pull request #753.](https://github.com/Awful/Awful.apk/pull/753)