### PR TITLE
fix a couple of build warnings

### DIFF
--- a/Awful.apk/src/main/AndroidManifest.xml
+++ b/Awful.apk/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     minor number ahead of production, so they can be updated independently, and the beta can be pushed to production when ready.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      package="com.ferg.awfulapp"
     android:versionCode="31302"
     android:versionName="3.13.2"
       android:installLocation="auto">

--- a/build.gradle
+++ b/build.gradle
@@ -16,5 +16,5 @@ plugins {
     id 'com.android.application' version '8.13.1' apply false
     id 'com.android.library' version '8.13.1' apply false
     id 'org.jetbrains.kotlin.android' version '2.2.21' apply false
-    id 'com.google.devtools.ksp' version '2.2.10-2.0.2'
+    id 'com.google.devtools.ksp' version '2.2.21-2.0.5'
 }


### PR DESCRIPTION
```
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="com.ferg.awfulapp" from the source AndroidManifest.xml
```

```
ksp-2.2.10-2.0.2 is too old for kotlin-2.2.21. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.10.
```