### PR TITLE
cleanup(webview): drop trivial DEBUG-only overrides in LoggingWebChromeClient (#422)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/LoggingWebChromeClient.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/LoggingWebChromeClient.java
@@ -1,6 +1,5 @@
 package com.ferg.awfulapp.webview;
 
-import android.os.Message;
 import androidx.annotation.CallSuper;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/LoggingWebChromeClient.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/LoggingWebChromeClient.java
@@ -1,5 +1,6 @@
 package com.ferg.awfulapp.webview;
 
+import android.os.Message;
 import androidx.annotation.CallSuper;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -37,28 +38,6 @@ public class LoggingWebChromeClient extends WebChromeClient {
     public LoggingWebChromeClient(WebView webView) {
         super();
         this.webView = webView;
-    }
-
-    @CallSuper
-    @Override
-    public void onCloseWindow(WebView window) {
-        super.onCloseWindow(window);
-        if (DEBUG) Log.d(TAG, "onCloseWindow");
-    }
-
-    @CallSuper
-    @Override
-    public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
-        if (DEBUG)
-            Log.d(TAG, "onCreateWindow" + (isDialog ? " isDialog" : "") + (isUserGesture ? " isUserGesture" : ""));
-        return super.onCreateWindow(view, isDialog, isUserGesture, resultMsg);
-    }
-
-    @CallSuper
-    @Override
-    public boolean onJsTimeout() {
-        if (DEBUG) Log.d(TAG, "onJsTimeout");
-        return super.onJsTimeout();
     }
 
     @Override


### PR DESCRIPTION
Closes #422.

The issue raises the question of whether the trivial DEBUG-only overrides in `LoggingWebChromeClient` (`onCloseWindow`, `onCreateWindow`, `onJsTimeout`) earn their keep. They each exist solely to call `Log.d` then forward to super. The author leaned toward dropping them until there is an actual bug to chase. This PR does that and also removes the now-unused `android.os.Message` import.

`onConsoleMessage`, `onShowCustomView`, and `onHideCustomView` stay as-is because they actually do work.

```diff
-    @CallSuper
-    @Override
-    public void onCloseWindow(WebView window) {
-        super.onCloseWindow(window);
-        if (DEBUG) Log.d(TAG, "onCloseWindow");
-    }
-
-    @CallSuper
-    @Override
-    public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
-        if (DEBUG)
-            Log.d(TAG, "onCreateWindow" + (isDialog ? " isDialog" : "") + (isUserGesture ? " isUserGesture" : ""));
-        return super.onCreateWindow(view, isDialog, isUserGesture, resultMsg);
-    }
-
-    @CallSuper
-    @Override
-    public boolean onJsTimeout() {
-        if (DEBUG) Log.d(TAG, "onJsTimeout");
-        return super.onJsTimeout();
-    }
```

If anyone wants this logging back later, the methods are five lines and trivial to restore.
