### PR TITLE
fix closed sticky threads not being treated like sticky threads

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -277,7 +277,7 @@ class ForumParseTask(
 
             lastPoster = threadElement.selectFirst(".lastpost .author")!!.text()
             isLocked = threadElement.hasClass("closed")
-            isSticky = threadElement.selectFirst(".title_sticky") != null
+            isSticky = threadElement.selectFirst(".title_sticky, .sticky_closed") != null
 
             // optional thread rating
             rating = threadElement.selectFirst(".rating img")


### PR DESCRIPTION
Pretty self-explanatory, not sure when the forums changed to not add `.title_sticky` to closed sticky threads, they apparently get `.sticky_closed` instead.