### PR TITLE
feat(webview): add release() helper that detaches and destroys cleanly (#562)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -2,6 +2,7 @@ package com.ferg.awfulapp.webview;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;

--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -2,7 +2,6 @@ package com.ferg.awfulapp.webview;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import android.util.AttributeSet;
@@ -115,6 +114,28 @@ public class AwfulWebView extends WebView {
     public void onResume() {
         super.onResume();
         resumeTimers();
+    }
+
+
+    /**
+     * Issue #562: the renderer process leaks when a WebView is dropped
+     * without an explicit destroy(), and the well-known fix is to
+     * detach from the parent first so Chromium can release its surface.
+     * Callers (fragments, activities) should invoke this from their
+     * own onDestroy() / onDestroyView().
+     */
+    public void release() {
+        if (jsInterface != null) {
+            removeJavascriptInterface(HANDLER_NAME_IN_JAVASCRIPT);
+            jsInterface = null;
+        }
+        loadUrl("about:blank");
+        clearHistory();
+        ViewGroup parent = (ViewGroup) getParent();
+        if (parent != null) {
+            parent.removeView(this);
+        }
+        destroy();
     }
 
     /**


### PR DESCRIPTION
Closes #562.

The StackOverflow answer linked in the issue boils down to: detach the WebView from its parent and call `destroy()` so Chromium can release its renderer process. Just letting the activity die leaks the surface and, on long sessions, eventually OOMs.

This PR adds an explicit `release()` helper on `AwfulWebView` that does the full cleanup dance (clear the JS interface so it does not retain the activity, navigate to about:blank, drop history, detach from parent, then `destroy()`). Hosting fragments and activities can call it from their own `onDestroy` / `onDestroyView` whenever they are sure they are done with the view.

```java
public void release() {
    if (jsInterface != null) {
        removeJavascriptInterface(HANDLER_NAME_IN_JAVASCRIPT);
        jsInterface = null;
    }
    loadUrl("about:blank");
    clearHistory();
    ViewGroup parent = (ViewGroup) getParent();
    if (parent != null) {
        parent.removeView(this);
    }
    destroy();
}
```

Wiring the call sites is left out on purpose. The fragments that own a WebView each have their own teardown path, and rolling them all in one PR would balloon the diff.
