### PR TITLE
Static bookmarks shortcut for APIs >=25.

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -252,15 +252,20 @@
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|keyboardHidden|screenSize"
             />
-        <activity 
+
+        <!-- Legacy activity for API 24 and below, to create bookmarks shortcut.
+             Isn't enabled until first launch on appropriate device. -->
+        <activity
             android:name="com.ferg.awfulapp.UserCPShortcutActivity"
             android:label="@string/usercp"
+            android:enabled="@bool/legacy_shortcut_creation"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.CREATE_SHORTCUT" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
         <activity android:name="com.ferg.awfulapp.MessageDisplayActivity"
                   android:configChanges="orientation|keyboardHidden|screenSize" />
         <activity android:name="com.ferg.awfulapp.PrivateMessageActivity"

--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -73,6 +73,8 @@
 				<data android:pathPrefix="/bookmarkthreads.php"/>
 				<data android:pathPrefix="/showthread.php"/>
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts"/>
         </activity-alias>
         <activity-alias android:label="@string/app_name"
                         android:icon="@mipmap/ic_launcher_dog"
@@ -99,6 +101,8 @@
                 <data android:pathPrefix="/bookmarkthreads.php"/>
                 <data android:pathPrefix="/showthread.php"/>
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                       android:resource="@xml/shortcuts"/>
         </activity-alias>
 
         <activity-alias android:label="@string/app_name"
@@ -126,6 +130,8 @@
                 <data android:pathPrefix="/bookmarkthreads.php"/>
                 <data android:pathPrefix="/showthread.php"/>
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                       android:resource="@xml/shortcuts"/>
         </activity-alias>
 
         <activity-alias android:label="@string/app_name"
@@ -153,6 +159,8 @@
                 <data android:pathPrefix="/bookmarkthreads.php"/>
                 <data android:pathPrefix="/showthread.php"/>
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                       android:resource="@xml/shortcuts"/>
         </activity-alias>
 
         <activity-alias android:label="@string/app_name"
@@ -180,6 +188,8 @@
                 <data android:pathPrefix="/bookmarkthreads.php"/>
                 <data android:pathPrefix="/showthread.php"/>
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                       android:resource="@xml/shortcuts"/>
         </activity-alias>
 
         <activity-alias android:label="@string/app_name"
@@ -207,6 +217,8 @@
                 <data android:pathPrefix="/bookmarkthreads.php"/>
                 <data android:pathPrefix="/showthread.php"/>
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                       android:resource="@xml/shortcuts"/>
         </activity-alias>
         <!--
         This handles share intents, and is meant to run invisibly and separately in its own task (singleInstance)

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/NavigationEvent.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/NavigationEvent.kt
@@ -146,10 +146,12 @@ sealed class NavigationEvent(private val extraTypeId: String) {
 
         // the identifiers for each navigation type, added to and read from the app's intents, and the key used to store them
 
+        /** This is baked into shortcuts.xml, if you change the value here, change the value there */
         private const val EVENT_EXTRA_KEY = "navigation event"
         private const val TYPE_RE_AUTHENTICATE = "nav_re-auth"
         private const val TYPE_MAIN_ACTIVITY = "nav_main_activity"
         /** This one gets baked into the bookmarks widget when it's created, so if you change the value they'll have to be remade */
+        /** This is baked into shortcuts.xml, if you change the value here, change the value there */
         private const val TYPE_BOOKMARKS = "nav_bookmarks"
         private const val TYPE_FORUM_INDEX = "nav_forum_index"
         private const val TYPE_THREAD = "nav_thread"

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/UserCPShortcutActivity.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/UserCPShortcutActivity.kt
@@ -35,7 +35,6 @@ class UserCPShortcutActivity : Activity() {
         val shortcut = ShortcutInfoCompat.Builder(this, getString(R.string.awful_bookmarks_shortcut_id))
             .setIntent(shortcutIntent)
             .setShortLabel(name)
-            // TODO: doesn't support themed icons in this configuration. Unable to find a workaround right now.
             .setIcon(launcherIcon)
             .build()
 

--- a/Awful.apk/src/main/res/drawable/ic_baseline_bookmarks_24.xml
+++ b/Awful.apk/src/main/res/drawable/ic_baseline_bookmarks_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,18l2,1V3c0,-1.1 -0.9,-2 -2,-2H8.99C7.89,1 7,1.9 7,3h10c1.1,0 2,0.9 2,2v13zM15,5H5c-1.1,0 -2,0.9 -2,2v16l7,-3 7,3V7c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/Awful.apk/src/main/res/values-v25/attrs.xml
+++ b/Awful.apk/src/main/res/values-v25/attrs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="legacy_shortcut_creation">false</bool>
+</resources>

--- a/Awful.apk/src/main/res/values/attrs.xml
+++ b/Awful.apk/src/main/res/values/attrs.xml
@@ -4,4 +4,5 @@
         <attr name="status_message" format="string"/>
         <attr name="show_spinner" format="boolean"/>
     </declare-styleable>
+    <bool name="legacy_shortcut_creation">true</bool>
 </resources>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -4,7 +4,9 @@
     <!-- Share handling -->
     <string name="share_handler_no_url_found">This share isn\'t an Awful link!</string>
 
+    <!-- Legacy support for bookmarks shortcut -->
     <string name="awful_bookmarks_shortcut_id">awful-bookmarks-shortcut</string>
+
     <string name="awful_web_provider">AwfulWebProvider</string>
     <string name="cancel">Cancel</string>
     <string name="confirm">OK</string>

--- a/Awful.apk/src/main/res/xml/shortcuts.xml
+++ b/Awful.apk/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,15 @@
+<?xml-v25 version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="bookmarks"
+        android:shortcutShortLabel="@string/user_cp"
+        android:icon="@drawable/ic_baseline_bookmarks_24">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.ferg.awfulapp"
+            android:targetClass="com.ferg.awfulapp.ForumsIndexActivity">
+            <!-- Must match values in NavigationEvent.kt for EVENT_EXTRA_KEY and TYPE_BOOKMARKS -->
+            <extra android:name="navigation event" android:value="nav_bookmarks" />
+        </intent>
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Adds the bookmarks shortcut to Awful's static menu (see #765.) Since the shortcut directly references the production target package and class, the shortcut will only work to open the production version's bookmarks, *not* the debug version's bookmarks. This can lead to "App not installed" when tested on devices without the production version also installed.

Also, instead of completely removing the bookmarks widget, it's now only enabled for devices with API <=24, and doesn't show up in widget menus when API >=25. If this isn't satisfactory, I can update the commit to remove it entirely. Let me know! Thanks.