### PR TITLE
track the last post time for threads so we can fix the bookmarks sorting

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/ForumDisplayFragment.java
@@ -654,7 +654,13 @@ public class ForumDisplayFragment extends AwfulFragment implements SwipyRefreshL
                 selectionArgs = AwfulProvider.int2StrArray(getForumId(), thisPageIndex, nextPageIndex);
             }
             boolean sortNewFirst = (isBookmarks && getPrefs().newThreadsFirstUCP) || (!isBookmarks && getPrefs().newThreadsFirstForum);
-            String sortOrder = sortNewFirst ? AwfulThread.HAS_NEW_POSTS + " DESC, " + AwfulThread.INDEX : AwfulThread.INDEX;
+            String sortOrder;
+            if (sortNewFirst) {
+                String secondarySort = isBookmarks ? AwfulThread.LAST_POST_DATE + " DESC" : AwfulThread.INDEX;
+                sortOrder = AwfulThread.HAS_NEW_POSTS + " DESC, " + secondarySort;
+            } else {
+                sortOrder = isBookmarks ? AwfulThread.LAST_POST_DATE + " DESC" : AwfulThread.INDEX;
+            }
 
             return new CursorLoader(getActivity(), contentUri, AwfulProvider.ThreadProjection, selection, selectionArgs, sortOrder);
         }

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/AwfulProvider.java
@@ -161,6 +161,7 @@ public class AwfulProvider extends ContentProvider {
         sThreadProjectionMap.put(AwfulThread.STICKY, AwfulThread.STICKY);
         sThreadProjectionMap.put(AwfulThread.CATEGORY, AwfulThread.CATEGORY);
         sThreadProjectionMap.put(AwfulThread.LASTPOSTER, AwfulThread.LASTPOSTER);
+        sThreadProjectionMap.put(AwfulThread.LAST_POST_DATE, AwfulThread.LAST_POST_DATE);
         sThreadProjectionMap.put(AwfulThread.HAS_NEW_POSTS, AwfulThread.UNREADCOUNT+" > 0 AS "+ AwfulThread.HAS_NEW_POSTS);
         sThreadProjectionMap.put(AwfulThread.HAS_VIEWED_THREAD, AwfulThread.HAS_VIEWED_THREAD);
         sThreadProjectionMap.put(AwfulThread.ARCHIVED, AwfulThread.ARCHIVED);
@@ -217,6 +218,7 @@ public class AwfulProvider extends ContentProvider {
         sUCPThreadProjectionMap.put(AwfulThread.STICKY, AwfulThread.STICKY);
         sUCPThreadProjectionMap.put(AwfulThread.CATEGORY, AwfulThread.CATEGORY);
         sUCPThreadProjectionMap.put(AwfulThread.LASTPOSTER, AwfulThread.LASTPOSTER);
+        sUCPThreadProjectionMap.put(AwfulThread.LAST_POST_DATE, AwfulThread.LAST_POST_DATE);
         sUCPThreadProjectionMap.put(AwfulThread.TAG_URL, AwfulThread.TAG_URL);
         sUCPThreadProjectionMap.put(AwfulThread.TAG_EXTRA, AwfulThread.TAG_EXTRA);
         sUCPThreadProjectionMap.put(AwfulThread.TAG_CACHEFILE, AwfulThread.TAG_CACHEFILE);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/provider/DatabaseHelper.java
@@ -20,7 +20,7 @@ import com.ferg.awfulapp.thread.AwfulThread;
 public class DatabaseHelper extends SQLiteOpenHelper {
 
     private static final String DATABASE_NAME = "awful.db";
-    private static final int DATABASE_VERSION = 38;
+    private static final int DATABASE_VERSION = 39;
 
     static final String TABLE_FORUM    = "forum";
     public static final String TABLE_THREADS    = "threads";
@@ -86,6 +86,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 AwfulThread.HAS_VIEWED_THREAD + " INTEGER, " +
                 AwfulThread.ARCHIVED + " INTEGER, " +
                 AwfulThread.RATING + " INTEGER, " +
+                AwfulThread.LAST_POST_DATE + " INTEGER, " +
                 UPDATED_TIMESTAMP + " DATETIME);");
     }
 
@@ -212,6 +213,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             case 37:
                 dropTables(aDb, TABLE_POSTS);
                 createPostTable(aDb);
+            case 38:
+                aDb.execSQL("ALTER TABLE " + TABLE_THREADS + " ADD COLUMN " + AwfulThread.LAST_POST_DATE + " INTEGER DEFAULT 0");
                 break;//make sure to keep this break statement on the last case of this switch
             default:
                 wipeRecreateTables(aDb);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/AwfulThread.java
@@ -89,6 +89,7 @@ public class AwfulThread extends AwfulPagedItem  {
 	public static final String STICKY               = "sticky";
 	public static final String CATEGORY             = "category";
 	public static final String LASTPOSTER           = "killedby";
+	public static final String LAST_POST_DATE       = "last_post_date";
 	public static final String FORUM_TITLE          = "forum_title";
 	public static final String HAS_NEW_POSTS        = "has_new_posts";
     public static final String HAS_VIEWED_THREAD    = "has_viewed_thread";
@@ -110,6 +111,7 @@ public class AwfulThread extends AwfulPagedItem  {
     public String author;
     public int authorId;
     public String lastPoster;
+    public long lastPostDate;
     public int postCount;
     public int unreadCount;
 
@@ -147,6 +149,7 @@ public class AwfulThread extends AwfulPagedItem  {
         thread.author = row.getString(row.getColumnIndex(AUTHOR));
         thread.authorId = row.getInt(row.getColumnIndex(AUTHOR_ID));
         thread.lastPoster = row.getString(row.getColumnIndex(LASTPOSTER));
+        thread.lastPostDate = row.getLong(row.getColumnIndex(LAST_POST_DATE));
         thread.postCount = row.getInt(row.getColumnIndex(POSTCOUNT));
         thread.unreadCount = row.getInt(row.getColumnIndex(UNREADCOUNT));
 
@@ -181,6 +184,7 @@ public class AwfulThread extends AwfulPagedItem  {
         cv.put(CAN_OPEN_CLOSE, asSqlBoolean(canOpenClose));
 
         cv.put(LASTPOSTER, lastPoster);
+        cv.put(LAST_POST_DATE, lastPostDate);
         cv.put(LOCKED, asSqlBoolean(isLocked));
         cv.put(STICKY, asSqlBoolean(isSticky));
         cv.put(RATING, rating);

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/thread/ForumParsing.kt
@@ -14,6 +14,8 @@ import com.ferg.awfulapp.thread.AwfulThread.*
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import timber.log.Timber
+import java.text.SimpleDateFormat
+import java.util.Locale
 import java.util.concurrent.*
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -276,6 +278,10 @@ class ForumParseTask(
             canOpenClose = author == username
 
             lastPoster = threadElement.selectFirst(".lastpost .author")!!.text()
+            lastPostDate = threadElement.selectFirst(".lastpost div")?.text()?.let {
+                try { SimpleDateFormat("HH:mm MMM dd, yyyy", Locale.US).parse(it)?.time ?: 0L }
+                catch (e: Exception) { 0L }
+            } ?: 0L
             isLocked = threadElement.hasClass("closed")
             isSticky = threadElement.selectFirst(".title_sticky") != null
 


### PR DESCRIPTION
TLDR: when you're looking at a forum thread list, it's always sorted correctly (by last post date). But when you're looking at your bookmarks, it doesn't sort "live" on the PHP side - in some post a while ago astral said there's a job every minute or so that updates the bookmarks view to match the last post time. But this means if you have active threads bookmarked, when you look at your bookmarks page you'll see them sorted incorrectly (a thread with newer unread posts will appear below a different one, and then if you refresh later even with no other posts since then it'll re-order to be fixed) and that's been driving me crazy so I added this to my fork months ago. I figure it might bother other people too so I did the work to isolate it into a PR but I'd understand if this is considered too big of a change for a minor fix like this (that is a workaround for the actual forums PHP being dumb) since it has to bump the DB version.