### PR TITLE
Set active theme based on system. (Options light/dark/battery/system.)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -298,7 +298,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 			Timber.i("Restoring fragment - loading cached posts from database");
 			setThreadId(aSavedState.getInt(THREAD_ID_KEY, NULL_THREAD_ID));
 			setPageNumber(aSavedState.getInt(THREAD_PAGE_KEY, FIRST_PAGE));
-			// TODO: 04/05/2017 saved scroll position doesn't seem to actually get used to set the position?
 			savedScrollPosition = aSavedState.getInt(SCROLL_POSITION_KEY, 0);
 			loadFromCache = true;
 		}
@@ -1084,6 +1083,11 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
             String html = AwfulHtmlPage.getThreadHtml(aPosts, AwfulPreferences.getInstance(getActivity()), getPageNumber(), mLastPage);
             refreshSessionCookie();
 			mThreadView.setBodyHtml(html);
+			if (savedScrollPosition != 0) {
+				// this won't put us exactly where we were, just close. webviews are difficult beasts
+				mThreadView.scrollTo(0, savedScrollPosition);
+				savedScrollPosition = 0;
+			}
 			displayingFullPage = aPosts.size() >= getPrefs().postPerPage; // shouldn't ever be > but just to be safe
             setProgress(100);
         } catch (Exception e) {
@@ -1490,8 +1494,6 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
         	if(mThreadView != null){
         		populateThreadView(AwfulPost.fromCursor(getActivity(), aData));
         	}
-			// TODO: 04/05/2017 sometimes you don't want this resetting, e.g. restoring fragment state
-			savedScrollPosition = 0;
         }
 
         @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
@@ -25,7 +25,9 @@ public abstract class Keys {
     @IntDef({
             USERNAME,
             USER_AVATAR_URL,
+            THEME_CHANGING,
             THEME,
+            THEME_DARK_MODE,
             LAUNCHER_ICON,
             LAYOUT,
             IMGUR_THUMBNAILS,
@@ -140,7 +142,9 @@ public abstract class Keys {
 
     public static final int USERNAME = R.string.pref_key_username;
     public static final int USER_AVATAR_URL = R.string.pref_key_user_title;
+    public static final int THEME_CHANGING = R.string.pref_key_theme_changing;
     public static final int THEME = R.string.pref_key_theme;
+    public static final int THEME_DARK_MODE = R.string.pref_key_theme_dark_mode;
     public static final int LAUNCHER_ICON = R.string.pref_key_launcher_icon;
     public static final int LAYOUT = R.string.pref_key_layout;
     public static final int IMGUR_THUMBNAILS = R.string.pref_key_imgur_thumbnails;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/SettingsActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/SettingsActivity.java
@@ -22,7 +22,6 @@ import android.widget.Toast;
 
 import com.ferg.awfulapp.AwfulActivity;
 import com.ferg.awfulapp.R;
-import com.ferg.awfulapp.constants.Constants;
 import com.ferg.awfulapp.preferences.fragments.RootSettings;
 import com.ferg.awfulapp.preferences.fragments.SettingsFragment;
 
@@ -96,8 +95,7 @@ public class SettingsActivity extends AwfulActivity implements AwfulPreferences.
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         prefs = AwfulPreferences.getInstance(this, this);
-        currentThemeName = prefs.theme;
-        updateTheme();
+        currentThemeName = prefs.getActiveTheme();
         // theme needs to be set BEFORE the super call, or it'll be inconsistent
         super.onCreate(savedInstanceState);
         setContentView(R.layout.settings);
@@ -253,11 +251,11 @@ public class SettingsActivity extends AwfulActivity implements AwfulPreferences.
             }
         }
 
-        if (!getMPrefs().theme.equals(this.currentThemeName)) {
-            this.currentThemeName = getMPrefs().theme;
-            updateTheme();
-            recreate();
+        if (!getMPrefs().getActiveTheme().equals(this.currentThemeName)) {
+            this.currentThemeName = getMPrefs().getActiveTheme();
         }
+        // AwfulActivity has a pref change listener that will apply theme change if needed
+        super.onPreferenceChange(preferences, key);
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThemeSettings.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/fragments/ThemeSettings.java
@@ -41,7 +41,9 @@ public class ThemeSettings extends SettingsFragment {
     {
         SETTINGS_XML_RES_ID = R.xml.themesettings;
         VALUE_SUMMARY_PREF_KEYS = new int[]{
+                R.string.pref_key_theme_changing,
                 R.string.pref_key_theme,
+                R.string.pref_key_theme_dark_mode,
                 R.string.pref_key_layout,
                 R.string.pref_key_preferred_font
         };
@@ -96,7 +98,8 @@ public class ThemeSettings extends SettingsFragment {
         List<CharSequence> themeNames = new ArrayList<>();
         List<CharSequence> themeValues = new ArrayList<>();
         ListPreference themePref = (ListPreference) findPrefById(R.string.pref_key_theme);
-        if (themePref == null) {
+        ListPreference darkThemePref = (ListPreference) findPrefById(R.string.pref_key_theme_dark_mode);
+        if (themePref == null || darkThemePref == null) {
             throw new RuntimeException("Theme or layout preference is missing!");
         }
 
@@ -127,6 +130,7 @@ public class ThemeSettings extends SettingsFragment {
         }
 
         setListPreferenceChoices(themePref, themeNames, themeValues);
+        setListPreferenceChoices(darkThemePref, themeNames, themeValues);
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulTheme.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulTheme.java
@@ -174,7 +174,7 @@ public enum AwfulTheme {
         if (forumId != null && prefs.forceForumThemes) {
             forumTheme = themeForForumId(forumId, prefs);
         }
-        return (forumTheme != null) ? forumTheme : themeForCssFilename(prefs.theme);
+        return (forumTheme != null) ? forumTheme : themeForCssFilename(prefs.getActiveTheme());
     }
 
     /**

--- a/Awful.apk/src/main/res/values/preference_keys.xml
+++ b/Awful.apk/src/main/res/values/preference_keys.xml
@@ -3,7 +3,9 @@
     <!--keys for preferences that store a value in the SharedPreferences -->
     <string name="pref_key_username">username</string>
     <string name="pref_key_user_title">user_title</string>
+    <string name="pref_key_theme_changing">theme_changing</string>
     <string name="pref_key_theme">theme</string>
+    <string name="pref_key_theme_dark_mode">theme_dark_mode</string>
     <string name="pref_key_layout">layouts</string>
     <string name="pref_key_imgur_thumbnails">imgur_thumbnails</string>
     <string name="pref_key_preferred_font">preferred_font</string>
@@ -82,7 +84,9 @@
     <string name="pref_key_open_thread_menu_item">open_thread</string>
     <string name="pref_key_account_menu_item">account</string>
     <string name="pref_key_forum_index_menu_item">forum_index_menu_item</string>
+    <string name="pref_key_theme_changing_menu_item">theme_changing</string>
     <string name="pref_key_theme_menu_item">theme</string>
+    <string name="pref_key_theme_dark_mode_menu_item">theme_dark_mode</string>
     <string name="pref_key_thread_menu_item">thread</string>
     <string name="pref_key_posts_menu_item">posts</string>
     <string name="pref_key_images_menu_item">images</string>

--- a/Awful.apk/src/main/res/values/setting_constants.xml
+++ b/Awful.apk/src/main/res/values/setting_constants.xml
@@ -7,6 +7,16 @@
         <item>landscape</item>
     </string-array>
 
+    <string-array name="theme_changing_values">
+        <item>@string/theme_changing_always_light</item>
+        <item>@string/theme_changing_always_dark</item>
+        <item>@string/theme_changing_follow_battery_saver</item>
+        <item>@string/theme_changing_follow_system</item>
+    </string-array>
+    <string name="theme_changing_always_light">always_light</string>
+    <string name="theme_changing_always_dark">always_dark</string>
+    <string name="theme_changing_follow_battery_saver">follow_battery_saver</string>
+    <string name="theme_changing_follow_system">follow_system</string>
     <string-array name="layouts_values">
         <item>default</item>
     </string-array>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -434,7 +434,15 @@
     <string name="disable_timgs_summary">Don\'t shrink large images</string>
 
     <!-- Theme Settings page -->
+    <string name="theme_changing">Active theme</string>
+    <string-array name="theme_changing">
+        <item>Light</item>
+        <item>Dark</item>
+        <item>Set by Battery Saver</item>
+        <item>Use system default</item>
+    </string-array>
     <string name="theme">Theme</string>
+    <string name="theme_dark_mode">Dark mode theme</string>
     <string name="force_forum_themes">Force forum themes</string>
     <string name="force_forum_themes_summary">Specific theme in YOSPOS, BYOB and FYAD</string>
     <string name="layouts">Layout</string>

--- a/Awful.apk/src/main/res/xml/themesettings.xml
+++ b/Awful.apk/src/main/res/xml/themesettings.xml
@@ -2,10 +2,22 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
         <!-- Theme and Layout list prefs have their entries/values initialised in ThemeSettings -->
         <ListPreference
+            android:key="@string/pref_key_theme_changing"
+            android:title="@string/theme_changing"
+            android:entries="@array/theme_changing"
+            android:entryValues="@array/theme_changing_values"
+            android:defaultValue="follow_system"
+            />
+        <ListPreference
             android:key="@string/pref_key_theme"
             android:title="@string/theme"
             android:defaultValue="default.css"
             />
+        <ListPreference
+                android:key="@string/pref_key_theme_dark_mode"
+                android:title="@string/theme_dark_mode"
+                android:defaultValue="default.css"
+                />
         <SwitchPreference
             android:key="@string/pref_key_force_forum_themes"
             android:title="@string/force_forum_themes"


### PR DESCRIPTION
Running up that hill (toward feature parity with iOS.) Tested on emulators running APIs 21, 25, 29 and 33. Tested on device running API 29. Please let me know if you encounter issues!