### PR TITLE
Use newer event.composedPath() if deprecated event.path is not available

### DIFF
--- a/Awful.apk/src/main/assets/javascript/thread.js
+++ b/Awful.apk/src/main/assets/javascript/thread.js
@@ -96,7 +96,10 @@ function containerInit() {
  * @returns {Element|undefined} The requested Element or undefined if the Element is not found
  */
 function findInPath(event, cssClass, returnElement) {
-	var search = Array.prototype.filter.call(event.path, function filter(node) {
+	// Standards-compliant approach is event.composedPath(), but it was added in Chromium 53 and
+	// Android 5 (API level 21) could still be using Chromium 37. So we check for the deprecated
+	// event.path and use the standard approach if the older approach fails.
+	var search = Array.prototype.filter.call(event.path || event.composedPath(), function filter(node) {
 		return node.classList && node.classList.contains(cssClass);
 	});
 	return returnElement ? search[0] : search.length > 0;


### PR DESCRIPTION
Users mysteriously and intermittently missing the following:

* No three-dot menu
* Can't expand poster information/avatar
* Can't enlarge [timg]s
* Spoilers won't be revealed on tap
* Long press on images doesn't show Toast

may be experiencing Chromium [removing the nonstandard Event.path API](https://bugs.chromium.org/p/chromium/issues/detail?id=1277431). Inspecting the WebView on an affected device showed errors in `findInPath()` that broke the features above.

To reproduce the bug on stock Android:
* Install WebView beta version, which comes with the WebView DevTools app
* In `WebView DevTools > Flags`, set the `EventPath` flag to disabled.
* Restart Awful.
* Listed Javascript features should now be broken, but force-enabling `EventPath` will restore features on affected devices.

I couldn't find any other usages of `event.path` in the Javascript assets, so here's to hoping this may end the problem for good!