### PR TITLE
highlight the user's own threads

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/AwfulPreferences.java
@@ -143,6 +143,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
     public boolean newThreadsFirstForum;
     public boolean threadInfo_Rating;
     public boolean threadInfo_Tag;
+    public boolean highlightYourThreads;
     public boolean forumIndexShowSections;
 	public boolean forumIndexShowSubtitles;
 	public boolean forumIndexHideSubforums;
@@ -280,6 +281,7 @@ public class AwfulPreferences implements OnSharedPreferenceChangeListener {
         showAllSpoilers			 = getPreference(Keys.SHOW_ALL_SPOILERS, false);
         threadInfo_Rating		 = getPreference(Keys.THREAD_INFO_RATING, true);
         threadInfo_Tag		 	 = getPreference(Keys.THREAD_INFO_TAG, true);
+		highlightYourThreads	 = getPreference(Keys.HIGHLIGHT_YOUR_THREADS, true);
 		imgurAccount			 = getPreference(Keys.IMGUR_ACCOUNT, (String) null);
 		imgurAccountToken		 = getPreference(Keys.IMGUR_ACCOUNT_TOKEN, (String) null);
 		imgurRefreshToken		 = getPreference(Keys.IMGUR_REFRESH_TOKEN, (String) null);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/preferences/Keys.java
@@ -140,7 +140,8 @@ public abstract class Keys {
             FORUM_INDEX_HIDE_SUBFORUMS,
             POST_WARNING_ACCEPTED,
             PROBATION_IGNORE,
-            SHOW_HIDDEN_THREADS
+            SHOW_HIDDEN_THREADS,
+            HIGHLIGHT_YOUR_THREADS
     })
     @Retention(RetentionPolicy.SOURCE)
     public @interface BooleanPreference {
@@ -233,6 +234,7 @@ public abstract class Keys {
     public static final int BLOCKED_AVATAR_URLS = R.string.pref_key_blocked_avatar_urls;
     public static final int HIDDEN_THREAD_IDS = R.string.pref_key_hidden_thread_ids;
     public static final int SHOW_HIDDEN_THREADS = R.string.pref_key_show_hidden_threads;
+    public static final int HIGHLIGHT_YOUR_THREADS = R.string.pref_key_highlight_your_threads;
 
     public static final int POST_WARNING_ACCEPTED = R.string.pref_key_post_warning_accepted;
 }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/ColorProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/ColorProvider.java
@@ -35,7 +35,8 @@ public enum ColorProvider {
     UNREAD_TEXT(R.attr.unreadFontColor),
     ACTION_BAR(R.attr.actionBarColor),
     ACTION_BAR_TEXT(R.attr.actionBarFontColor),
-    PROGRESS_BAR(R.attr.progressBarColor);
+    PROGRESS_BAR(R.attr.progressBarColor),
+    SELF_THREAD_BACKGROUND(R.attr.selfThreadBackground);
 
     private static final int[] BOOKMARK_COLORS = getColorResIds(R.array.bookmarkColors);
     private static final int[] BOOKMARK_COLORS_DIM = getColorResIds(R.array.bookmarkDimColors);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -308,6 +308,13 @@ public class AwfulThread extends AwfulPagedItem  {
         }
 
 
+        // highlight threads authored by the current user
+        if (prefs.highlightYourThreads && prefs.userId > 0 && thread.authorId == prefs.userId) {
+            item.setBackgroundColor(ColorProvider.SELF_THREAD_BACKGROUND.getColor(forumId));
+        } else {
+            item.setBackgroundColor(ColorProvider.BACKGROUND.getColor(forumId));
+        }
+
         // thread title
         TextView title  = item.findViewById(R.id.title);
         title.setText(thread.title != null ? thread.title : "UNKNOWN");

--- a/Awful.apk/src/main/res/values/colors.xml
+++ b/Awful.apk/src/main/res/values/colors.xml
@@ -53,6 +53,10 @@
 
     <color name="default_srl_background_color">#FFFAFAFA</color>
 
+    <color name="self_thread_default">#ECFFD9</color>
+    <color name="self_thread_dark">#1A2800</color>
+    <color name="self_thread_oled">#1E0E00</color>
+
 
     <!-- Bookmark colours for stars/unread counters -->
     <integer-array name="bookmarkColors">

--- a/Awful.apk/src/main/res/values/preference_keys.xml
+++ b/Awful.apk/src/main/res/values/preference_keys.xml
@@ -52,6 +52,7 @@
     <string name="pref_key_show_all_spoilers">show_all_spoilers</string>
     <string name="pref_key_thread_info_rating">threadinfo_rating</string>
     <string name="pref_key_thread_info_tag">threadinfo_tag</string>
+    <string name="pref_key_highlight_your_threads">highlight_your_threads</string>
     <string name="pref_key_new_threads_first_ucp">new_threads_first_ucp</string>
     <string name="pref_key_new_threads_first_forum">new_threads_first_forum</string>
     <string name="pref_key_upper_next_arrow">upper_next_arrow</string>

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -366,6 +366,8 @@
     <string name="color_bookmarks">Color bookmarks</string>
     <string name="color_bookmarks_summary">Use \'star\' colors for unread post counts</string>
     <string name="threadinfo_rating">Show thread ratings</string>
+    <string name="highlight_your_threads">Highlight your threads</string>
+    <string name="highlight_your_threads_summary">Tint background of threads you created</string>
     <string name="show_hidden_threads">Show hidden threads</string>
     <string name="new_threads_first_category">Sort by unread</string>
     <string name="new_threads_first_ucp">Bookmarks view</string>

--- a/Awful.apk/src/main/res/values/themes.xml
+++ b/Awful.apk/src/main/res/values/themes.xml
@@ -55,6 +55,7 @@
         <item name="srlBackgroundColor">@color/default_srl_background_color</item>
         <item name="srlProgressColors">@array/defaultSrlProgressColors</item>
         <item name="android:listDivider">@color/alt_background</item>
+        <item name="selfThreadBackground">@color/self_thread_default</item>
 
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
         <item name="android:actionOverflowButtonStyle">@style/Base.Widget.AppCompat.ActionButton.Overflow</item>
@@ -108,6 +109,7 @@
         <item name="srlBackgroundColor">@color/dark_alt_background</item>
         <item name="srlProgressColors">@array/darkSrlProgressColors</item>
         <item name="android:listDivider">@color/dark_header_background</item>
+        <item name="selfThreadBackground">@color/self_thread_dark</item>
 
         <item name="drawerArrowStyle">@style/DrawerArrowStyle</item>
         <item name="awfulPopUpTheme">@style/ThemeOverlay.AppCompat</item>
@@ -118,6 +120,7 @@
 
     <style name="Theme.AwfulTheme.OLED" parent="Theme.AwfulTheme.Dark">
         <item name="background">@android:color/black</item>
+        <item name="selfThreadBackground">@color/self_thread_oled</item>
 
         <item name="colorPrimary">?background</item>
         <item name="colorPrimaryDark">?background</item>

--- a/Awful.apk/src/main/res/values/values.xml
+++ b/Awful.apk/src/main/res/values/values.xml
@@ -47,4 +47,6 @@
     <attr name="srlBackgroundColor" format="color"/>
     <!-- Foreground colour for the spinning loading icon. This should point to an array of colour references -->
     <attr name="srlProgressColors" format="reference" />
+    <!-- Background colour for threads authored by the current user -->
+    <attr name="selfThreadBackground" format="color"/>
 </resources>

--- a/Awful.apk/src/main/res/xml/threadinfosettings.xml
+++ b/Awful.apk/src/main/res/xml/threadinfosettings.xml
@@ -22,6 +22,12 @@
           android:defaultValue="true"
           />
 		<SwitchPreference
+			app:iconSpaceReserved="false"
+			android:key="@string/pref_key_highlight_your_threads"
+			android:title="@string/highlight_your_threads"
+			android:summary="@string/highlight_your_threads_summary"
+			android:defaultValue="true" />
+		<SwitchPreference
 			android:defaultValue="true"
 			android:key="@string/pref_key_show_hidden_threads"
 			android:title="@string/show_hidden_threads"


### PR DESCRIPTION
this change highlights the user's created threads in the thread list, with a toggle to turn it off
tried to follow all of the conventions laid out already, and this was straightforward, but let me know if i need to fix anything