### PR TITLE
Add TikTok embedding preference.

### DIFF
--- a/Awful.apk/src/main/assets/javascript/embedding.js
+++ b/Awful.apk/src/main/assets/javascript/embedding.js
@@ -235,7 +235,9 @@ function processThreadEmbeds(replacementArea) {
 	}
 
 	/**
-	 * Checks whether an element should be embedded depending on whether there are NWS/NMS emoticons in the post or if it is spoilered
+	 * Checks whether an element should be embedded depending on whether there are NWS/NMS emoticons in the post or if it is spoilered.
+	 *
+	 * Duplicate logic for YouTube/TikTok embeds is in AwfulPost.java (postElementIsNMWSOrSpoilered). Make changes in both locations!
 	 * @param {Element} element The element that might be NWS or spoilered
 	 * @returns {Boolean} False if the element is spoilered or possibly NWS/NMS
 	 */

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
@@ -144,6 +144,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
     //EXPERIMENTAL STUFF
     public boolean inlineYoutube;
     public boolean inlineTweets;
+	public boolean inlineTiktoks;
     public boolean inlineVines;
     public boolean inlineWebm;
 	public boolean autostartWebm;
@@ -260,6 +261,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
         highlightOP				 = getPreference(Keys.HIGHLIGHT_OP, true);
 		inlineYoutube            = getPreference(Keys.INLINE_YOUTUBE, true);
 		inlineTweets             = getPreference(Keys.INLINE_TWEETS, true);
+		inlineTiktoks            = getPreference(Keys.INLINE_TIKTOKS, false);
 		inlineVines            	 = getPreference(Keys.INLINE_VINES, false);
 		inlineWebm            	 = getPreference(Keys.INLINE_WEBM, true);
 		autostartWebm            = getPreference(Keys.AUTOSTART_WEBM, false);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
@@ -103,6 +103,7 @@ public abstract class Keys {
             INLINE_INSTAGRAM,
             INLINE_SOUNDCLOUD,
             INLINE_TWITCH,
+            INLINE_TIKTOKS,
             INLINE_VINES,
             INLINE_WEBM,
             AUTOSTART_WEBM,
@@ -179,6 +180,7 @@ public abstract class Keys {
     public static final int INLINE_INSTAGRAM = R.string.pref_key_inline_instagram;
     public static final int INLINE_SOUNDCLOUD = R.string.pref_key_inline_soundcloud;
     public static final int INLINE_TWITCH = R.string.pref_key_inline_twitch;
+    public static final int INLINE_TIKTOKS = R.string.pref_key_inline_tiktoks;
     public static final int INLINE_VINES = R.string.pref_key_inline_vines;
     public static final int INLINE_WEBM = R.string.pref_key_inline_webm;
     public static final int AUTOSTART_WEBM = R.string.pref_key_autostart_webm;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AnnouncementsRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AnnouncementsRequest.kt
@@ -75,7 +75,7 @@ class AnnouncementsRequest(context: Context)
             val postBody = announcementSection.selectFirst(".postbody")
             if (postBody != null) {
                 // process videos, images and links and store the resulting post HTML
-                AwfulPost.convertVideos(postBody, prefs.inlineYoutube)
+                AwfulPost.convertVideos(postBody, prefs.inlineYoutube, prefs.inlineTiktoks)
                 for (image in postBody.getElementsByTag("img")) {
                     AwfulPost.processPostImage(image, false, prefs)
                 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/SinglePostRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/SinglePostRequest.kt
@@ -32,7 +32,7 @@ class SinglePostRequest(context: Context, private val postId: String)
         val postBody = doc.selectFirst(".postbody")
         val fyadPostBody = postBody?.selectFirst(".complete_shit")
         (fyadPostBody ?: postBody ?: throw AwfulError("Couldn't find post content")).apply {
-            AwfulPost.convertVideos(this, prefs.inlineYoutube)
+            AwfulPost.convertVideos(this, prefs.inlineYoutube, prefs.inlineTiktoks)
             getElementsByTag("img").forEach {
                 AwfulPost.processPostImage(
                     it,

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -142,7 +142,7 @@ class PostParseTask(
             val postBody = postData.selectFirst(".postbody")
             val fyadPostBody = postBody!!.selectFirst(".complete_shit")
             (fyadPostBody ?: postBody).apply {
-                convertVideos(this, prefs.inlineYoutube)
+                convertVideos(this, prefs.inlineYoutube, prefs.inlineTiktoks)
                 getElementsByTag("img").forEach { processPostImage(it, postHasBeenRead, prefs) }
                 getElementsByTag("a").forEach(::tryConvertToHttps)
                 if (this == fyadPostBody) {

--- a/Awful.apk/src/main/res/values/preference_keys.xml
+++ b/Awful.apk/src/main/res/values/preference_keys.xml
@@ -39,6 +39,7 @@
     <string name="pref_key_inline_instagram">inline_instagram</string>
     <string name="pref_key_inline_soundcloud">inline_soundcloud</string>
     <string name="pref_key_inline_twitch">inline_twitch</string>
+    <string name="pref_key_inline_tiktoks">inline_tiktoks</string>
     <string name="pref_key_inline_vines">inline_vines</string>
     <string name="pref_key_inline_webm">inline_webm</string>
     <string name="pref_key_autostart_webm">autostart_webm</string>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -403,6 +403,7 @@
     <string name="inline_soundcloud">Soundcloud</string>
     <string name="post_embedding_divider_videos">Videos</string>
     <string name="inline_youtube">YouTube</string>
+    <string name="inline_tiktoks">TikTok</string>
     <string name="inline_vines">Vine</string>
     <string name="inline_twitch">Twitch</string>
     <string name="inline_twitch_summary">Slow with several on a page</string>

--- a/Awful.apk/src/main/res/xml/post_embedding_settings.xml
+++ b/Awful.apk/src/main/res/xml/post_embedding_settings.xml
@@ -35,6 +35,12 @@
 
         <SwitchPreference
             android:defaultValue="false"
+            android:key="@string/pref_key_inline_tiktoks"
+            android:title="@string/inline_tiktoks"
+            />
+
+        <SwitchPreference
+            android:defaultValue="false"
             android:key="@string/pref_key_inline_vines"
             android:title="@string/inline_vines"
             />


### PR DESCRIPTION
Also changes the preprocessing of YouTube/TikTok videos so the app doesn't embed those in spoiler tags or in posts that may be NWS. There's some copy/paste duplication of code, but until there's a *another* hyper-popular video embed site, further abstraction seemed unnecessary.

I decided to handle TikTok embeds in `AwfulPost.java` because like YouTube embeds, they are in the site HTML as `<iframe>` elements and it's presumably less work for the app to preprocess them instead of having `embedding.js` race to remove the embed before it starts loading.