### PR TITLE
feat(webview): saveScrollPosition / restoreScrollPosition helpers (#626)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -173,6 +173,38 @@ public class AwfulWebView extends WebView {
 
 
     /**
+     * Issue #626: capture the current scroll position into a
+     * window-scoped variable so a follow-up content swap can restore it.
+     * Pair with {@link #restoreScrollPosition()} called once the new
+     * body HTML has been rendered.
+     */
+    public void saveScrollPosition() {
+        runJavascript("window.__awfulSavedScroll = window.scrollY;");
+    }
+
+    /**
+     * Restore a previously captured scroll position. Safe to call before
+     * the DOM has finished settling, the JS uses requestAnimationFrame
+     * to retry until the document height covers the saved offset.
+     */
+    public void restoreScrollPosition() {
+        runJavascript(
+                "(function(){" +
+                    "var target = window.__awfulSavedScroll;" +
+                    "if (target == null) { return; }" +
+                    "function tryScroll() {" +
+                        "if (document.documentElement.scrollHeight >= target) {" +
+                            "window.scrollTo({top: target});" +
+                        "} else {" +
+                            "window.requestAnimationFrame(tryScroll);" +
+                        "}" +
+                    "}" +
+                    "tryScroll();" +
+                "})();");
+    }
+
+
+    /**
      * Set and display the current HTML for the container body.
      * <p>
      * Call this to update the WebView with new HTML content, calling {@link #refreshPageContents()}


### PR DESCRIPTION
Towards #626.

The thread WebView swaps inner HTML rather than navigating, so the standard `WebView.scrollTo` dance does not survive a page change. Two helpers are enough to handle the common case: capture the current scroll offset before a swap, then restore it once the new HTML has rendered.

The restore helper uses `requestAnimationFrame` to retry until the document is tall enough to actually contain the saved offset, which avoids the classic "scroll fires before images settle and lands too high" problem.

```java
public void saveScrollPosition() {
    runJavascript("window.__awfulSavedScroll = window.scrollY;");
}

public void restoreScrollPosition() {
    runJavascript(
            "(function(){" +
                "var target = window.__awfulSavedScroll;" +
                "if (target == null) { return; }" +
                "function tryScroll() {" +
                    "if (document.documentElement.scrollHeight >= target) {" +
                        "window.scrollTo({top: target});" +
                    "} else {" +
                        "window.requestAnimationFrame(tryScroll);" +
                    "}" +
                "}" +
                "tryScroll();" +
            "})();");
}
```

Callers in `ThreadDisplayFragment` and the PM view can opt in by bracketing their `setBodyHtml` calls with these two methods. I did not wire the call sites in this PR to keep the diff focused.
