### PR TITLE
Add support for Cloudflare captcha challenges

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -12,16 +12,16 @@
       android:installLocation="auto">
     <supports-screens
         android:smallScreens="true"
-        android:normalScreens="true" 
-        android:largeScreens="true" 
-        android:anyDensity="true" 
+        android:normalScreens="true"
+        android:largeScreens="true"
+        android:anyDensity="true"
         />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-feature android:name="android.hardware.touchscreen" android:required="false" />
-    <application 
+    <application
 		android:label="@string/app_name"
 		android:name="com.ferg.awfulapp.AwfulApplication"
         android:allowBackup="true"
@@ -252,6 +252,9 @@
             android:windowSoftInputMode="adjustResize"
             android:configChanges="orientation|keyboardHidden|screenSize"
             />
+
+        <activity android:name="com.ferg.awfulapp.CaptchaActivity"
+            android:theme="@style/Theme.AppCompat.Light" />
 
         <!-- Legacy activity for API 24 and below, to create bookmarks shortcut.
              Isn't enabled until first launch on appropriate device. -->

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulActivity.kt
@@ -73,8 +73,14 @@ abstract class AwfulActivity : AppCompatActivity(), AwfulPreferences.AwfulPrefer
                 if (ignoreFormkey == null || userAvatarUrl == null) RefreshUserProfileRequest(this@AwfulActivity).sendBlind()
                 if (ignoreFormkey == null) FeatureRequest(this@AwfulActivity).sendBlind()
             }
-        // TODO: this interferes with the code in AwfulFragment#reAuthenticate - i.e. it forces "return to this activity" behaviour, but fragments may want to return to the main activity.
-        // And the activity isn't always the authority, e.g. using BasicActivity which is a plain container where all the specific behaviour is handled by its fragment. It's awkward
+
+            // When a captcha is being handled, the login screen should be suppressed. Solving
+            // captchas is required for logging in, so overriding the captcha view makes the app
+            // unusuable otherwise.
+            CaptchaActivity.isCaptchaBeingHandled() -> { /* do nothing */ }
+
+            // TODO: this interferes with the code in AwfulFragment#reAuthenticate - i.e. it forces "return to this activity" behaviour, but fragments may want to return to the main activity.
+            // And the activity isn't always the authority, e.g. using BasicActivity which is a plain container where all the specific behaviour is handled by its fragment. It's awkward
             this !is AwfulLoginActivity -> showLogIn(returnToMainActivity = false)
         }
     }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulApplication.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulApplication.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.StrictMode;
+import android.webkit.WebView;
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.ferg.awfulapp.announcements.AnnouncementsManager;
@@ -27,9 +28,36 @@ public class AwfulApplication extends Application {
     private static SharedPreferences appStatePrefs;
     private static boolean crashlyticsEnabled = false;
 
+    /**
+     * Stores the user agent used by web views in this application, which is required to be
+     * initialised early on to correctly handle Cloudflare captcha situations.
+     *
+     * If the user is affected by Cloudflare captchas, the user-agents of all HTTP requests coming
+     * from Awful must be synchronised. Setting a custom user-agent does not work, because
+     * Cloudflare only allows mainstream browser user-agents.
+     */
+    private static String AWFUL_USER_AGENT = null;
+
+    public static String getAwfulUserAgent() {
+        return AWFUL_USER_AGENT;
+    }
+
+    /**
+     * Instantiates an ephemeral WebView which is only used to retrieve the default user agent
+     * of web views on this system.
+     *
+     * @return User-Agent string of WebView instances on this system.
+     */
+    private String getWebViewUserAgent() {
+        WebView view = new WebView(getApplicationContext());
+        return view.getSettings().getUserAgentString();
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
+
+        AWFUL_USER_AGENT = getWebViewUserAgent();
 
         // initialise the AwfulPreferences singleton first since a lot of things rely on it for a Context
         AwfulPreferences mPref = AwfulPreferences.getInstance(this);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/AwfulLoginActivity.java
@@ -172,6 +172,8 @@ public class AwfulLoginActivity extends AwfulActivity {
 
             @Override
             public void failure(VolleyError error) {
+                CaptchaActivity.handleCaptchaChallenge(self, error);
+
                 // Volley sometimes generates NetworkErrors with no response set, or wraps them
                 NetworkResponse response = error.networkResponse;
                 if (response == null) {
@@ -182,12 +184,12 @@ public class AwfulLoginActivity extends AwfulActivity {
                 }
                 if (response != null && response.statusCode == HttpStatus.SC_MOVED_TEMPORARILY) {
                     Boolean result = CookieController.saveLoginCookies(getApplicationContext());
-                    if(result){
+                    if (result) {
                         // TODO: this should probably be handled by firing a ProfileRequest and getting the username from there, maybe through SyncManager
                         AwfulPreferences prefs = AwfulPreferences.getInstance(getApplicationContext());
                         prefs.setPreference(Keys.USERNAME, username);
                         onLoginSuccess();
-                    }else{
+                    } else {
                         onLoginFailed();
                     }
                 } else {
@@ -201,7 +203,8 @@ public class AwfulLoginActivity extends AwfulActivity {
                 setResult(Activity.RESULT_OK);
                 self.finish();
             }
-            private  void onLoginFailed(){
+
+            private void onLoginFailed() {
                 mDialog.dismiss();
                 Toast.makeText(AwfulLoginActivity.this, R.string.login_failed, Toast.LENGTH_SHORT).show();
                 setResult(Activity.RESULT_CANCELED);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/CaptchaActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/CaptchaActivity.java
@@ -28,18 +28,6 @@ import static com.ferg.awfulapp.constants.Constants.FUNCTION_INDEX;
  */
 public class CaptchaActivity extends AwfulActivity /* truly */ {
     /**
-     * User agent used by web views in the application.
-     *
-     * If the user is affected by Cloudflare captchas, the user-agents of the captcha web view and
-     * all AwfulRequests must be synchronised. Setting a custom user-agent does not work, because
-     * Cloudflare only allows mainstream browser user-agents.
-     *
-     * As a workaround, this class sets the captcha user agent when presenting a challenge to the
-     * user, and `AwfulRequest` then uses this user agent if it is present.
-     */
-    public static String captchaUserAgent = null;
-
-    /**
      * Informs other part of the application that captcha handling is in progress, which can be
      * used to suppress things like showing the login activity while the captcha handler is active.
      */
@@ -62,7 +50,6 @@ public class CaptchaActivity extends AwfulActivity /* truly */ {
 
         captchaView = (WebView) findViewById(R.id.captchaView);
         captchaView.getSettings().setJavaScriptEnabled(true);
-        captchaUserAgent = captchaView.getSettings().getUserAgentString();
 
         final CaptchaActivity activity = this;
         captchaView.setWebViewClient(new WebViewClient() {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/CaptchaActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/CaptchaActivity.java
@@ -1,5 +1,7 @@
 package com.ferg.awfulapp;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.webkit.CookieManager;
@@ -7,6 +9,8 @@ import android.webkit.ValueCallback;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import com.android.volley.NetworkResponse;
+import com.android.volley.VolleyError;
 import com.ferg.awfulapp.network.CookieController;
 
 import static com.ferg.awfulapp.constants.Constants.BASE_URL;
@@ -103,6 +107,24 @@ public class CaptchaActivity extends AwfulActivity /* truly */ {
         }
 
         return null;
+    }
+
+    /**
+     * Helper method to be called by activities that receive an error response. If the error was due
+     * to a captcha, the CaptchActivity will be invoked. Otherwise this does nothing.
+     */
+    public static void handleCaptchaChallenge(Activity sourceActivity, VolleyError error) {
+        NetworkResponse response = error.networkResponse;
+        if (response != null
+                && response.statusCode == 403
+                && response.headers != null
+                && response.headers.containsKey("cf-mitigated")) {
+            Log.i(TAG, "found captcha challenge, launching captcha activity");
+
+            final Intent captchaIntent = new Intent(sourceActivity, CaptchaActivity.class);
+            captchaIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            sourceActivity.startActivity(captchaIntent);
+        }
     }
 
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/CaptchaActivity.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/CaptchaActivity.java
@@ -60,29 +60,32 @@ public class CaptchaActivity extends AwfulActivity /* truly */ {
                     // whether we received a successful response. A workaround is checking
                     // whether markup that should be present on the index is there.
                     view.evaluateJavascript(
-                            "(function() { return document.body.id == 'something_awful'; })();",
-                            new ValueCallback<String>() {
-                                @Override
-                                public void onReceiveValue(String s) {
-                                    if (s.equals("true")) {
-                                        Log.d(TAG, "captcha finished successfully");
-                                        final String allCookies = CookieManager.getInstance().getCookie(BASE_URL);
-                                        final String captchaCookie = parseCaptchaCookie(allCookies);
+                            "(function() { return (document.body && document.body.id == 'something_awful'); })();",
+                            s -> {
+                                if (s.equals("true")) {
+                                    Log.d(TAG, "captcha finished successfully");
+                                    final String allCookies = CookieManager.getInstance().getCookie(BASE_URL);
+                                    final String captchaCookie = parseCaptchaCookie(allCookies);
 
-                                        if (captchaCookie != null) {
-                                            CookieController.setCaptchaCookie(captchaCookie);
-                                        } else {
-                                            Log.w(TAG, "captcha finished, but captcha cookie not set");
-                                        }
-
-                                        activity.finish();
+                                    if (captchaCookie != null) {
+                                        CookieController.setCaptchaCookie(captchaCookie);
+                                    } else {
+                                        Log.w(TAG, "captcha finished, but captcha cookie not set");
                                     }
+
+                                    activity.finish();
                                 }
                             });
                 }
             }
         });
 
+        captchaView.loadUrl(FUNCTION_INDEX);
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
         captchaView.loadUrl(FUNCTION_INDEX);
     }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -462,6 +462,7 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
 
                         @Override
                         public void failure(VolleyError error) {
+                            CaptchaActivity.handleCaptchaChallenge(getActivity(), error);
                             Timber.w("Failed to sync thread list!");
                             refreshInfo();
                             lastRefresh = System.currentTimeMillis();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -46,18 +46,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import com.ferg.awfulapp.search.SearchFilter;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import androidx.fragment.app.FragmentManager;
-import androidx.loader.app.LoaderManager;
-import androidx.core.content.ContextCompat;
-import androidx.loader.content.CursorLoader;
-import androidx.loader.content.Loader;
-import androidx.core.view.MenuItemCompat;
-import androidx.appcompat.widget.ShareActionProvider;
 import android.text.TextUtils;
 import android.text.format.Formatter;
 import android.view.InflateException;
@@ -68,7 +56,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.CookieManager;
-import android.webkit.CookieSyncManager;
 import android.webkit.DownloadListener;
 import android.webkit.JavascriptInterface;
 import android.webkit.WebView;
@@ -88,6 +75,7 @@ import com.ferg.awfulapp.preferences.Keys;
 import com.ferg.awfulapp.provider.AwfulProvider;
 import com.ferg.awfulapp.provider.AwfulTheme;
 import com.ferg.awfulapp.provider.ColorProvider;
+import com.ferg.awfulapp.search.SearchFilter;
 import com.ferg.awfulapp.task.AwfulRequest;
 import com.ferg.awfulapp.task.BookmarkRequest;
 import com.ferg.awfulapp.task.IgnoreRequest;
@@ -115,6 +103,7 @@ import com.ferg.awfulapp.webview.WebViewJsInterface;
 import com.ferg.awfulapp.widget.PageBar;
 import com.ferg.awfulapp.widget.PagePicker;
 import com.ferg.awfulapp.widget.WebViewSearchBar;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayout;
 import com.orangegangsters.github.swipyrefreshlayout.library.SwipyRefreshLayoutDirection;
 
@@ -131,6 +120,15 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.ShareActionProvider;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.MenuItemCompat;
+import androidx.fragment.app.FragmentManager;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
 import timber.log.Timber;
 
 /**
@@ -471,16 +469,14 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
         getLoaderManager().destroyLoader(Constants.POST_LOADER_ID);
     }
 
-    // TODO: fix deprecated warnings
-    private synchronized void refreshSessionCookie(){
-        if(mThreadView != null){
-        	CookieSyncManager.createInstance(getActivity());
-        	CookieManager cookieMonster = CookieManager.getInstance();
-        	cookieMonster.removeAllCookie();
-        	cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_SESSIONID));
-        	cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_SESSIONHASH));
-        	cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_USERID));
-        	cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_PASSWORD));
+	private synchronized void refreshSessionCookie(){
+		if(mThreadView != null){
+			CookieManager cookieMonster = CookieManager.getInstance();
+			cookieMonster.removeAllCookies(null /* status not interesting/actionable */);
+			cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_SESSIONID));
+			cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_SESSIONHASH));
+			cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_USERID));
+			cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_PASSWORD));
 
 			// Add the captcha cookie if it is present.
 			final String captchaCookie = CookieController.getCookieString(Constants.COOKIE_NAME_CAPTCHA);
@@ -488,10 +484,10 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 				cookieMonster.setCookie(Constants.COOKIE_DOMAIN_CAPTCHA, captchaCookie);
 			}
 
-        	cookieMonster.setAcceptThirdPartyCookies(mThreadView, true);
-        	CookieSyncManager.getInstance().sync();
-        }
-    }
+			cookieMonster.setAcceptThirdPartyCookies(mThreadView, true);
+			cookieMonster.flush();
+		}
+	}
  
     
     @Override

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -837,6 +837,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 
 				@Override
 				public void failure(VolleyError error) {
+					CaptchaActivity.handleCaptchaChallenge(activity, error);
 					Timber.w("Failed to sync thread! Error: %s", error.getMessage());
 					refreshInfo();
 					refreshPosts();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -481,6 +481,13 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
         	cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_SESSIONHASH));
         	cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_USERID));
         	cookieMonster.setCookie(Constants.COOKIE_DOMAIN, CookieController.getCookieString(Constants.COOKIE_NAME_PASSWORD));
+
+			// Add the captcha cookie if it is present.
+			final String captchaCookie = CookieController.getCookieString(Constants.COOKIE_NAME_CAPTCHA);
+			if (!captchaCookie.isEmpty()) {
+				cookieMonster.setCookie(Constants.COOKIE_DOMAIN_CAPTCHA, captchaCookie);
+			}
+
         	cookieMonster.setAcceptThirdPartyCookies(mThreadView, true);
         	CookieSyncManager.getInstance().sync();
         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
@@ -141,6 +141,10 @@ public class Constants {
 	public static final String COOKIE_PREF_EXPIRY_DATE = "expiration";
 	public static final String COOKIE_PREF_VERSION     = "version";
 
+    // Cloudflare cookie which is set after completing captcha challenges.
+    public static final String COOKIE_NAME_CAPTCHA = "cf_clearance";
+    public static final String COOKIE_DOMAIN_CAPTCHA = "somethingawful.com";
+
 	// Content provider
     public static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".provider";
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2011, Scott Ferguson
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -12,7 +12,7 @@
  *     * Neither the name of the software nor the
  *       names of its contributors may be used to endorse or promote products
  *       derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY SCOTT FERGUSON ''AS IS'' AND ANY
  * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -34,11 +34,10 @@ public class Constants {
 
     public static final String SITE_HTML_ENCODING = "CP1252";
 
-    //public static final String BASE_URL = "http://forums.somethingawful.com";
     public static final String BASE_URL = "https://forums.somethingawful.com";
 
     public static final String FUNCTION_LOGIN           = BASE_URL + "/account.php";
-    public static final String FUNCTION_LOGIN_SSL       = "https://forums.somethingawful.com/account.php";
+    public static final String FUNCTION_INDEX           = BASE_URL + "/index.php";
     public static final String FUNCTION_BOOKMARK        = BASE_URL + "/bookmarkthreads.php";
     public static final String FUNCTION_ANNOUNCEMENTS   = BASE_URL + "/announcement.php";
     public static final String FUNCTION_USERCP          = BASE_URL + "/usercp.php";
@@ -52,12 +51,12 @@ public class Constants {
     public static final String FUNCTION_PRIVATE_MESSAGE = BASE_URL + "/private.php";
     public static final String FUNCTION_BANLIST         = BASE_URL + "/banlist.php";
     public static final String FUNCTION_RATE_THREAD     = BASE_URL + "/threadrate.php";
-	public static final String FUNCTION_MISC 			= BASE_URL + "/misc.php";
+    public static final String FUNCTION_MISC            = BASE_URL + "/misc.php";
     public static final String FUNCTION_REPORT 			= BASE_URL + "/modalert.php";
     public static final String FUNCTION_POSTINGS 		= BASE_URL + "/postings.php";
     public static final String FUNCTION_NEW_THREAD 		= BASE_URL + "/newthread.php";
 
-	public static final String PATH_FORUM 				= "forumdisplay.php";
+    public static final String PATH_FORUM 				= "forumdisplay.php";
     public static final String PATH_THREAD          	= "showthread.php";
     public static final String PATH_BOOKMARKS          	= "bookmarkthreads.php";
     public static final String PATH_USERCP          	= "usercp.php";
@@ -71,7 +70,7 @@ public class Constants {
     public static final String ACTION_QUERY 			  = "query";
     public static final String ACTION_RESULTS 			  = "results";
     public static final String ACTION_TOGGLE_THREAD_LOCKED = "openclosethread";
-    
+
     public static final String PARAM_USER_ID   = "userid";
     public static final String PARAM_USERNAME  = "username";
     public static final String PARAM_PASSWORD  = "password";
@@ -101,11 +100,11 @@ public class Constants {
 
 	public static final String USERLIST_IGNORE = "ignore";
 	public static final String USERLIST_BUDDY  = "buddy";
-	
+
 	public static final String VALUE_POST 	   = "post";
 	public static final String VALUE_NEWPOST   = "newpost";
 	public static final String VALUE_LASTPOST  = "lastpost";
-    
+
     public static final String FRAGMENT_PTI    = "pti";
 
     // Intent parameters
@@ -126,14 +125,14 @@ public class Constants {
     public static final String FORMKEY  = "formkey";
 
     public static final String PREFERENCES = "prefs";
-    
+
 	public static final String COOKIE_DOMAIN        = "forums.somethingawful.com";
 	public static final String COOKIE_PATH          = "/";
 	public static final String COOKIE_NAME_USERID   = "bbuserid";
 	public static final String COOKIE_NAME_PASSWORD = "bbpassword";
 	public static final String COOKIE_NAME_SESSIONID = "sessionid";
 	public static final String COOKIE_NAME_SESSIONHASH = "sessionhash";
-	
+
 	public static final String COOKIE_PREFERENCE       = "awful_cookie_pref";
 	public static final String COOKIE_PREF_USERID      = "bbuserid";
 	public static final String COOKIE_PREF_PASSWORD    = "bbpassword";
@@ -144,7 +143,7 @@ public class Constants {
 
 	// Content provider
     public static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".provider";
-    
+
     //default per-page, user configurable
     public static final int ITEMS_PER_PAGE = 40;
     //we can have up to 80 threads per forum page (SAMart)
@@ -186,7 +185,7 @@ public class Constants {
     public static final String PREVIEW_REPLY = "Preview Reply";
 
 	public static final String YES = "yes";//heh
-	
+
 	//NOT FOR NETWORK USE
 	public static final String FORUM_PAGE = "forum_page";
 	//NOT FOR NETWORK USE
@@ -197,12 +196,12 @@ public class Constants {
 	public static final int DEFAULT_FONT_SIZE_SP = 16;
     public static final int DEFAULT_FIXED_FONT_SIZE_SP = 13;
     public static final int MINIMUM_FONT_SIZE_SP = 5;
-	
+
 	public static final double TABLET_MIN_SIZE = 7; //everything above this is considered tablet layout
 
     public static final String REPLY_POST_ID = "reply_post_id";
     public static final String REPLY_THREAD_ID = "reply_thread_id";
-    
+
     public static final int AWFUL_THREAD_ID = 3571717;
     public static final int FORUM_ID_SHSC = 22;
     public static final int FORUM_ID_YOSPOS = 219;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/AwfulImageLoader.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/AwfulImageLoader.java
@@ -7,6 +7,7 @@ import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.ImageLoader;
 import com.android.volley.toolbox.ImageRequest;
+import com.ferg.awfulapp.AwfulApplication;
 import com.ferg.awfulapp.CaptchaActivity;
 
 import java.util.HashMap;
@@ -38,10 +39,7 @@ public class AwfulImageLoader extends ImageLoader {
             @Override
             public Map<String, String> getHeaders() {
                 final Map<String, String> headers = new HashMap<>();
-
-                if (CaptchaActivity.captchaUserAgent != null) {
-                    headers.put("User-Agent", CaptchaActivity.captchaUserAgent);
-                }
+                headers.put("User-Agent", AwfulApplication.getAwfulUserAgent());
 
                 final Optional<String> captchaCookie = CookieController.getCaptchaCookie();
                 if (captchaCookie.isPresent()) {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/AwfulImageLoader.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/AwfulImageLoader.java
@@ -1,0 +1,55 @@
+package com.ferg.awfulapp.network;
+
+import android.graphics.Bitmap;
+import android.widget.ImageView;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.ImageLoader;
+import com.android.volley.toolbox.ImageRequest;
+import com.ferg.awfulapp.CaptchaActivity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Image loader that can set Cloudflare captcha related headers on requests, which are also required
+ * on `fi.somethingawful.com`. See `CaptchaActivity` and related classes for more details on the
+ * captcha situation.
+ */
+public class AwfulImageLoader extends ImageLoader {
+    /**
+     * Constructs a new ImageLoader.
+     *
+     * @param queue      The RequestQueue to use for making image requests.
+     * @param imageCache The cache to use as an L1 cache.
+     */
+    public AwfulImageLoader(RequestQueue queue, ImageCache imageCache) {
+        super(queue, imageCache);
+    }
+
+    @Override
+    protected Request<Bitmap> makeImageRequest(String requestUrl, int maxWidth, int maxHeight,
+                                               ImageView.ScaleType scaleType, final String cacheKey) {
+        return new ImageRequest(requestUrl, response ->
+                onGetImageSuccess(cacheKey, response), maxWidth, maxHeight, scaleType, Bitmap.Config.RGB_565, error ->
+                onGetImageError(cacheKey, error)) {
+            @Override
+            public Map<String, String> getHeaders() {
+                final Map<String, String> headers = new HashMap<>();
+
+                if (CaptchaActivity.captchaUserAgent != null) {
+                    headers.put("User-Agent", CaptchaActivity.captchaUserAgent);
+                }
+
+                final Optional<String> captchaCookie = CookieController.getCaptchaCookie();
+                if (captchaCookie.isPresent()) {
+                    headers.put("Cookie", captchaCookie.get());
+                }
+
+                return headers;
+            }
+        };
+    }
+}

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/CookieController.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/CookieController.java
@@ -243,7 +243,7 @@ public class CookieController {
      * If the Cloudflare captcha cookie is set, return it so that it can be appended to the provided
      * cookies.
      */
-    private static Optional<String> getCaptchaCookie() {
+    public static Optional<String> getCaptchaCookie() {
         // It seems like there is no direct accessor for a specific cookie, so this little dance has
         // to be done all the time to find the right one.
         for (HttpCookie c : cookieManager.getCookieStore().get(uri)) {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/network/NetworkUtils.java
@@ -61,7 +61,7 @@ public class NetworkUtils {
 
     private static RequestQueue mNetworkQueue;
     private static LRUImageCache mImageCache;
-    private static ImageLoader mImageLoader;
+    private static AwfulImageLoader mImageLoader;
 
     /**
      * Initialise request handling and caching - call this early!
@@ -74,7 +74,7 @@ public class NetworkUtils {
         mNetworkQueue = Volley.newRequestQueue(context);
         // TODO: find out if this is even being used anywhere
         mImageCache = new LRUImageCache();
-        mImageLoader = new ImageLoader(mNetworkQueue, mImageCache);
+        mImageLoader = new AwfulImageLoader(mNetworkQueue, mImageCache);
 
         try {
             HttpResponseCache.install(new File(context.getCacheDir(), "httpcache"), 5242880);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.kt
@@ -10,6 +10,7 @@ import androidx.annotation.UiThread
 import com.android.volley.*
 import com.android.volley.toolbox.HttpHeaderParser
 import com.ferg.awfulapp.AwfulApplication
+import com.ferg.awfulapp.CaptchaActivity
 import com.ferg.awfulapp.R
 import com.ferg.awfulapp.constants.Constants.BASE_URL
 import com.ferg.awfulapp.constants.Constants.SITE_HTML_ENCODING
@@ -317,8 +318,15 @@ abstract class AwfulRequest<T>(protected val context: Context, private val baseU
 
         @Throws(AuthFailureError::class)
         override fun getHeaders(): Map<String, String> {
-            return mutableMapOf<String, String>().apply(CookieController::setCookieHeaders)
-                    .also { Timber.i("getHeaders: %s", this) }
+            val headers = mutableMapOf<String, String>()
+                .apply(CookieController::setCookieHeaders)
+
+            CaptchaActivity.captchaUserAgent?.let {
+                headers.put("User-Agent", it)
+            }
+
+            return headers
+                .also { Timber.i("getHeaders: %s", this) };
         }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.kt
@@ -318,17 +318,10 @@ abstract class AwfulRequest<T>(protected val context: Context, private val baseU
 
         @Throws(AuthFailureError::class)
         override fun getHeaders(): Map<String, String> {
-            val headers = mutableMapOf<String, String>()
+            return mutableMapOf<String, String>("User-Agent" to AwfulApplication.getAwfulUserAgent())
                 .apply(CookieController::setCookieHeaders)
-
-            CaptchaActivity.captchaUserAgent?.let {
-                headers.put("User-Agent", it)
-            }
-
-            return headers
                 .also { Timber.i("getHeaders: %s", this) };
         }
-
 
         @Throws(AuthFailureError::class)
         override fun getBody(): ByteArray {

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/AwfulRequest.kt
@@ -284,7 +284,13 @@ abstract class AwfulRequest<T>(protected val context: Context, private val baseU
                         append("(null VolleyError)")
                     } else {
                         Timber.e(volleyError)
-                        append(cause?.message ?: "unknown cause")
+
+                        if (networkResponse?.headers?.get("cf-mitigated") == "challenge") {
+                            append("captcha requested")
+                        } else {
+                            append(cause?.message ?: "unknown cause")
+                        }
+
                         networkResponse?.let { append("\nStatus code: ${networkResponse.statusCode}") }
                     }
                     Timber.e(toString())

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/LoginRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/LoginRequest.kt
@@ -13,7 +13,7 @@ import org.jsoup.nodes.Document
  * the current username if successful.
  */
 class LoginRequest(context: Context, private val username: String, password: String)
-    : AwfulRequest<Boolean>(context, FUNCTION_LOGIN_SSL, isPostRequest = true) {
+    : AwfulRequest<Boolean>(context, FUNCTION_LOGIN, isPostRequest = true) {
 
     init {
         with(parameters) {

--- a/Awful.apk/src/main/res/layout/captcha_activity.xml
+++ b/Awful.apk/src/main/res/layout/captcha_activity.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/captchaView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This change implements a new activity which can display captcha challenges to users and synchronise the relevant cookie and user-agent data to make requests succeed after a captcha challenge. I made a [demo video](https://tazj.in/blobs/awful-captcha.mp4).

This fixes #776. Please see that issue for some more context.

The change is fairly complex, I suggest reviewing the individual commits in order. Each commit has a detailed description of what it does and why.

There are several issues with this implementation:

* ~~The user-agent synchronisation requires a web view to be instantiated, which can only occur inside of an activity. The only activity where this was reasonable to do is `CaptchaActivity`. This means that after a restart of the app, even if the captcha clearance is still valid, the user will briefly see a flash of the forums index page.~~

  Fixed by initialising the user-agent on app launch in the `AwfulApplication` class.
* The user always sees a flash of the forums index page after solving a captcha, which is due to the cumbersome method of detecting whether a request in a `WebView` succeeded.
* The handler for invoking the captcha challenge can not easily be installed in a central location, so it's done in some specific places (login, forums refresh, thread reload) which should cover most use-cases.
* ~~I haven't figured out how forum icons are loaded, they don't seem to be going through `AwfulRequest`, so they're not using the user-agent and cookie that they should. This means that they fail and a placeholder is displayed on captcha'd connections.~~
  
  Update: Fixed by adding `AwfulImageLoader` class.
* ~~Avatars and smilies don't load. They seem to be loaded in another kind of web view that isn't using the right settings.~~ Fixed in the web view for thread display.
* Sometimes on repeated captcha prompts, the captcha page is just white and doesn't display anything. No idea what's going on there, the Chrome inspector thing shows that it's actually a Cloudflare page that's just ... empty. This goes away after restarting the app. I have no idea what state in the app leads to this occuring.

Still, this is a lot better than before as with this change Awful goes from unusable to usable in non-Western countries (it was previously unusable in China, Russia, ...) and on connections to popular VPN providers which trigger captcha challenges. The issues listed above can be addressed in follow-up changes.