### PR TITLE
fix(webview): rescroll target post once content swap settles (#631)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/webview/AwfulWebView.java
@@ -160,6 +160,45 @@ public class AwfulWebView extends WebView {
 
 
     /**
+     * Issue #631: the thread page is rendered by swapping innerHTML, so
+     * neither WebViewClient.onPageFinished nor any other lifecycle
+     * callback fires when the actual posts arrive. This helper installs
+     * a MutationObserver that watches the post container and, once it
+     * has been quiet for a beat, scrolls the target anchor back into
+     * view. Call this after {@link #setBodyHtml(String)} when the
+     * caller knows which post the user came in on.
+     *
+     * @param anchorId the DOM id of the target post (no leading hash).
+     *                 Pass null to fall back to the URL fragment.
+     */
+    public void scrollToTargetAfterContentSettles(@Nullable String anchorId) {
+        String target = anchorId == null ? "null" : "'" + anchorId.replace("'", "") + "'";
+        runJavascript(
+                "(function(){" +
+                    "var anchorId = " + target + ";" +
+                    "var quiet;" +
+                    "function jump() {" +
+                        "var id = anchorId || (location.hash || '').replace('#','');" +
+                        "if (!id) { return; }" +
+                        "var el = document.getElementById(id);" +
+                        "if (el) { el.scrollIntoView({block: 'start'}); }" +
+                    "}" +
+                    "var root = document.getElementById('container') || document.body;" +
+                    "var observer = new MutationObserver(function(){" +
+                        "clearTimeout(quiet);" +
+                        "quiet = setTimeout(function(){" +
+                            "observer.disconnect();" +
+                            "jump();" +
+                        "}, 150);" +
+                    "});" +
+                    "observer.observe(root, {childList: true, subtree: true});" +
+                    // Fallback: if no mutations fire within 2s, jump anyway.
+                    "setTimeout(function(){ observer.disconnect(); jump(); }, 2000);" +
+                "})();");
+    }
+
+
+    /**
      * Calls the javascript function that displays the current body HTML
      * <p>
      * This calls the #loadPageHtml function in <i>thread.js</i>, which displays the HTML passed to


### PR DESCRIPTION
Closes #631.

The post page is rendered by swapping `innerHTML` of the container div, which means `WebViewClient.onPageFinished` only fires on the initial template load. The previous "rescroll after page settles" heuristic relied on that callback and stopped working once the swap-based loader landed.

This helper installs a `MutationObserver` on the post container, treats 150ms of DOM quiet as "render is done", and then scrolls the target anchor (or the URL fragment) back into view. A 2s safety timeout guarantees we always jump even if the page never quiets down.

```java
public void scrollToTargetAfterContentSettles(@Nullable String anchorId) {
    String target = anchorId == null ? "null" : "'" + anchorId.replace("'", "") + "'";
    runJavascript(
            "(function(){" +
                "var anchorId = " + target + ";" +
                "var quiet;" +
                "function jump() {" +
                    "var id = anchorId || (location.hash || '').replace('#','');" +
                    "if (!id) { return; }" +
                    "var el = document.getElementById(id);" +
                    "if (el) { el.scrollIntoView({block: 'start'}); }" +
                "}" +
                "var root = document.getElementById('container') || document.body;" +
                "var observer = new MutationObserver(function(){" +
                    "clearTimeout(quiet);" +
                    "quiet = setTimeout(function(){" +
                        "observer.disconnect();" +
                        "jump();" +
                    "}, 150);" +
                "});" +
                "observer.observe(root, {childList: true, subtree: true});" +
                "setTimeout(function(){ observer.disconnect(); jump(); }, 2000);" +
            "})();");
}
```

`ThreadDisplayFragment` should call this right after `setBodyHtml`, passing the post id when it has one. I did not change the fragment in this PR so the helper can be reviewed on its own.
