### PR TITLE
check if a post was already reported before showing the report dialog

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -83,6 +83,7 @@ import com.ferg.awfulapp.task.ImageSizeRequest;
 import com.ferg.awfulapp.task.MarkLastReadRequest;
 import com.ferg.awfulapp.task.RedirectTask;
 import com.ferg.awfulapp.task.RefreshUserProfileRequest;
+import com.ferg.awfulapp.task.ReportCheckRequest;
 import com.ferg.awfulapp.task.ReportRequest;
 import com.ferg.awfulapp.task.SinglePostRequest;
 import com.ferg.awfulapp.task.ThreadLockUnlockRequest;
@@ -768,6 +769,27 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 	 * @param postId	The ID of the bad post
      */
 	public void reportUser(int postId){
+		queueRequest(new ReportCheckRequest(getActivity(), postId)
+			.build(ThreadDisplayFragment.this, new AwfulRequest.AwfulResultCallback<Boolean>() {
+				@Override
+				public void success(Boolean alreadyReported) {
+					if (alreadyReported) {
+						getAlertView().setTitle("This post has already been reported recently")
+							.setIcon(R.drawable.ic_mood).show();
+					} else {
+						showReportDialog(postId);
+					}
+				}
+
+				@Override
+				public void failure(VolleyError error) {
+					getAlertView().setTitle("Failed to check report status")
+						.setIcon(R.drawable.ic_mood).show();
+				}
+			}));
+	}
+
+	private void showReportDialog(int postId) {
 		final EditText reportReason = new EditText(this.getActivity());
 
 		new AlertDialog.Builder(this.getActivity())

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ReportCheckRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ReportCheckRequest.kt
@@ -1,0 +1,21 @@
+package com.ferg.awfulapp.task
+
+import android.content.Context
+import com.ferg.awfulapp.constants.Constants.*
+import org.jsoup.nodes.Document
+
+/**
+ * A request that checks whether a post has already been reported recently.
+ */
+class ReportCheckRequest(context: Context, postId: Int)
+    : AwfulRequest<Boolean>(context, FUNCTION_REPORT) {
+
+    init {
+        parameters.add(PARAM_POST_ID, postId.toString())
+    }
+
+    override fun handleResponse(doc: Document): Boolean {
+        val body = doc.body()
+        return body != null && body.hasClass("standarderror")
+    }
+}


### PR DESCRIPTION
just like the website does. adds a round-trip to the forum before the textbox pops up, but that's a better experience than typing a bunch of words and submitting and being sad that it was wasted time

i havent added a new file before but i dont think i needed to do anything special like list it somewhere? this works for me already at least lol