### PR TITLE
Update shortcut creation process.

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/UserCPShortcutActivity.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/UserCPShortcutActivity.kt
@@ -3,6 +3,9 @@ package com.ferg.awfulapp
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.drawable.IconCompat
 import com.ferg.awfulapp.preferences.AwfulPreferences
 
 /**
@@ -19,22 +22,24 @@ class UserCPShortcutActivity : Activity() {
         finish()
     }
 
-
     /**
      * Builds the Intent to create the Bookmarks widget, containing the app's "show the bookmarks"
      * Intent (for when it's clicked) and an icon and title for the widget.
      */
     private fun setupShortcut() {
         val shortcutIntent = NavigationEvent.Bookmarks.getIntent(this)
-        val iconResource = Intent.ShortcutIconResource.fromContext(this, getLauncherIcon())
-        // Then, set up the container intent (the response to the caller)
-        with(Intent()) {
-            putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent)
-            putExtra(Intent.EXTRA_SHORTCUT_NAME, getString(R.string.usercp))
-            putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, iconResource)
-            // Now, return the result to the launcher
-            setResult(Activity.RESULT_OK, this)
-        }
+        shortcutIntent.action = Intent.ACTION_DEFAULT
+        val name = getString(R.string.usercp)
+        val launcherIcon = IconCompat.createWithResource(this, getLauncherIcon())
+
+        val shortcut = ShortcutInfoCompat.Builder(this, getString(R.string.awful_bookmarks_shortcut_id))
+            .setIntent(shortcutIntent)
+            .setShortLabel(name)
+            // TODO: doesn't support themed icons in this configuration. Unable to find a workaround right now.
+            .setIcon(launcherIcon)
+            .build()
+
+        setResult(RESULT_OK, ShortcutManagerCompat.createShortcutResultIntent(this, shortcut))
     }
 
     private fun getLauncherIcon(): Int {

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <!-- Share handling -->
     <string name="share_handler_no_url_found">This share isn\'t an Awful link!</string>
 
+    <string name="awful_bookmarks_shortcut_id">awful-bookmarks-shortcut</string>
     <string name="awful_web_provider">AwfulWebProvider</string>
     <string name="cancel">Cancel</string>
     <string name="confirm">OK</string>


### PR DESCRIPTION
Something in the most recent release causes [bookmark shortcuts to break](https://forums.somethingawful.com/showthread.php?threadid=3743815&pagenumber=18#post527231867), which can be replicated on API 33 by creating the bookmarks shortcut and then changing the themed icons setting. Once the setting is changed, the shortcut is permanently broken, even if the themed icons setting is changed back.

This fixes shortcut functionality, but unfortunately the shortcut icon won't reflect the themed icon setting (if applicable,) and I can't find a workaround.