### PR TITLE
Fix probation time parsing off by 12hrs in PM.

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
@@ -177,7 +177,7 @@ public class AwfulError extends VolleyError {
                 String date = m.group(2);
 
                 // Jan 11, 2013 10:35 AM  vs  Jan 11, 2013 22:35
-                String pattern = date.endsWith("m") ? "MMM d, yyyy hh:mm a" : "MMM d, yyyy HH:mm";
+                String pattern = date.toLowerCase().endsWith("m") ? "MMM d, yyyy hh:mm a" : "MMM d, yyyy HH:mm";
                 SimpleDateFormat probationFormat = new SimpleDateFormat(pattern, Locale.US);
                 try {
                     probTimestamp = probationFormat.parse(date).getTime();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/util/AwfulError.java
@@ -177,7 +177,7 @@ public class AwfulError extends VolleyError {
                 String date = m.group(2);
 
                 // Jan 11, 2013 10:35 AM  vs  Jan 11, 2013 22:35
-                String pattern = date.toLowerCase().endsWith("m") ? "MMM d, yyyy hh:mm a" : "MMM d, yyyy HH:mm";
+                String pattern = StringUtils.endsWithIgnoreCase(date, "m") ? "MMM d, yyyy hh:mm a" : "MMM d, yyyy HH:mm";
                 SimpleDateFormat probationFormat = new SimpleDateFormat(pattern, Locale.US);
                 try {
                     probTimestamp = probationFormat.parse(date).getTime();


### PR DESCRIPTION
From anonymous user: a probation time that was supposed to end at 11:25 PM is showing as ending at 11:25 AM. Seems to be because the code is looking for a trailing "m" (case-sensitive) to use the AM/PM parser, otherwise it defaults to 24hr time. So change to case-insensitive comparison.

```
<div id="probation_warn">
<h4>TAKE A BREAK</h4>
You have been put on probation until Sep 29, 2022 11:25 PM. You cannot post while
on probation. You might find out why you are on probation if you
<a href="/banlist.php?userid=redacted">check the Leper's
Colony</a>. If you <a href="//www.somethingawful.com/d/forum-rules/forum-rules.php">read the fucking rules</a>,
maybe this won't happen again!
</div>
```