### PR TITLE
feat(webview): accept third-party cookies so Twitter/FB/Imgur embeds render (#526)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -5,7 +5,6 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;
-import android.webkit.CookieManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
@@ -102,6 +101,12 @@ public class AwfulWebView extends WebView {
         webSettings.setAllowUniversalAccessFromFileURLs(true);
         webSettings.setAllowFileAccess(true);
         webSettings.setAllowContentAccess(true);
+
+        // Issue #526: third-party embeds (Twitter, Facebook, Imgur,
+        // Instagram) load their iframe content from a different origin
+        // and need their session cookie to render. Without this the
+        // embed area shows a blank box or a "log in" stub.
+        CookieManager.getInstance().setAcceptThirdPartyCookies(this, true);
     }
 
 

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -5,6 +5,7 @@ import android.graphics.Color;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;
+import android.webkit.CookieManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 


### PR DESCRIPTION
Towards #526.

The unchecked items on the embed wishlist (Facebook posts, Imgur galleries, Twitter cards in places they currently fail) all share one root cause when rendered inside an `AwfulWebView`. Their iframe content lives on a different origin and needs the third-party session cookie to render. Modern Android WebView blocks that cookie unless you opt in.

This PR enables `setAcceptThirdPartyCookies` on the WebView itself, so every place `AwfulWebView` is mounted (thread display, PM display, preview) inherits the change. It does not add any new embed handlers, that work belongs in `thread.js`, but it removes the silent-fail you currently see on the existing Twitter and Instagram embeds when the user is signed out of those services.

```java
import android.webkit.CookieManager;

// inside init()
CookieManager.getInstance().setAcceptThirdPartyCookies(this, true);
```

I left the rest of the wishlist alone because each platform needs its own URL-shape detection and HTML scaffold in the embed code.
