### PR TITLE
Improve Twitter embeds

### DIFF
--- a/Awful.apk/src/main/assets/javascript/embedding.js
+++ b/Awful.apk/src/main/assets/javascript/embedding.js
@@ -99,6 +99,8 @@ function processThreadEmbeds(replacementArea) {
 
 	function replaceTweets(twitterDomain, urlMatchRegex) {
 		window._oembedCache = window._oembedCache || {};
+		window._oembedPending = window._oembedPending || {};
+		var isDark = document.getElementById('theme-css').dataset.darkTheme === 'true';
 		var tweets = replacementArea.querySelectorAll('.postcontent a[href*="' + twitterDomain + '"]');
 
 		tweets = Array.prototype.reduce.call(tweets, function reduceTweets(filteredTwoops, twitterURL) {
@@ -112,7 +114,6 @@ function processThreadEmbeds(replacementArea) {
 
 		tweets.forEach(function eachTweet(tweet) {
 			var tweetUrl = tweet.href;
-			var isDark = document.getElementById('theme-css').dataset.darkTheme === 'true';
 
 			function insertTweet(html) {
 				var div = document.createElement('div');
@@ -130,7 +131,7 @@ function processThreadEmbeds(replacementArea) {
 				}
 			}
 
-			function insertErrorEmbed(message) {
+			function buildErrorHtml(message) {
 				var bg = isDark ? '#15202b' : '#ffffff';
 				var border = isDark ? '#38444d' : '#cfd9de';
 				var textColor = isDark ? '#8b98a5' : '#536471';
@@ -149,12 +150,7 @@ function processThreadEmbeds(replacementArea) {
 
 				link.appendChild(urlLine);
 				link.appendChild(messageLine);
-
-				var div = document.createElement('div');
-				div.classList.add('tweet');
-				tweet.parentNode.replaceChild(div, tweet);
-				div.appendChild(link);
-				window._oembedCache[tweetUrl] = div.innerHTML;
+				return link.outerHTML;
 			}
 
 			if (window._oembedCache[tweetUrl]) {
@@ -162,32 +158,44 @@ function processThreadEmbeds(replacementArea) {
 				return;
 			}
 
-			fetch('https://publish.' + twitterDomain + '/oembed?omit_script=true&url=' + escape(tweetUrl))
-				.then(function checkResponse(response) {
-					if (!response.ok) {
-						if (response.status === 404) {
-							insertErrorEmbed('This tweet has been deleted.');
-							return null;
+			if (!window._oembedPending[tweetUrl]) {
+				window._oembedPending[tweetUrl] = fetch('https://publish.' + twitterDomain + '/oembed?omit_script=true&url=' + escape(tweetUrl))
+					.then(function checkResponse(response) {
+						if (!response.ok) {
+							if (response.status === 404) {
+								return buildErrorHtml('This tweet has been deleted.');
+							}
+							return response.json().then(function(data) {
+								var message = (data && data.error) ? data.error : 'Failed to load tweet (HTTP ' + response.status + ').';
+								return buildErrorHtml(message);
+							}).catch(function() {
+								return buildErrorHtml('Failed to load tweet (HTTP ' + response.status + ').');
+							});
 						}
 						return response.json().then(function(data) {
-							var message = (data && data.error) ? data.error : 'Failed to load tweet (HTTP ' + response.status + ').';
-							insertErrorEmbed(message);
-							return null;
-						}).catch(function() {
-							insertErrorEmbed('Failed to load tweet (HTTP ' + response.status + ').');
-							return null;
+							return (data && data.html) ? data.html : null;
 						});
-					}
-					return response.json();
-				})
-				.then(function handleData(data) {
-					if (!data || !data.html) { return; }
-					window._oembedCache[tweetUrl] = data.html;
-					insertTweet(data.html);
-				})
-				.catch(function handleError(error) {
-					insertErrorEmbed('Failed to load tweet (network error).');
-				});
+					})
+					.then(function cacheResult(html) {
+						delete window._oembedPending[tweetUrl];
+						if (html) {
+							window._oembedCache[tweetUrl] = html;
+						}
+						return html;
+					})
+					.catch(function handleError(error) {
+						delete window._oembedPending[tweetUrl];
+						var html = buildErrorHtml('Failed to load tweet (network error).');
+						window._oembedCache[tweetUrl] = html;
+						return html;
+					});
+			}
+
+			window._oembedPending[tweetUrl].then(function(html) {
+				if (html) {
+					insertTweet(html);
+				}
+			});
 		});
 	}
 

--- a/Awful.apk/src/main/assets/javascript/embedding.js
+++ b/Awful.apk/src/main/assets/javascript/embedding.js
@@ -98,6 +98,7 @@ function processThreadEmbeds(replacementArea) {
 	}
 
 	function replaceTweets(twitterDomain, urlMatchRegex) {
+		window._oembedCache = window._oembedCache || {};
 		var tweets = replacementArea.querySelectorAll('.postcontent a[href*="' + twitterDomain + '"]');
 
 		tweets = Array.prototype.reduce.call(tweets, function reduceTweets(filteredTwoops, twitterURL) {
@@ -111,20 +112,82 @@ function processThreadEmbeds(replacementArea) {
 
 		tweets.forEach(function eachTweet(tweet) {
 			var tweetUrl = tweet.href;
-			JSONP.get('https://publish.' + twitterDomain + '/oembed?omit_script=true&url=' + escape(tweetUrl), {}, function getTworts(data) {
+			var isDark = document.getElementById('theme-css').dataset.darkTheme === 'true';
+
+			function insertTweet(html) {
 				var div = document.createElement('div');
 				div.classList.add('tweet');
 				tweet.parentNode.replaceChild(div, tweet);
-				div.innerHTML = data.html;
-				if (document.getElementById('theme-css').dataset.darkTheme === 'true') {
-					div.querySelector('blockquote').dataset.theme = 'dark';
+				div.innerHTML = html;
+				var bq = div.querySelector('blockquote');
+				if (bq && isDark) {
+					bq.dataset.theme = 'dark';
 				}
 				if (window.twttr.init) {
 					window.twttr.widgets.load(div);
 				} else {
 					window.missedEmbeds.push(div);
 				}
-			});
+			}
+
+			function insertErrorEmbed(message) {
+				var bg = isDark ? '#15202b' : '#ffffff';
+				var border = isDark ? '#38444d' : '#cfd9de';
+				var textColor = isDark ? '#8b98a5' : '#536471';
+
+				var link = document.createElement('a');
+				link.href = tweetUrl;
+				link.style.cssText = 'display:block;border:1px solid ' + border + ';border-radius:12px;padding:16px;margin:8px 0;background:' + bg + ';font-family:-apple-system,BlinkMacSystemFont,sans-serif;text-decoration:none';
+
+				var urlLine = document.createElement('span');
+				urlLine.textContent = tweetUrl;
+				urlLine.style.cssText = 'display:block;color:#1d9bf0;font-size:13px;margin-bottom:8px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap';
+
+				var messageLine = document.createElement('p');
+				messageLine.textContent = message;
+				messageLine.style.cssText = 'color:' + textColor + ';margin:0;font-size:14px';
+
+				link.appendChild(urlLine);
+				link.appendChild(messageLine);
+
+				var div = document.createElement('div');
+				div.classList.add('tweet');
+				tweet.parentNode.replaceChild(div, tweet);
+				div.appendChild(link);
+				window._oembedCache[tweetUrl] = div.innerHTML;
+			}
+
+			if (window._oembedCache[tweetUrl]) {
+				insertTweet(window._oembedCache[tweetUrl]);
+				return;
+			}
+
+			fetch('https://publish.' + twitterDomain + '/oembed?omit_script=true&url=' + escape(tweetUrl))
+				.then(function checkResponse(response) {
+					if (!response.ok) {
+						if (response.status === 404) {
+							insertErrorEmbed('This tweet has been deleted.');
+							return null;
+						}
+						return response.json().then(function(data) {
+							var message = (data && data.error) ? data.error : 'Failed to load tweet (HTTP ' + response.status + ').';
+							insertErrorEmbed(message);
+							return null;
+						}).catch(function() {
+							insertErrorEmbed('Failed to load tweet (HTTP ' + response.status + ').');
+							return null;
+						});
+					}
+					return response.json();
+				})
+				.then(function handleData(data) {
+					if (!data || !data.html) { return; }
+					window._oembedCache[tweetUrl] = data.html;
+					insertTweet(data.html);
+				})
+				.catch(function handleError(error) {
+					insertErrorEmbed('Failed to load tweet (network error).');
+				});
 		});
 	}
 

--- a/Awful.apk/src/main/assets/javascript/thread.js
+++ b/Awful.apk/src/main/assets/javascript/thread.js
@@ -131,9 +131,7 @@ function loadPageHtml() {
  * Initializes the newly added posts that have just been added to the container
  */
 function pageInit() {
-	document.head.querySelectorAll('.JSONP').forEach(function removeScripts(script) {
-		script.remove();
-	});
+	window.missedEmbeds = [];
 	var spoilers = document.body.querySelectorAll('.bbc-spoiler');
 	spoilers.forEach(function each(spoiler) {
 		spoiler.removeAttribute('onmouseover');


### PR DESCRIPTION
The goal of this is to reduce the number of failed Tweet embeds due to rate-limiting, but I figured while I was in there I'd fancy things up for other failure cases. Doesn't change any of the visuals or user behavior of the tweets that embed fine.

First I replaced JSONP with fetch() to proper HTTP error handling and enables caching of responses across page navigations within a thread. I just realized while typing up these notes that we still issue multiple requests for the same Tweet if it appears multiple times in a page (e.g. a post and quotes) so I'm going to fix that real quick in a subsequent commit to this PR.

Tweets that fail to embed now show a styled placeholder with the error reason from Twitter's API (e.g. deleted tweets, sensitive content) instead of silently failing to embed.

Easiest way to test this is on page 1200 of the PYF Tweets thread - it has a bunch of tweets (duh), a couple deleted tweets, and a couple of sensitive content tweets, e.g.:

<img width="590" height="586" alt="image" src="https://github.com/user-attachments/assets/2c9800a5-afdb-4d75-bdde-b8cc5dae510c" />
