### PR TITLE
minor report changes re: astral's backend changes

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -796,7 +796,7 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 	private void showReportDialog(int postId, String warning) {
 		final EditText reportReason = new EditText(this.getActivity());
 
-		String body = "Did this post break the forum rules? If so, please report it by clicking below. If you would like to add any comments explaining why you submitted this post, please do so here:";
+		String body = getString(R.string.report_post_message);
 		CharSequence message;
 		if (warning.isEmpty()) {
 			message = body;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ThreadDisplayFragment.java
@@ -46,8 +46,11 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.text.SpannableString;
+import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.format.Formatter;
+import android.text.style.ForegroundColorSpan;
 import android.view.InflateException;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -84,6 +87,7 @@ import com.ferg.awfulapp.task.MarkLastReadRequest;
 import com.ferg.awfulapp.task.RedirectTask;
 import com.ferg.awfulapp.task.RefreshUserProfileRequest;
 import com.ferg.awfulapp.task.ReportCheckRequest;
+import com.ferg.awfulapp.task.ReportCheckResult;
 import com.ferg.awfulapp.task.ReportRequest;
 import com.ferg.awfulapp.task.SinglePostRequest;
 import com.ferg.awfulapp.task.ThreadLockUnlockRequest;
@@ -770,14 +774,14 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
      */
 	public void reportUser(int postId){
 		queueRequest(new ReportCheckRequest(getActivity(), postId)
-			.build(ThreadDisplayFragment.this, new AwfulRequest.AwfulResultCallback<Boolean>() {
+			.build(ThreadDisplayFragment.this, new AwfulRequest.AwfulResultCallback<ReportCheckResult>() {
 				@Override
-				public void success(Boolean alreadyReported) {
-					if (alreadyReported) {
+				public void success(ReportCheckResult result) {
+					if (result.getAlreadyReported()) {
 						getAlertView().setTitle("This post has already been reported recently")
 							.setIcon(R.drawable.ic_mood).show();
 					} else {
-						showReportDialog(postId);
+						showReportDialog(postId, result.getWarning() != null ? result.getWarning() : "");
 					}
 				}
 
@@ -789,12 +793,27 @@ public class ThreadDisplayFragment extends AwfulFragment implements NavigationEv
 			}));
 	}
 
-	private void showReportDialog(int postId) {
+	private void showReportDialog(int postId, String warning) {
 		final EditText reportReason = new EditText(this.getActivity());
+
+		String body = "Did this post break the forum rules? If so, please report it by clicking below. If you would like to add any comments explaining why you submitted this post, please do so here:";
+		CharSequence message;
+		if (warning.isEmpty()) {
+			message = body;
+		} else {
+			int warningColor = getResources().getColor(R.color.popup_warning_text);
+			SpannableString warningSpan = new SpannableString(warning);
+			warningSpan.setSpan(new ForegroundColorSpan(warningColor), 0, warning.length(), 0);
+			SpannableStringBuilder sb = new SpannableStringBuilder();
+			sb.append(warningSpan);
+			sb.append("\n\n");
+			sb.append(body);
+			message = sb;
+		}
 
 		new AlertDialog.Builder(this.getActivity())
 		  .setTitle("Report inappropriate post")
-		  .setMessage("Did this post break the forum rules? If so, please report it by clicking below. If you would like to add any comments explaining why you submitted this post, please do so here:")
+		  .setMessage(message)
 		  .setView(reportReason)
 		  .setPositiveButton("Report", (dialog, whichButton) -> {
             String reason = reportReason.getText().toString();

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/constants/Constants.java
@@ -88,7 +88,6 @@ public class Constants {
 	public static final String PARAM_VOTE 	   = "vote";
 	public static final String PARAM_POST_ID   = "postid";
 	public static final String PARAM_USERLIST  = "userlist";
-	public static final String PARAM_COMMENTS  = "comments";
     public static final String PARAM_FORMKEY = "formkey";
     public static final String PARAM_FORM_COOKIE = "form_cookie";
     public static final String PARAM_ATTACHMENT = "attachment";

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ReportCheckRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ReportCheckRequest.kt
@@ -2,20 +2,39 @@ package com.ferg.awfulapp.task
 
 import android.content.Context
 import com.ferg.awfulapp.constants.Constants.*
+import com.ferg.awfulapp.util.AwfulError
 import org.jsoup.nodes.Document
 
 /**
- * A request that checks whether a post has already been reported recently.
+ * Checks whether a post has already been reported, and if it hasn't it grabs the warning
+ * text above the report editor (e.g. the post is more than two weeks old).
+ *
+ * Overrides [handleCriticalError] since the already-reported page triggers the base
+ * class's standarderror detection.
  */
 class ReportCheckRequest(context: Context, postId: Int)
-    : AwfulRequest<Boolean>(context, FUNCTION_REPORT) {
+    : AwfulRequest<ReportCheckResult>(context, FUNCTION_REPORT) {
 
     init {
         parameters.add(PARAM_POST_ID, postId.toString())
     }
 
-    override fun handleResponse(doc: Document): Boolean {
+    override fun handleCriticalError(error: AwfulError, doc: Document): Boolean = true
+
+    override fun handleResponse(doc: Document): ReportCheckResult {
         val body = doc.body()
-        return body != null && body.hasClass("standarderror")
+        if (body.hasClass("standarderror")) {
+            return ReportCheckResult(alreadyReported = true)
+        }
+        val warning = body.select("span.warningsmalltext")
+            ?.mapNotNull { it.text().takeIf(String::isNotBlank) }
+            ?.joinToString("\n")
+            ?.takeIf(String::isNotEmpty)
+        return ReportCheckResult(alreadyReported = false, warning = warning)
     }
 }
+
+data class ReportCheckResult(
+    val alreadyReported: Boolean,
+    val warning: String? = null
+)

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/task/ReportRequest.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/task/ReportRequest.kt
@@ -18,7 +18,7 @@ class ReportRequest(context: Context, private val postId: Int, private val comme
 
         init {
         with(parameters) {
-            add(PARAM_COMMENTS, comments)
+            add(PARAM_MESSAGE, comments)
             add(PARAM_POST_ID, postId.toString())
             add(PARAM_ACTION, "submit")
         }

--- a/Awful.apk/src/main/res/values/colors.xml
+++ b/Awful.apk/src/main/res/values/colors.xml
@@ -57,6 +57,8 @@
     <color name="self_thread_dark">#1A2800</color>
     <color name="self_thread_oled">#1E0E00</color>
 
+    <color name="popup_warning_text">#FF0000</color>
+
 
     <!-- Bookmark colours for stars/unread counters -->
     <integer-array name="bookmarkColors">

--- a/Awful.apk/src/main/res/values/strings.xml
+++ b/Awful.apk/src/main/res/values/strings.xml
@@ -525,6 +525,7 @@
     <string name="getting_forums">Getting forums</string>
     <string name="imgur_api_client_id">test</string>
     <string name="post_warning">The functionality to create threads is fresh and may contain bugs that could potentially lead to auto-bans.\n\nThere are no safety nets.\n\nBy accepting this you acknowledge that you are voluntarily taking this risk and only have yourself to blame if you get banned, either due to an app-malfunction or (more likely) your dog-shit posting.</string>
+    <string name="report_post_message">Did this post break the forum rules? If so, please report it by clicking below. If you would like to add any comments explaining why you submitted this post, please do so here:</string>
     <string name="terms_and_conditions">I accept the <a href="https://www.somethingawful.com/forum-rules/forum-rules/">terms and conditions of the forum rules</a></string>
 
 


### PR DESCRIPTION
1. the report message form field is now called "message" not "comments" so fix that per astral
2. stop the "this post was already reported recently" toast from happening twice due to two handlers dealing with it (this was my bug from before, not really related to the backend changes)
3. when we send a request to see if the post was already reported recently, we now grab any of the warnings on the page (which right now I think is just the "this post is older than two weeks are you sure you want to report it?" one). we show that in red in the report popup (using a normal solid red color looked fine on all the themes so i didnt bother theming it)

long-term it's a bit silly now that reports use the little popup instead of normal editor (since in the browser now it's just like making a post) but i don't think anyone will ever care about that. the warnings seemed useful, though.