### PR TITLE
fix(pm): preserve message WebView state across recreation (#691)

### DIFF
--- a/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
+++ b/Awful.apk/src/main/java/com/ferg/awfulapp/MessageFragment.java
@@ -107,6 +107,16 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
     }
+
+    @Override
+    public void onSaveInstanceState(@androidx.annotation.NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        // Issue #691: persist the message WebView so re-entering the
+        // fragment after the settings activity does not redraw blank.
+        if (messageWebView != null) {
+            messageWebView.saveState(outState);
+        }
+    }
 	
 	public View onCreateView(LayoutInflater aInflater, ViewGroup aContainer, Bundle aSavedState) {
         super.onCreateView(aInflater, aContainer, aSavedState);
@@ -134,9 +144,16 @@ public class MessageFragment extends AwfulFragment implements OnClickListener {
 		messageWebView.setJavascriptHandler(new WebViewJsInterface());
 		messageWebView.setContent(AwfulHtmlPage.getContainerHtml(mPrefs, null, false));
 
+		// Issue #691: restore the saved WebView snapshot when the
+		// fragment is recreated so the message body does not come back
+		// blank after popping back from the settings activity.
+		if (aSavedState != null) {
+			messageWebView.restoreState(aSavedState);
+		}
+
 		if(pmId <=0){
         	messageWebView.setVisibility(GONE);
-        }else{
+        }else if (aSavedState == null) {
             syncPM();
         }
 


### PR DESCRIPTION
Closes #691.

Reopening the PM view after popping back from the settings activity (and on configuration changes in general) shows a blank message body. The fragment uses `setRetainInstance(true)` for the wrapper but the embedded `AwfulWebView` is rebuilt and its state is not preserved.

This change persists the WebView in `onSaveInstanceState`, restores it in `onCreateView`, and skips the `syncPM()` refetch when there is a snapshot to restore. The blank screen goes away and the existing first-load path is unchanged.

```java
@Override
public void onSaveInstanceState(@androidx.annotation.NonNull Bundle outState) {
    super.onSaveInstanceState(outState);
    if (messageWebView != null) {
        messageWebView.saveState(outState);
    }
}
```

```java
if (aSavedState != null) {
    messageWebView.restoreState(aSavedState);
}

if (pmId <= 0) {
    messageWebView.setVisibility(GONE);
} else if (aSavedState == null) {
    syncPM();
}
```
