### PR TITLE
Add Thread list setting to remove hidden threads from thread list

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -338,6 +338,7 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
                 return true;
             case R.id.toggle_hidden_thread:
                 toggleHiddenThread(threadId);
+                refreshInfo();
                 return true;
         }
 
@@ -642,6 +643,10 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
             } else {
                 selection = String.format("%s=? AND %s>=? AND %s<?",
                         AwfulThread.FORUM_ID, AwfulThread.INDEX, AwfulThread.INDEX);
+                if (!getPrefs().showHiddenThreads) {
+                    selection += String.format(" AND %s NOT IN (%s)",
+                            DatabaseHelper.TABLE_THREADS + "." + AwfulThread.ID, String.join(",", getPrefs().hiddenThreadIds));
+                }
                 selectionArgs = AwfulProvider.int2StrArray(getForumId(), thisPageIndex, nextPageIndex);
             }
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
@@ -136,6 +136,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
     public boolean alwaysOpenUrls;
     public Set<String> blockedAvatarUrls;
     public Set<String> hiddenThreadIds;
+    public boolean showHiddenThreads;
 
     //FORUM STUFF
     public boolean newThreadsFirstUCP;
@@ -293,6 +294,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
         alwaysOpenUrls	 	 	 = getPreference(Keys.ALWAYS_OPEN_URLS, false);
         blockedAvatarUrls        = getPreference(Keys.BLOCKED_AVATAR_URLS, Collections.emptySet());
         hiddenThreadIds 		 = getPreference(Keys.HIDDEN_THREAD_IDS, Collections.emptySet());
+        showHiddenThreads 		 = getPreference(Keys.SHOW_HIDDEN_THREADS, true);
         lockScrolling			 = getPreference(Keys.LOCK_SCROLLING, false);
         disableTimgs			 = getPreference(Keys.DISABLE_TIMGS, false);
         currPrefVersion          = getPreference(Keys.CURR_PREF_VERSION, 0);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
@@ -139,7 +139,8 @@ public abstract class Keys {
             FORUM_INDEX_SHOW_SUBTITLES,
             FORUM_INDEX_HIDE_SUBFORUMS,
             POST_WARNING_ACCEPTED,
-            PROBATION_IGNORE
+            PROBATION_IGNORE,
+            SHOW_HIDDEN_THREADS
     })
     @Retention(RetentionPolicy.SOURCE)
     public @interface BooleanPreference {
@@ -231,6 +232,7 @@ public abstract class Keys {
     public static final int MARKED_USERS = R.string.pref_key_marked_users;
     public static final int BLOCKED_AVATAR_URLS = R.string.pref_key_blocked_avatar_urls;
     public static final int HIDDEN_THREAD_IDS = R.string.pref_key_hidden_thread_ids;
+    public static final int SHOW_HIDDEN_THREADS = R.string.pref_key_show_hidden_threads;
 
     public static final int POST_WARNING_ACCEPTED = R.string.pref_key_post_warning_accepted;
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
@@ -23,7 +23,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final int DATABASE_VERSION = 37;
 
     static final String TABLE_FORUM    = "forum";
-    static final String TABLE_THREADS    = "threads";
+    public static final String TABLE_THREADS    = "threads";
     // TODO: 06/05/2017 this is only public because a fragment is building selection arguments - move that out of there!
     public static final String TABLE_UCP_THREADS    = "ucp_thread";
     static final String TABLE_POSTS    = "posts";

--- a/Awful.apk/src/main/res/values/preference_keys.xml
+++ b/Awful.apk/src/main/res/values/preference_keys.xml
@@ -61,6 +61,7 @@
     <string name="pref_key_always_open_urls">always_open_urls</string>
     <string name="pref_key_blocked_avatar_urls">blocked_avatar_urls</string>
     <string name="pref_key_hidden_thread_ids">hidden_thread_ids</string>
+    <string name="pref_key_show_hidden_threads">show_hidden_threads</string>
     <string name="pref_key_lock_scrolling">lock_scrolling</string>
     <string name="pref_key_disable_timgs">disable_timgs</string>
     <string name="pref_key_disable_pull_next">disable_pull_next</string>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -366,6 +366,7 @@
     <string name="color_bookmarks">Color bookmarks</string>
     <string name="color_bookmarks_summary">Use \'star\' colors for unread post counts</string>
     <string name="threadinfo_rating">Show thread ratings</string>
+    <string name="show_hidden_threads">Show hidden threads</string>
     <string name="new_threads_first_category">Sort by unread</string>
     <string name="new_threads_first_ucp">Bookmarks view</string>
     <string name="new_threads_first_ucp_summary">Show threads with unread posts first</string>

--- a/Awful.apk/src/main/res/xml/threadinfosettings.xml
+++ b/Awful.apk/src/main/res/xml/threadinfosettings.xml
@@ -21,7 +21,12 @@
           android:title="@string/threadinfo_rating"
           android:defaultValue="true"
           />
-      <PreferenceCategory
+		<SwitchPreference
+			android:defaultValue="true"
+			android:key="@string/pref_key_show_hidden_threads"
+			android:title="@string/show_hidden_threads"
+			app:iconSpaceReserved="false" />
+	<PreferenceCategory
 		  app:iconSpaceReserved="false"
 		  android:title="@string/new_threads_first_category">
           <SwitchPreference


### PR DESCRIPTION
feature request:
- https://forums.somethingawful.com/showthread.php?goto=post&postid=545106817#post545106817
- https://forums.somethingawful.com/showthread.php?goto=post&postid=545422154#post545422154

Hidden threads will have a visible placeholder by default (current behavior), but a new toggle setting in `Settings > Thread list > Show hidden threads` allows the placeholders to be removed

[show-hidden-threads.webm](https://github.com/user-attachments/assets/023eed7b-c0c9-4a5f-b0d6-4f9bb85644fc)

In the extreme edge case that all threads on a page are hidden, the page is blank but otherwise works:

[edge-case-empty-page.webm](https://github.com/user-attachments/assets/da70967a-50ab-4bbd-80da-7f71647c46d1)
